### PR TITLE
Fix more fuzzing found issues.

### DIFF
--- a/htscodecs/rANS_byte.h
+++ b/htscodecs/rANS_byte.h
@@ -128,7 +128,7 @@ static inline void RansDecInit(RansState* r, uint8_t** pptr)
     x  = ptr[0] << 0;
     x |= ptr[1] << 8;
     x |= ptr[2] << 16;
-    x |= ptr[3] << 24;
+    x |= ((uint32_t)ptr[3]) << 24;
     ptr += 4;
 
     *pptr = ptr;

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1572,6 +1572,7 @@ uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 	    }
 
 	    if ((ttype & 15) != 0 && (ttype & 128)) {
+		if (tnum < 0) goto err;
 		ctx->desc[tnum<<4].buf = malloc(nreads);
 		if (!ctx->desc[tnum<<4].buf)
 		    goto err;
@@ -1582,6 +1583,7 @@ uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 		memset(&ctx->desc[tnum<<4].buf[1], N_MATCH, nreads-1);
 	    }
 
+	    if (tnum < 0) goto err;
 	    i = (tnum<<4) | (ttype&15);
 	    if (j >= i)
 		goto err;
@@ -1608,6 +1610,7 @@ uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 	}
 
 	if ((ttype & 15) != 0 && (ttype & 128)) {
+	    if (tnum < 0) goto err;
 	    if (ctx->desc[tnum<<4].buf) free(ctx->desc[tnum<<4].buf);
 	    ctx->desc[tnum<<4].buf = malloc(nreads);
 	    if (!ctx->desc[tnum<<4].buf)
@@ -1624,6 +1627,7 @@ uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 	int64_t clen, ulen = uncompressed_size(&in[o], sz-o);
 	if (ulen < 0 || ulen >= INT_MAX)
 	    goto err;
+	if (tnum < 0) goto err;
 	i = (tnum<<4) | (ttype&15);
 
 	if (i >= MAX_TBLOCKS || i < 0)


### PR DESCRIPTION
Credit to OSS-Fuzz

- Protect against no tokens present in tok_name3 codec.

  Fixes oss-fuzz 30008

- Fix undefined shift in rANS_byte.h
  (I thought I'd grepped for all of these, but didn't think the look
  in the header files.)

  Fixes oss-fuzz 30017