### PR TITLE
Modernise autoconf usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,7 +70,6 @@ dnl Checks for programs.
 AC_PROG_CC
 AC_PROG_INSTALL
 LT_INIT
-AC_PROG_LIBTOOL
 
 # # by Marcelo Magallon <mmagallo@efis.ucr.ac.cr>
 # # Turn around -rpath problem with libtool 1.0c
@@ -108,7 +107,6 @@ dnl 	AC_DEFINE([HAVE_LIBBSC],1,[Define to 1 if you have the libbsc library.])])
 AX_LIBDEFLATE
 
 dnl Checks for header files.
-AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(fcntl.h limits.h unistd.h malloc.h)
 AC_CHECK_HEADER(zlib.h)
@@ -116,4 +114,5 @@ AC_CHECK_HEADER(zlib.h)
 dnl Checks for library functions.
 AC_SEARCH_LIBS([pthread_join], [pthread])
 
-AC_OUTPUT(Makefile htscodecs/Makefile tests/Makefile)
+AC_CONFIG_FILES([Makefile htscodecs/Makefile tests/Makefile])
+AC_OUTPUT

--- a/m4/ax_with_libdeflate.m4
+++ b/m4/ax_with_libdeflate.m4
@@ -31,7 +31,7 @@
 AC_DEFUN([AX_LIBDEFLATE],
 [
   AC_ARG_WITH(libdeflate,
-	      AC_HELP_STRING([--with-libdeflate=DIR],[look for libdeflate in DIR]),
+	      AS_HELP_STRING([--with-libdeflate=DIR],[look for libdeflate in DIR]),
 	      [ac_libdeflate_with=$withval],[ac_libdeflate_with="no"])
 
   # Check if it's a working library

--- a/m4/zlib.m4
+++ b/m4/zlib.m4
@@ -4,7 +4,7 @@
 AC_DEFUN([ZLIB_CHECK_CONFIG],
 [
   AC_ARG_WITH(zlib,
-	      AC_HELP_STRING([--with-zlib=DIR],[look for zlib in DIR]),
+	      AS_HELP_STRING([--with-zlib=DIR],[look for zlib in DIR]),
 	      [_zlib_with=$withval],[_zlib_with="no"])
 
   ZLIB_ROOT=""
@@ -24,11 +24,10 @@ AC_DEFUN([ZLIB_CHECK_CONFIG],
     CPPFLAGS="$CPPFLAGS -I${ZLIB_ROOT}/include"
     _ldflags=$LDFLAGS
     LDFLAGS="$LFDLAGS -L${ZLIB_ROOT}/lib"
-    AC_LANG_SAVE
-    AC_LANG_C
+    AC_LANG_PUSH([C])
     AC_CHECK_LIB(z, inflateEnd,
 	[AC_CHECK_HEADER(zlib.h, zlib_ok=yes, zlib_ok=no)])
-    AC_LANG_RESTORE
+    AC_LANG_POP([C])
     if test "$zlib_ok" != "yes"
     then
         # Backout and whinge


### PR DESCRIPTION
Avoid warnings about obsolete usage from `autoreconf`:

```
configure.ac:73: warning: The macro `AC_PROG_LIBTOOL' is obsolete.
configure.ac:73: You should run autoupdate.
configure.ac:93: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:93: warning: The macro `AC_LANG_C' is obsolete.
configure.ac:111: warning: The macro `AC_HEADER_STDC' is obsolete.
configure.ac:119: warning: AC_OUTPUT should be used without arguments.
```

The most recent “new” autoconf feature in this change is from 2.59 in 2006. `LT_INIT` has sufficed for libtool for even longer.