### PR TITLE
Fix spurious test failure on Solaris/OpenIndiana

### DIFF
--- a/tests/fqzcomp.test
+++ b/tests/fqzcomp.test
@@ -8,7 +8,7 @@ fi
 for f in `ls -1 $srcdir/dat/q* $srcdir/htscodecs-corpus/dat/q* 2>/dev/null`
 do
     comp=${f%/*/*}/dat/fqzcomp/${f##*/}
-    awk '{print $1}' < $f > $out/fqz
+    cut -f 1 $f > $out/fqz
     for s in 0 1 2 3
     do
         printf 'Testing fqzcomp_qual -r -s %s on %s\t' $s "$f"


### PR DESCRIPTION
This fails with `awk: record 'S9$#6#6%7654A5634A;$...' too long` on Solaris/OpenIndiana's `awk`. We could configure around this to use `nawk` on this platform instead (as in PR samtools/samtools#1165, but more complicated due to needing to transmit the setting from htslib as well), but in this case it's easier to just use `cut`.