### PR TITLE
Fix off-by-one error on initial size check for arith_dynamic.

### DIFF
--- a/htscodecs/c_range_coder.h
+++ b/htscodecs/c_range_coder.h
@@ -61,7 +61,7 @@ static inline void RC_StartDecode(RangeCoder *rc)
     rc->Carry = 0;
     rc->Cache = 0;
     rc->code  = 0;
-    if (rc->in_buf+5 >= rc->in_end) {
+    if (rc->in_buf+5 > rc->in_end) {
         rc->in_buf = rc->in_end; // prevent decode
         return;
     }


### PR DESCRIPTION
This meant the most naive of small tests would fail to decode as the compressed data size exactly consumes the size of the initialisation of `rc->code`.  We incorrectly rejected this case.

Note this also shows a weakness of error reporting, as the caller needs a better way to be told of the input data being too small (which admittedly it wasn't, but the bug meant it thought it was but no report was given).

That's a much wider change, for another PR some time, as it'll need the error handling in c_simple_model.h completely redesigning.