### PR TITLE
Various rANS speedups

### DIFF
--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1171,10 +1171,24 @@ unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
 	    idx[i] = i ? idx[i-1] + part_len[i-1] : 0; // cumulative index
 	}
 
-	for (i = x = 0; i < in_size-N; i += N, x++) {
+#define KN 8
+	i = x = 0;
+	if (in_size >= N*KN) {
+	    for (; i < in_size-N*KN;) {
+		int k;
+		unsigned char *ink = in+i;
+		for (j = 0; j < N; j++)
+		    for (k = 0; k < KN; k++)
+			transposed[idx[j]+x+k] = ink[j+N*k];
+		x += KN; i+=N*KN;
+	    }
+	}
+#undef KN
+	for (; i < in_size-N; i += N, x++) {
 	    for (j = 0; j < N; j++)
 		transposed[idx[j]+x] = in[i+j];
 	}
+
 	for (; i < in_size; i += N, x++) {
 	    for (j = 0; i+j < in_size; j++)
 		transposed[idx[j]+x] = in[i+j];

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -650,20 +650,19 @@ static int compute_shift(uint32_t *F0, uint32_t (*F)[256], uint32_t *T,
 
 	double l10 = log(TOTFREQ_O1_FAST + sm10);
 	double l12 = log(TOTFREQ_O1      + sm12);
+	double T_slow = (double)TOTFREQ_O1/T[i];
+	double T_fast = (double)TOTFREQ_O1_FAST/T[i];
 
 	for (j = 0; j < 256; j++) {
 	    if (F[i][j]) {
 		ns++;
 
-		int x = (double)TOTFREQ_O1_FAST * F[i][j]/T[i];
-		e10 -= F[i][j] * (fast_log(MAX(x,1)) - l10);
+		e10 -= F[i][j] * (fast_log(MAX(F[i][j]*T_fast,1)) - l10);
+		e12 -= F[i][j] * (fast_log(MAX(F[i][j]*T_slow,1)) - l12);
 
-		x = (double)TOTFREQ_O1 * F[i][j]/T[i];
-		e12 -= F[i][j] * (fast_log(MAX(x,1)) - l12);
-
-		// Estimation of compressedf symbol freq table too.
-		e10 += 4;
-		e12 += 6;
+		// Estimation of compressed symbol freq table too.
+		e10 += 1.3;
+		e12 += 4.7;
 	    }
 	}
 
@@ -682,7 +681,9 @@ static int compute_shift(uint32_t *F0, uint32_t (*F)[256], uint32_t *T,
 	if (max_tot < max_val)
 	    max_tot = max_val;
     }
-    int shift = e10/e12 < 1.01 || max_tot <= TOTFREQ_O1_FAST ? TF_SHIFT_O1_FAST : TF_SHIFT_O1;
+    int shift = e10/e12 < 1.01 || max_tot <= TOTFREQ_O1_FAST
+	? TF_SHIFT_O1_FAST
+	: TF_SHIFT_O1;
 
 //    fprintf(stderr, "e10/12 = %f %f %f, shift %d\n",
 //    	    e10/log(256), e12/log(256), e10/e12, shift);

--- a/htscodecs/rANS_word.h
+++ b/htscodecs/rANS_word.h
@@ -280,7 +280,58 @@ static inline void RansDecSymbolInit(RansDecSymbol* s, uint32_t start, uint32_t 
 // See RansEncSymbolInit for a description of how this works.
 static inline void RansEncPutSymbol(RansState* r, uint8_t** pptr, RansEncSymbol const* sym)
 {
-    RansAssert(sym->x_max != 0); // can't encode symbol with freq=0
+    //RansAssert(sym->x_max != 0); // can't encode symbol with freq=0
+
+    // renormalize
+    uint32_t x = *r;
+    uint32_t x_max = sym->x_max;
+
+#ifdef HTSCODECS_LITTLE_ENDIAN
+    // Branchless renorm.
+    //
+    // This works best on high entropy data where branch prediction
+    // is poor.
+    //
+    // Note the bit-packing and RLE modes are more likely to be used on
+    // low entropy data, making this assertion generally true.
+    // TODO: maybe have two different variants, and a detection mechanism
+    // based on freq table to work out which method would be most efficient?
+    int c = x >= x_max;
+    uint16_t* ptr = *(uint16_t **)pptr;
+    ptr[-1] = x & 0xffff;
+    x >>= c*16;
+    *pptr = (uint8_t *)(ptr-c);
+#else
+    if (x >= x_max) {
+	uint8_t* ptr = *pptr;
+        ptr -= 2;
+	ptr[0] = x & 0xff;
+	ptr[1] = (x >> 8) & 0xff;
+	x >>= 16;
+	*pptr = ptr;
+    }
+#endif
+
+    // x = C(s,x)
+    // NOTE: written this way so we get a 32-bit "multiply high" when
+    // available. If you're on a 64-bit platform with cheap multiplies
+    // (e.g. x64), just bake the +32 into rcp_shift.
+    //uint32_t q = (uint32_t) (((uint64_t)x * sym->rcp_freq) >> 32) >> sym->rcp_shift;
+
+    // Slow method, but robust
+//    *r = ((x / sym->freq) << sym->scale_bits) + (x % sym->freq) + sym->start;
+//    return;
+
+    // The extra >>32 has already been added to RansEncSymbolInit
+    uint32_t q = (uint32_t) (((uint64_t)x * sym->rcp_freq) >> sym->rcp_shift);
+    *r = x + sym->bias + q * sym->cmpl_freq;
+
+//    assert(((x / sym->freq) << sym->scale_bits) + (x % sym->freq) + sym->start == *r);
+}
+
+static inline void RansEncPutSymbol_branched(RansState* r, uint8_t** pptr, RansEncSymbol const* sym)
+{
+    //RansAssert(sym->x_max != 0); // can't encode symbol with freq=0
 
     // renormalize
     uint32_t x = *r;

--- a/htscodecs/rle.c
+++ b/htscodecs/rle.c
@@ -158,14 +158,13 @@ uint8_t *rle_decode(uint8_t *lit, uint64_t lit_len,
     uint8_t *lit_end = lit + lit_len;
     uint8_t *out_end = out + *out_len;
     uint8_t *outp = out;
+
     while (lit < lit_end) {
 	if (outp >= out_end)
 	    goto err;
 
-	uint8_t b = *lit++;
-	if (!saved[b]) {
-	    *outp++ = b;
-	} else {
+	uint8_t b = *lit;
+	if (saved[b]) {
 	    uint32_t rlen;
 	    run += var_get_u32(run, run_end, &rlen);
 	    if (rlen) {
@@ -176,7 +175,10 @@ uint8_t *rle_decode(uint8_t *lit, uint64_t lit_len,
 	    } else {
 		*outp++ = b;
 	    }
+	} else {
+	    *outp++ = b;
 	}
+	lit++;
     }
 
     *out_len = outp-out;

--- a/htscodecs/utils.h
+++ b/htscodecs/utils.h
@@ -46,17 +46,44 @@ static inline void unstripe(unsigned char *out, unsigned char *outN,
     if (ulen >= N) {
 	switch (N) {
 	case 4:
+#define LLN 16
+	    if (ulen >= 4*LLN) {
+		while (j < ulen-4*LLN) {
+		    int l;
+		    for (l = 0; l < LLN; l++) {
+			for (k = 0; k < 4; k++)
+			    out[j+k+l*4] = outN[idxN[k]+l];
+		    }
+		    for (k = 0; k < 4; k++)
+			idxN[k] += LLN;
+		    j += 4*LLN;
+		}
+	    }
 	    while (j < ulen-4) {
 		for (k = 0; k < 4; k++)
 		    out[j++] = outN[idxN[k]++];
 	    }
+#undef LLN
 	    break;
 
 	case 2:
+#define LLN 4
+	    if (ulen >= 2*LLN) {
+		while (j < ulen-2*LLN) {
+		    int l;
+		    for (l = 0; l < LLN; l++) {
+			for (k = 0; k < 2; k++)
+			    out[j++] = outN[idxN[k]+l];
+		    }
+		    for (k = 0; k < 2; k++)
+			idxN[k] += l;
+		}
+	    }
 	    while (j < ulen-2) {
 		for (k = 0; k < 2; k++)
 		    out[j++] = outN[idxN[k]++];
 	    }
+#undef LLN
 	    break;
 
 	default:

--- a/htscodecs/utils.h
+++ b/htscodecs/utils.h
@@ -195,6 +195,7 @@ void hist1_4(unsigned char *in, unsigned int in_size,
 	    l = c;
 	}
     }
+    T0[l]++;
 
     int i;
     for (i = 0; i < 256; i++)


### PR DESCRIPTION
A mixture of bits cherry-picked out of the unroll32 branch.  These apply to the main codecs and not just the 32-way SIMD implementation.  Some perf stat reports from 10 runs on low complexity (q4) and high complexity (q40) data sets comparing master (old) vs this PR (new).

Clang10
```
                    Giga-cycles enc     Giga-cycles dec
                    old      new        old      new
4x8 -o1 q4          2186     2061 -     1225     1202 -
4x8 -o1 q40         1570     1482 -     1033     1034 ~
4x16 -o193 q4       1533     1435 -      778      762 -
4x16 -o1 q40        2553     1789 --     863      868 ~
```
Gcc11
```
                    Giga-cycles enc     Giga-cycles dec
                    old      new        old      new
4x8 -o1 q4          2174     2075 -     1234     1205 -
4x8 -o1 q40         1667     1574 -     1045     1045 =
4x16 -o193 q4       1694     1573 -      775      789 +
4x16 -o1 q40        2539     1798 --     865      867 ~
```

New decoder is marginally different, sometimes better, sometimes worse, but varies by file / compiler. All minor and maybe just noise.  Nothing was specifically changed here, so any genuine speed differences are likely simply down to function alignment.

Encoder is universally faster, considerably so for 4x16 on complex data (q40).
