### PR TITLE
Use printf in shell scripts instead of echo -n

### DIFF
--- a/tests/arith.test
+++ b/tests/arith.test
@@ -15,7 +15,7 @@ do
 	then
 	    continue
 	fi
-        echo -n Testing arith_dynamic -r -o$o on $f "	"
+        printf 'Testing arith_dynamic -r -o%s on %s\t' $o "$f"
 
 	# Round trip
         ./arith_dynamic -r -o$o $out/arith-nl $out/arith.comp 2>>$out/arith.stderr || exit 1

--- a/tests/fqzcomp.test
+++ b/tests/fqzcomp.test
@@ -11,7 +11,7 @@ do
     awk '{print $1}' < $f > $out/fqz
     for s in 0 1 2 3
     do
-        echo -n Testing fqzcomp_qual -r -s $s on $f "	"
+        printf 'Testing fqzcomp_qual -r -s %s on %s\t' $s "$f"
 
 	# Round trip
         ./fqzcomp_qual -r -s $s $out/fqz > $out/fqz.comp 2>>$out/fqz.stderr || exit 1

--- a/tests/rans4x16.test
+++ b/tests/rans4x16.test
@@ -15,7 +15,7 @@ do
 	then
 	    continue
 	fi
-        echo -n Testing rans4x16 -r -o$o on $f "	"
+        printf 'Testing rans4x16 -r -o%s on %s\t' $o "$f"
 
 	# Round trip
         ./rans4x16pr -r -o$o  $out/r4x16-nl $out/r4x16.comp 2>>$out/r4x16.stderr || exit 1

--- a/tests/rans4x8.test
+++ b/tests/rans4x8.test
@@ -11,7 +11,7 @@ do
     cut -f 1 < $f | tr -d '\012' > $out/r4x8-nl
     for o in 0 1
     do
-        echo -n Testing rans4x8 -r -o$o on $f "	"
+        printf 'Testing rans4x8 -r -o%s on %s\t' $o "$f"
 
 	# Round trip
         ./rans4x8 -r -o$o $out/r4x8-nl $out/r4x8.comp 2>>$out/r4x8.stderr || exit 1

--- a/tests/tok3.test
+++ b/tests/tok3.test
@@ -10,7 +10,7 @@ do
     comp=${f%/*/*}/names/tok3/${f##*/}
     for lvl in 1 3 5 7 9 11 13 15 17 19
     do
-        echo -n Testing tokenise_name3 -r -$lvl on $f "	"
+        printf 'Testing tokenise_name3 -r -%s on %s\t' $lvl "$f"
 
 	# Round trip
 	./tokenise_name3 -r -$lvl < $f > $out/tok3.comp


### PR DESCRIPTION
On macOS the shell's builtin `echo` doesn't process options in some circumstances, resulting in

```
-n Testing arith_dynamic [...]
11615
```

as can be seen in [HTSlib macOS CI build logs](https://cirrus-ci.com/task/4839257728614400).

Using `printf(1)` is (sadly) overall more portable.