### PR TITLE
fix undefined shift.

### DIFF
--- a/htscodecs/rANS_static.c
+++ b/htscodecs/rANS_static.c
@@ -266,8 +266,8 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
     if (*in++ != 0) // Order-0 check
 	return NULL;
     
-    in_sz  = ((in[0])<<0) | ((in[1])<<8) | ((in[2])<<16) | ((in[3])<<24);
-    out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | ((in[7])<<24);
+    in_sz  = ((in[0])<<0) | ((in[1])<<8) | ((in[2])<<16) | (((uint32_t)in[3])<<24);
+    out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | (((uint32_t)in[7])<<24);
     if (in_sz != in_size-9)
 	return NULL;
 
@@ -802,8 +802,8 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
     if (*in++ != 1) // Order-1 check
 	return NULL;
 
-    in_sz  = ((in[0])<<0) | ((in[1])<<8) | ((in[2])<<16) | ((in[3])<<24);
-    out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | ((in[7])<<24);
+    in_sz  = ((in[0])<<0) | ((in[1])<<8) | ((in[2])<<16) | (((uint32_t)in[3])<<24);
+    out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | (((uint32_t)in[7])<<24);
     if (in_sz != in_size-9)
 	return NULL;
 

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1549,7 +1549,7 @@ uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 	return NULL;
 
     //int nreads = *(uint32_t *)(in+4);
-    int nreads = (in[4]<<0) | (in[5]<<8) | (in[6]<<16) | (in[7]<<24);
+    int nreads = (in[4]<<0) | (in[5]<<8) | (in[6]<<16) | (((uint32_t)in[7])<<24);
     int use_arith = in[8];
     name_context *ctx = create_context(nreads);
     if (!ctx)


### PR DESCRIPTION
Google fuzzer identified this in tokenise_name3.c.

The rANS_static.c change was found looking for others via grep.  I'm
unsure if it's possible to trigger (although it seems likely) and if
so why it hasn't been found yet, but protecting it too just incase.

Credit to OSS-Fuzz
Fixes oss-fuzz 29956