### PR TITLE
SIMD tidy up

### DIFF
--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -854,7 +854,7 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
             : rans_compress_O0_4x16;
     }
     unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
-    // These may be unused, defending on HAVE_* config.h macros
+    // These may be unused, depending on HAVE_* config.h macros
     int have_ssse3   UNUSED = 0;
     int have_sse4_1  UNUSED = 0;
     int have_popcnt  UNUSED = 0;
@@ -935,7 +935,7 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
             : rans_uncompress_O0_4x16;
     }
     unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
-    // These may be unused, defending on HAVE_* config.h macros
+    // These may be unused, depending on HAVE_* config.h macros
     int have_ssse3   UNUSED = 0;
     int have_sse4_1  UNUSED = 0;
     int have_popcnt  UNUSED = 0;

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1039,19 +1039,8 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
     }
 }
 
-#else // defined(__GNUC__) && defined(__x86_64__)
+#else // !(defined(__GNUC__) && defined(__x86_64__)) && !defined(__ARM_NEON)
 
-// We may well be able to write generate AVX2 code, but if we can't auto-detect
-// it then it's pointless.  We can however still use the 32-way codec as
-// we may be decoding on a machine with AVX2 support and the CPU hit isn't
-// vast.
-#ifdef HAVE_AVX2
-#  undef HAVE_AVX2
-#endif
-
-#ifdef HAVE_AVX2
-#  undef HAVE_AVX512
-#endif
 static inline
 unsigned char *(*rans_enc_func(int do_simd, int order))
     (unsigned char *in,

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -841,44 +841,44 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
             ? rans_compress_O1_4x16
             : rans_compress_O0_4x16;
     }
-	unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
-	int have_ssse3   = 0;
-	int have_sse4_1  = 0;
-	int have_popcnt  = 0;
-	int have_avx2    = 0;
-	int have_avx512f = 0;
+    unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+    int have_ssse3   = 0;
+    int have_sse4_1  = 0;
+    int have_popcnt  = 0;
+    int have_avx2    = 0;
+    int have_avx512f = 0;
 
-	int level = __get_cpuid_max(0, NULL);
-	if (level >= 1) {
-	    __cpuid_count(1, 0, eax, ebx, ecx, edx);
+    int level = __get_cpuid_max(0, NULL);
+    if (level >= 1) {
+	__cpuid_count(1, 0, eax, ebx, ecx, edx);
 #if defined(bit_SSSE3)
-	    have_ssse3 = ecx & bit_SSSE3;
+	have_ssse3 = ecx & bit_SSSE3;
 #endif
 #if defined(bit_POPCNT)
-	    have_popcnt = ecx & bit_POPCNT;
+	have_popcnt = ecx & bit_POPCNT;
 #endif
 #if defined(bit_SSE4_1)
-	    have_sse4_1 = ecx & bit_SSE4_1;
+	have_sse4_1 = ecx & bit_SSE4_1;
 #endif
-	}
-	if (level >= 7) {
-	    __cpuid_count(7, 0, eax, ebx, ecx, edx);
+    }
+    if (level >= 7) {
+	__cpuid_count(7, 0, eax, ebx, ecx, edx);
 #if defined(bit_AVX2)
-	    have_avx2 = ebx & bit_AVX2;
+	have_avx2 = ebx & bit_AVX2;
 #endif
 #if defined(bit_AVX512F)
-	    have_avx512f = ebx & bit_AVX512F;
+	have_avx512f = ebx & bit_AVX512F;
 #endif
-	}
+    }
 
-	if (!have_popcnt) have_avx512f = have_avx2 = have_sse4_1 = 0;
-	if (!have_ssse3)  have_sse4_1 = 0;
+    if (!have_popcnt) have_avx512f = have_avx2 = have_sse4_1 = 0;
+    if (!have_ssse3)  have_sse4_1 = 0;
 
-	if (!(rans_cpu & RANS_CPU_ENC_AVX512)) have_avx512f = 0;
-	if (!(rans_cpu & RANS_CPU_ENC_AVX2))   have_avx2 = 0;
-	if (!(rans_cpu & RANS_CPU_ENC_SSE4))   have_sse4_1 = 0;
+    if (!(rans_cpu & RANS_CPU_ENC_AVX512)) have_avx512f = 0;
+    if (!(rans_cpu & RANS_CPU_ENC_AVX2))   have_avx2 = 0;
+    if (!(rans_cpu & RANS_CPU_ENC_SSE4))   have_sse4_1 = 0;
 
-	if (order & 1) {
+    if (order & 1) {
 #if defined(HAVE_AVX512)
         if (have_avx512f)
             return rans_compress_O1_32x16_avx512;
@@ -892,20 +892,20 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
             return rans_compress_O1_32x16;
 #endif
         return rans_compress_O1_32x16;
-	} else {
+    } else {
 #if defined(HAVE_AVX512)
-	    if (have_avx512f)
-            return rans_compress_O0_32x16_avx512;
+	if (have_avx512f)
+	    return rans_compress_O0_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-		if (have_avx2)
-            return rans_compress_O0_32x16_avx2;
+	if (have_avx2)
+	    return rans_compress_O0_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
-        if (have_sse4_1)
-            return rans_compress_O0_32x16;
+	if (have_sse4_1)
+	    return rans_compress_O0_32x16;
 #endif
-        return rans_compress_O0_32x16;
+	return rans_compress_O0_32x16;
     }
 }
 
@@ -921,75 +921,75 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
             ? rans_uncompress_O1_4x16
             : rans_uncompress_O0_4x16;
     }
-	unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
-	int have_ssse3   = 0;
-	int have_sse4_1  = 0;
-	int have_popcnt  = 0;
-	int have_avx2    = 0;
-	int have_avx512f = 0;
+    unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+    int have_ssse3   = 0;
+    int have_sse4_1  = 0;
+    int have_popcnt  = 0;
+    int have_avx2    = 0;
+    int have_avx512f = 0;
 
-	int level = __get_cpuid_max(0, NULL);
-	if (level >= 1) {
-	    __cpuid_count(1, 0, eax, ebx, ecx, edx);
+    int level = __get_cpuid_max(0, NULL);
+    if (level >= 1) {
+	__cpuid_count(1, 0, eax, ebx, ecx, edx);
 #if defined(bit_SSSE3)
-	    have_ssse3 = ecx & bit_SSSE3;
+	have_ssse3 = ecx & bit_SSSE3;
 #endif
 #if defined(bit_POPCNT)
-	    have_popcnt = ecx & bit_POPCNT;
+	have_popcnt = ecx & bit_POPCNT;
 #endif
 #if defined(bit_SSE4_1)
-	    have_sse4_1 = ecx & bit_SSE4_1;
+	have_sse4_1 = ecx & bit_SSE4_1;
 #endif
-	}
-	if (level >= 7) {
-	    __cpuid_count(7, 0, eax, ebx, ecx, edx);
+    }
+    if (level >= 7) {
+	__cpuid_count(7, 0, eax, ebx, ecx, edx);
 #if defined(bit_AVX2)
-	    have_avx2 = ebx & bit_AVX2;
+	have_avx2 = ebx & bit_AVX2;
 #endif
 #if defined(bit_AVX512F)
-	    have_avx512f = ebx & bit_AVX512F;
+	have_avx512f = ebx & bit_AVX512F;
 #endif
-	}
+    }
 
-	if (!have_popcnt) have_avx512f = have_avx2 = have_sse4_1 = 0;
-	if (!have_ssse3)  have_sse4_1 = 0;
+    if (!have_popcnt) have_avx512f = have_avx2 = have_sse4_1 = 0;
+    if (!have_ssse3)  have_sse4_1 = 0;
 
-	if (!(rans_cpu & RANS_CPU_DEC_AVX512)) have_avx512f = 0;
-	if (!(rans_cpu & RANS_CPU_DEC_AVX2))   have_avx2 = 0;
-	if (!(rans_cpu & RANS_CPU_DEC_SSE4))   have_sse4_1 = 0;
+    if (!(rans_cpu & RANS_CPU_DEC_AVX512)) have_avx512f = 0;
+    if (!(rans_cpu & RANS_CPU_DEC_AVX2))   have_avx2 = 0;
+    if (!(rans_cpu & RANS_CPU_DEC_SSE4))   have_sse4_1 = 0;
 
-//	fprintf(stderr, "SSSE3 %d, SSE4.1 %d, POPCNT %d, AVX2 %d, AVX512F %d\n",
-//		have_ssse3, have_sse4_1, have_popcnt, have_avx2, have_avx512f);
+    //	fprintf(stderr, "SSSE3 %d, SSE4.1 %d, POPCNT %d, AVX2 %d, AVX512F %d\n",
+    //		have_ssse3, have_sse4_1, have_popcnt, have_avx2, have_avx512f);
 
-	if (order & 1) {
+    if (order & 1) {
 #if defined(HAVE_AVX512)
-	    if (have_avx512f)
-            return rans_uncompress_O1_32x16_avx512;
+	if (have_avx512f)
+	    return rans_uncompress_O1_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-		if (have_avx2)
-		   return rans_uncompress_O1_32x16_avx2;
+	if (have_avx2)
+	    return rans_uncompress_O1_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
         if (have_sse4_1)
             return rans_uncompress_O1_32x16_sse4;
 #endif
         return rans_uncompress_O1_32x16;
-	} else {
+    } else {
 #if defined(HAVE_AVX512)
-	    if (have_avx512f)
-            return rans_uncompress_O0_32x16_avx512;
+	if (have_avx512f)
+	    return rans_uncompress_O0_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-		if (have_avx2)
-            return rans_uncompress_O0_32x16_avx2;
+	if (have_avx2)
+	    return rans_uncompress_O0_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
-        if (have_sse4_1)
-            return rans_uncompress_O0_32x16_sse4;
+	if (have_sse4_1)
+	    return rans_uncompress_O0_32x16_sse4;
 #endif
-        return rans_uncompress_O0_32x16;
-	}
+	return rans_uncompress_O0_32x16;
+    }
 }
 
 #elif defined(__ARM_NEON)

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -830,6 +830,18 @@ void rans_set_cpu(int opts) {
 // Icc and Clang both also set __GNUC__
 #include <cpuid.h>
 
+#if defined(__clang__) && defined(__has_attribute)
+#  if __has_attribute(unused)
+#    define UNUSED __attribute__((unused))
+#  else
+#    define UNUSED
+#  endif
+#elif defined(__GNUC__) && __GNUC__ >= 3
+#  define UNUSED __attribute__((unused))
+#else
+#  define UNUSED
+#endif
+
 static inline
 unsigned char *(*rans_enc_func(int do_simd, int order))
     (unsigned char *in,
@@ -842,11 +854,12 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
             : rans_compress_O0_4x16;
     }
     unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
-    int have_ssse3   = 0;
-    int have_sse4_1  = 0;
-    int have_popcnt  = 0;
-    int have_avx2    = 0;
-    int have_avx512f = 0;
+    // These may be unused, defending on HAVE_* config.h macros
+    int have_ssse3   UNUSED = 0;
+    int have_sse4_1  UNUSED = 0;
+    int have_popcnt  UNUSED = 0;
+    int have_avx2    UNUSED = 0;
+    int have_avx512f UNUSED = 0;
 
     int level = __get_cpuid_max(0, NULL);
     if (level >= 1) {
@@ -922,11 +935,12 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
             : rans_uncompress_O0_4x16;
     }
     unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
-    int have_ssse3   = 0;
-    int have_sse4_1  = 0;
-    int have_popcnt  = 0;
-    int have_avx2    = 0;
-    int have_avx512f = 0;
+    // These may be unused, defending on HAVE_* config.h macros
+    int have_ssse3   UNUSED = 0;
+    int have_sse4_1  UNUSED = 0;
+    int have_popcnt  UNUSED = 0;
+    int have_avx2    UNUSED = 0;
+    int have_avx512f UNUSED = 0;
 
     int level = __get_cpuid_max(0, NULL);
     if (level >= 1) {

--- a/tests/benchmark.sh
+++ b/tests/benchmark.sh
@@ -5,8 +5,9 @@
 
 file=$1
 file2=`echo $1 | sed 's#.*/##'`
-r4x8=./tests/rans4x8
-r4x16=./tests/rans4x16pr
+test_dir=${TEST_DIR:-./tests}
+r4x8=$test_dir/rans4x8
+r4x16=$test_dir/rans4x16pr
 ntrials=${ntrials:-5}
 
 awkscript='BEGIN {e1=99999;e2=0;d1=99999;d2=0} /bytes/ {if (e1 > $1) {e1 = $1} if (e2 < $1) {e2 = $1} if (d1 > $4) {d1 = $4} if (d2 < $4) {d2 = $4};s=$10} END {print e1,e2,d1,d2,s}'
@@ -30,7 +31,7 @@ do
     set -- $(for i in `seq 1 $ntrials`;do
              $r4x16 -t -o4 -c$c $file 2>&1
         done | awk "$awkscript")
-    printf "r4x16   -o4 -c %-4s %10d %6.1f %6.1f\n" $c $5 $2 $4
+    printf "r32x16  -o4 -c %-4s %10d %6.1f %6.1f\n" $c $5 $2 $4
 done
 
 echo
@@ -51,5 +52,5 @@ do
     set -- $(for i in `seq 1 $ntrials`;do
              $r4x16 -t -o5 -c$c $file 2>&1
         done | awk "$awkscript")
-    printf "r4x16   -o5 -c %-4s %10d %6.1f %6.1f\n" $c $5 $2 $4
+    printf "r32x16  -o5 -c %-4s %10d %6.1f %6.1f\n" $c $5 $2 $4
 done


### PR DESCRIPTION
Removed a warning introduced in #43.  Also fixed broken indentation that appeared then too.

A subsequent PR will land to change everything to spaces, to avoid non-standard tab configurations leading people up the garden path.  (To my mind, the only valid definition of a tab is the one used as standard by unix terminals, as that permits people to view source outside of a particular editor.)