### PR TITLE
Make git ignore .pico files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.lo
 *.la
 *.o
+*.pico
 
 aclocal.m4
 autom4te.cache


### PR DESCRIPTION
Not needed for htscodecs itself, but it's handy for htslib which wants to build parts of htscodecs in a submodule, and makes separate PIC and non-PIC object files.