### PR TITLE
Fix a fuzzing test failure in tokenise_name3.

### DIFF
--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1214,6 +1214,7 @@ static int64_t arith_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t
     if (arith_uncompress_to(in+nb, in_len-nb, out, &olen) == NULL)
 	return -1;
     //fprintf(stderr, "    Stored clen=%d\n", (int)clen);
+    *out_len = olen;
     return clen+nb;
 }
 
@@ -1240,6 +1241,7 @@ static int64_t rans_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t 
     if (rans_uncompress_to_4x16(in+nb, in_len-nb, out, &olen) == NULL)
 	return -1;
     //fprintf(stderr, "    Stored clen=%d\n", (int)clen);
+    *out_len = olen;
     return clen+nb;
 }
 
@@ -1650,9 +1652,8 @@ uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 	uint64_t usz = ctx->desc[i].buf_a; // convert from size_t for 32-bit sys
 	clen = uncompress(use_arith, &in[o], sz-o, ctx->desc[i].buf, &usz);
 	ctx->desc[i].buf_a = usz;
-	if (clen < 0)
+	if (clen < 0 || ctx->desc[i].buf_a != ulen)
 	    goto err;
-	assert(ctx->desc[i].buf_a == ulen);
 
 	// fprintf(stderr, "%d: Decode tnum %d type %d clen %d ulen %d via %d\n",
 	// 	o, tnum, ttype, (int)clen, (int)ctx->desc[i].buf_a, ctx->desc[i].buf[0]);


### PR DESCRIPTION
The uncompress function didn't reset the uncompressed size (making the
subsequent assert pointless), instead trusting the recorded 'ulen'
size as real. If data uncompressed to a smaller amount, it meant parts
of the buffer were uninitialised, triggering an uninitialised memory
read.

Now this is fixed, we hit asserts, which isn't good either.  So that's
now a proper error return instead.