### PR TITLE
Silence "suggest braces around initialization" warning

### DIFF
--- a/htscodecs/rANS_static.c
+++ b/htscodecs/rANS_static.c
@@ -394,7 +394,7 @@ static void hist1_4(unsigned char *in, unsigned int in_size,
 
     unsigned char cc[5] = {0};
     if (in_size > 500000) {
-	int F1[256][259] = {0};
+	int F1[256][259] = {{0}};
 	while (in < in_end-8) {
 	    memcpy(cc, in, 4); in += 4;
 	    T0[cc[4]]++; F0[cc[4]][cc[0]]++;


### PR DESCRIPTION
The warning is issued by some versions of clang (notably the one Travis uses for Mac builds).  The extra braces aren't strictly
necessary, but adding them is harmless and makes builds using -Werror work.

For an example of the warning, see https://travis-ci.com/github/samtools/htscodecs/jobs/453582092