### PR TITLE
Update to release 1.1.1

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,55 @@
+Notes to maintainers for building releases.
+This is best done as a release PR so we can check it first.
+
+1. Places to update the version number include:
+
+   - htscodecs/htscodecs.h (used for program introspection)
+
+   - configure.ac AC_INIT macro
+
+   - configure.ac VERS_CURRENT, VERS_REVISION and VERS_AGE variables.
+     See the long comment above for instructions of how these change.
+
+   - NEWS and README files.
+
+
+2. Ensure NEWS and README files are up to date.  NEWS is a git log
+   summary.  README is probably just a version number update, unless
+   anything major needs bringing up.
+
+   - At time of merging, set the date at the top of NEWS.
+
+
+3. Test it all.
+   - Push to github PR so the CI can validate for us.
+
+   - make distcheck
+     This also makes the tarball htscodecs-${vers}.tar.gz.
+
+
+4. Merge into master
+
+
+5. Add an annotated tag with minimal message, eg:
+
+   - git tag -a v1.1 -m v1.1
+
+
+6. Push master and --tags upstream to github
+
+
+7. Make a new release on github.
+
+   - Title: "htscodecs ${vers}"
+
+   - Message: this is just a copy of NEWS.
+     It's already in Markdown format, but double check the preview panel.
+
+   - Upload the tarball produced from distcheck to the assets.
+
+
+8. Finally, consider updating any packages that use this as a
+   submodule to ensure they have the latest tagged release.
+
+   This will invariably help OS distributions keep their package
+   dependencies neatly in sync.

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
-Release 1.1: 6th July 2021
---------------------------
+Release 1.1.1: 6th July 2021
+----------------------------
 
 This release contains the following minoring changes.
 Please see the "git log" for the full details.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Htscodecs: version 1.1
-======================
+Htscodecs: version 1.1.1
+========================
 
 [![Build Status](https://api.cirrus-ci.com/github/jkbonfield/htscodecs.svg?branch=master)](https://cirrus-ci.com/github/jkbonfield/htscodecs)
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(htscodecs, 1.1)
+AC_INIT(htscodecs, 1.1.1)
 
 # Some functions benefit from -O3 optimisation, so if the user didn't
 # explicitly set any compiler flags, we'll plump for O3.
@@ -60,7 +60,7 @@ AM_MAINTAINER_MODE
 #       libhtscodecs.so.1.1.0
 
 VERS_CURRENT=2
-VERS_REVISION=2
+VERS_REVISION=3
 VERS_AGE=0
 AC_SUBST(VERS_CURRENT)
 AC_SUBST(VERS_REVISION)

--- a/htscodecs/htscodecs.h
+++ b/htscodecs/htscodecs.h
@@ -43,7 +43,7 @@
  * Note currently this needs manually editing as it isn't automatically
  * updated by autoconf.
  */
-#define HTSCODECS_VERSION 100000
+#define HTSCODECS_VERSION 100101
 
 /*
  * A const string form of the HTSCODECS_VERSION define.


### PR DESCRIPTION
The only change is updating the HTSCODECS_VERSION macro in htscodecs.h
also.  I forgot to do this for 1.1, so this is a tiny change.  (The
NEWS file just glosses over the existance of 1.1 and jumps straight to
1.1.1.)

My apologies.

Also added a MAINTAINERS.md file as an aide memoir for future releases.