### PR TITLE
Fix off-by-one error in array bounds checking.

### DIFF
--- a/htscodecs/rle.c
+++ b/htscodecs/rle.c
@@ -169,7 +169,7 @@ uint8_t *rle_decode(uint8_t *lit, uint64_t lit_len,
 	    uint32_t rlen;
 	    run += var_get_u32(run, run_end, &rlen);
 	    if (rlen) {
-		if (outp + rlen > out_end)
+		if (outp + rlen >= out_end)
 		    goto err;
 		memset(outp, b, rlen+1);
 		outp += rlen+1;


### PR DESCRIPTION
Credit to OSS-Fuzz
Fixes oss-fuzz 30381
Fixes oss-fuzz 30395