### PR TITLE
Work around an icc-2021 compiler bug (and speedup varint too).

### DIFF
--- a/htscodecs/varint.h
+++ b/htscodecs/varint.h
@@ -1,7 +1,7 @@
 // FIXME: make get functions const uint8_t *
 
 /*
- * Copyright (c) 2019,2020 Genome Research Ltd.
+ * Copyright (c) 2019,2020,2021 Genome Research Ltd.
  * Author(s): James Bonfield
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
The latest icc generates incorrect code for var_put_u32 and
var_put_u64 when using optimisation levels -O2 and above.  It does
(pointless) heavy SIMD unrolling, but appears to get something wrong
in the several hundred instructions generated (vs 50 or so for gcc).

This shows up in "make check CC=icc" with rans4x16 test failing.

There are simple ways of solve this, such as adding an additional loop
counter to force the compiler to notice the loop cannot be executed
100s of times and avoid the whole SIMDification, eg:

    int n = 5;
    do {
	s -= 7;
	*cp++ = ((i>>s) & 0x7f) + (s?128:0);
    } while (s && n-- > 0);

However it turns out it's generally quicker to just do an verbatim
if/else-if construction for most cases.  While this may be slower on
very large data, particularly huge 64-bit values unless we add in
additional upfront estimators via __builtin_clzl, our typical usage is
with small values.  That's even true for the calls to var_put_u64 as
we're calling that because the data *may* be large and not because it
*is* large.

Also did some less significant improvements to decode timings.

Some benchmarks on a noddy test tool, with "endp" checks enabled,
using -O3:

32-bit (perf task-lock msec for 100 million values), for random values
between 0 and 1 million (20 bits):

                      Encode         Decode
                    Old   New      Old   New
    icc            1271   303      476   504
    gcc11           744   311      516   311
    gcc7            754   339      733   438
    clang10         917   306      442   417

And 64-bit, with random 48-bit quantitites:

                      Encode         Decode
                    Old   New      Old   New
    icc            2492   737     1089  1039
    gcc11          1413   756      912   635
    gcc7           1427   611      911   658
    clang10        1745   764     1158   751

So not only now correct for icc, but a significant speed gain for all
compilers.  Note -O2 may not fare so well, but we're tuning for the
most optimised case.

[Note: For CRAM purposes, I don't think this code is particularly dominant in CPU usage as we generally use varint encoding for meta-data only, however equally so if I'm being forced to rewrite it due to buggy compilers, then I may as well choose a performance reimplementation.  I'd have rather not had to do anything though!]