### PR TITLE
Fix an uninitialised access in the name tokeniser decode.

### DIFF
--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1058,6 +1058,8 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
 	tok = decode_token_type(ctx, ntok);
 	//fprintf(stderr, "Tok %d = %d\n", ntok, tok);
 
+	ctx->lc[cnum].last_ntok = 0;
+
 	switch (tok) {
 	case N_CHAR:
 	    if (len+1 >= name_len) return -1;


### PR DESCRIPTION
If delta is zero (as it is for the first record) and we make use of something that does differencing to the previous record, then pnum == cnum and we query ctx->lc[pnum].ntok before setting ntok at the end of the loop.

Credit to OSS-Fuzz
Fixes oss-fuzz 32688