### PR TITLE
Add an arbitrary maxname on the name tokeniser.

### DIFF
--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1533,6 +1533,8 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
 
 	// Decode lengths
 	c_meta_len += var_get_u32(in+c_meta_len, in_end, &ulen);
+	if (c_meta_len >= in_size)
+	    return NULL;
 	unsigned int N = in[c_meta_len++];
 	unsigned int clenN[256], ulenN[256], idxN[256];
 	if (!out) {

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -194,6 +194,14 @@ static name_context *create_context(int max_names) {
 	return NULL;
 #endif
 
+    // An arbitrary limit to prevent malformed data from consuming excessive
+    // amounts of memory.  Consider upping this if we have genuine use cases
+    // for larger blocks.
+    if (max_names > 1e7) {
+	fprintf(stderr, "Name codec currently has a max of 10 million rec.\n");
+	return NULL;
+    }
+
 #ifndef NO_THREADS
     pthread_once(&tok_once, tok_tls_init);
 

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1542,7 +1542,8 @@ uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 
     int i, o = 9;
     //int ulen   = *(uint32_t *)in;
-    int ulen   = (in[0]<<0) | (in[1]<<8) | (in[2]<<16) | (in[3]<<24);
+    int ulen   = (in[0]<<0) | (in[1]<<8) | (in[2]<<16) |
+	(((uint32_t)in[3])<<24);
 
     if (ulen < 0 || ulen >= INT_MAX-1024)
 	return NULL;


### PR DESCRIPTION
This is independent from the OSS fuzzing and doesn't need to be applied for those, hence a separate PR. (Ignore my branch name! It does fix 29796 but for the wrong reason.)

This is set to about 15Gb.  It's still high, but it prevents the most
egregious excesses.  The purpose is simply to prevent malformed data
from requesting obscene amounts of memory (although in theory that may
still be possible if the caller is also doing multi-threading).

That's equivalent to 10 million records in a block.  1 million may be
more reasonable, but it's also something I've used in extreme cases so
if feels to close to proper usage to limit it at that value.

Detected while looking at OSS-Fuzz 29796, but this isn't that bug
(which has already been fixed elsewhere).