### PR TITLE
Fix a bug with name tokeniser and variable number of names per slice.

### DIFF
--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -211,7 +211,7 @@ static name_context *create_context(int max_names) {
 	if (!ctx) return NULL;
 	ctx->max_names = max_names;
 	pthread_setspecific(tok_key, ctx);
-    } else if (ctx->max_names < max_names) {
+    } else if (ctx->max_names < max_names+1) {
 	ctx = realloc(ctx, sizeof(*ctx) + ++max_names*sizeof(*ctx->lc));
 	if (!ctx) return NULL;
 	ctx->max_names = max_names;


### PR DESCRIPTION
If the number of names increases by exactly 1 between successive slices, and the old value was the size of our allocated buffer, then we don't grow it by one.  This causes the last decoded name to return -1 instead of 0 as we do the max_names check before doing t0 < 0, which in turn gives a failure to decode slice error message.

It could be fixed in two ways, by shifting where the end of names check happens, or fixing the allocation.  I chose the latter as it would take more head scratching to determine why the allocation has `++max_names` in it.