### PR TITLE
Assorted bug-fixes

### DIFF
--- a/htscodecs/arith_dynamic.c
+++ b/htscodecs/arith_dynamic.c
@@ -886,6 +886,8 @@ unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
 	if (c_meta_len >= in_size)
 	    return NULL;
 	unsigned int N = in[c_meta_len++];
+        if (N < 1)  // Must be at least one stripe
+            return NULL;
 	unsigned int clenN[256], ulenN[256], idxN[256];
 	if (!out) {
 	    if (ulen >= INT_MAX)

--- a/htscodecs/arith_dynamic.c
+++ b/htscodecs/arith_dynamic.c
@@ -1086,7 +1086,6 @@ unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
 		goto err;
 	}
     } else {
-	tmp1 = NULL;
 	tmp1_size = 0;
     }
 

--- a/htscodecs/fqzcomp_qual.c
+++ b/htscodecs/fqzcomp_qual.c
@@ -1282,6 +1282,8 @@ int fqz_read_parameters(fqz_gparams *gp, unsigned char *in, size_t in_size) {
 	int e = fqz_read_parameters1(&gp->p[i], in + in_idx, in_size-in_idx);
 	if (e < 0)
 	    goto err;
+        if (gp->p[i].do_sel && gp->max_sel == 0)
+            goto err; // Inconsistent
 	in_idx += e;
 
 	if (gp->max_sym < gp->p[i].max_sym)

--- a/htscodecs/fqzcomp_qual.c
+++ b/htscodecs/fqzcomp_qual.c
@@ -1204,24 +1204,36 @@ int fqz_read_parameters1(fqz_param *pm, unsigned char *in, size_t in_size) {
     }
 
     if (pm->qbits) {
-	if (pm->use_qtab)
-	    in_idx += read_array(in+in_idx, in_size-in_idx, pm->qtab, 256);
-	else
+	if (pm->use_qtab) {
+	    int used = read_array(in+in_idx, in_size-in_idx, pm->qtab, 256);
+	    if (used < 0)
+		return -1;
+	    in_idx += used;
+	} else {
 	    for (i = 0; i < 256; i++)
 		pm->qtab[i] = i;
+	}
     }
 
-    if (pm->use_ptab)
-	in_idx += read_array(in+in_idx, in_size-in_idx, pm->ptab, 1024);
-    else
+    if (pm->use_ptab) {
+	int used = read_array(in+in_idx, in_size-in_idx, pm->ptab, 1024);
+	if (used < 0)
+	    return -1;
+	in_idx += used;
+    } else {
 	for (i = 0; i < 1024; i++)
 	    pm->ptab[i] = 0;
+    }
 
-    if (pm->use_dtab)
-        in_idx += read_array(in+in_idx, in_size-in_idx, pm->dtab, 256);
-    else
+    if (pm->use_dtab) {
+        int used = read_array(in+in_idx, in_size-in_idx, pm->dtab, 256);
+	if (used < 0)
+	    return -1;
+	in_idx += used;
+    } else {
 	for (i = 0; i < 256; i++)
 	    pm->dtab[i] = 0;
+    }
 
     return in_idx;
 }
@@ -1250,7 +1262,10 @@ int fqz_read_parameters(fqz_gparams *gp, unsigned char *in, size_t in_size) {
 
     if (gp->gflags & GFLAG_HAVE_STAB) {
 	gp->max_sel = in[in_idx++];
-	in_idx += read_array(in+in_idx, in_size-in_idx, gp->stab, 256);
+	int used = read_array(in+in_idx, in_size-in_idx, gp->stab, 256);
+        if (used < 0)
+            goto err;
+	in_idx += used;
     } else {
 	for (i = 0; i < gp->nparam; i++)
 	    gp->stab[i] = i;

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -362,7 +362,7 @@ unsigned int rans_compress_bound_4x16(unsigned int size, int order) {
     if (!N) N=4;
 
     order &= 0xff;
-    int sz = (order == 0
+    unsigned int sz = (order == 0
 	? 1.05*size + 257*3 + 4
 	: 1.05*size + 257*257*3 + 4 + 257*3+4) +
 	((order & X_PACK) ? 1 : 0) +

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -911,16 +911,18 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
 
     uint8_t *sfb_ = pthread_getspecific(rans_key);
     if (!sfb_) {
-	sfb_ = calloc(256*(TOTFREQ_O1+MAGIC2), sizeof(*sfb_));
+	sfb_ = calloc(256*(TOTFREQ_O1+MAGIC2)
+                      + 256*256*sizeof(fb_t), sizeof(*sfb_));
 	pthread_setspecific(rans_key, sfb_);
     }
 #else
-    uint8_t *sfb_ = calloc(256*(TOTFREQ_O1+MAGIC2), sizeof(*sfb_));
+    uint8_t *sfb_ = calloc(256*(TOTFREQ_O1+MAGIC2)
+                           + 256*256*sizeof(fb_t), sizeof(*sfb_));
 #endif
 
     if (!sfb_)
 	return NULL;
-    fb_t fb[256][256];
+    fb_t (*fb)[256] = (fb_t (*)[256]) (sfb_ + 256*(TOTFREQ_O1+MAGIC2));
     uint8_t *sfb[256];
     if ((*cp >> 4) == TF_SHIFT_O1) {
 	for (i = 0; i < 256; i++)

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1607,7 +1607,6 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
 		goto err;
 	}
     } else {
-	tmp1 = NULL;
 	tmp1_size = 0;
     }
     tmp2_size = tmp3_size = tmp1_size;

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1382,6 +1382,8 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
 	if (c_meta_len >= in_size)
 	    return NULL;
 	unsigned int N = in[c_meta_len++];
+        if (N < 1)  // Must be at least one stripe
+            return NULL;
 	unsigned int clenN[256], ulenN[256], idxN[256];
 	if (!out) {
 	    if (ulen >= INT_MAX)

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1596,6 +1596,8 @@ uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 	    i = (tnum<<4) | (ttype&15);
 	    if (j >= i)
 		goto err;
+            if (!ctx->desc[j].buf)
+                goto err; // Attempt to copy a non-existent stream
 
 	    ctx->desc[i].buf_l = 0;
 	    ctx->desc[i].buf_a = ctx->desc[j].buf_a;


### PR DESCRIPTION
* Use consistent data types in `rans_compress_bound_4x16()`
* Reject stripe mode inputs with zero stripes, preventing an endless loop in `unstripe()`
* Fix UBSAN warnings about operations on NULL pointers, decoding bit-packed or RLE data.
* Reject attempts to duplicate non-existent name tokeniser streams.
* Fix possible use of uninitialised memory in rans_uncompress_O1_4x16().

The first three commits have been pulled over from #26, as they fix pre-existing bugs unrelated to the other updates there.