### PR TITLE
Bug fix to bounds checking in fqzcomp read_array.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,12 +41,12 @@ task:
     - make check CFLAGS="-g -O3 -Wall -Werror"
     - make distcheck
 
-# CentOS
-centos_task:
+# Rocky Linux
+rocky_task:
   << : *ENVIRONMENT
-  name: centos-gcc
+  name: rockylinux-gcc
   container:
-    image: centos:latest
+    image: rockylinux:latest
     cpu: 2
     memory: 1G
 

--- a/htscodecs/fqzcomp_qual.c
+++ b/htscodecs/fqzcomp_qual.c
@@ -163,7 +163,7 @@ static int read_array(unsigned char *in, size_t in_size, unsigned int *array, in
 		return -1;
 	    int copy = in[++i];
 	    z += run * copy;
-	    while (copy-- && z < size && j < 1024)
+	    while (copy-- && z <= size && j < 1024)
 		R[j++] = run;
 	}
 	if (j >= 1024)


### PR DESCRIPTION
An array of 128x8 = 1024.
This is RLE as 128, 128, x6

At z=256 z+128*6=1024, so this needs to be z<=size instead.
It meant some lookup tables weren't decodable.

Also included the same cirrus CI fix we applied to samtools et al (centos -> rocky)