### PR TITLE
Replace tabs with spaces.

### DIFF
--- a/htscodecs/arith_dynamic.c
+++ b/htscodecs/arith_dynamic.c
@@ -76,10 +76,10 @@
 
 unsigned int arith_compress_bound(unsigned int size, int order) {
     return (order == 0
-	? 1.05*size + 257*3 + 4
-	: 1.05*size + 257*257*3 + 4 + 257*3+4) +
-	((order & X_PACK) ? 1 : 0) +
-	((order & X_RLE) ? 1 + 257*3+4: 0) + 5;
+        ? 1.05*size + 257*3 + 4
+        : 1.05*size + 257*257*3 + 4 + 257*3+4) +
+        ((order & X_PACK) ? 1 : 0) +
+        ((order & X_RLE) ? 1 + 257*3+4: 0) + 5;
 }
 
 #ifndef MODEL_256 // see fqzcomp_qual_fuzz.c
@@ -93,20 +93,20 @@ unsigned int arith_compress_bound(unsigned int size, int order) {
 // the caller to store this.
 static
 unsigned char *arith_compress_O0(unsigned char *in, unsigned int in_size,
-				 unsigned char *out, unsigned int *out_size) {
+                                 unsigned char *out, unsigned int *out_size) {
     int i, bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     unsigned int m = 0;
     for (i = 0; i < in_size; i++)
-	if (m < in[i])
-	    m = in[i];
+        if (m < in[i])
+            m = in[i];
     m++;
     *out = m;
 
@@ -118,7 +118,7 @@ unsigned char *arith_compress_O0(unsigned char *in, unsigned int in_size,
     RC_StartEncode(&rc);
 
     for (i = 0; i < in_size; i++)
-	SIMPLE_MODEL(256, _encodeSymbol)(&byte_model, &rc, in[i]);
+        SIMPLE_MODEL(256, _encodeSymbol)(&byte_model, &rc, in[i]);
 
     RC_FinishEncode(&rc);
 
@@ -130,7 +130,7 @@ unsigned char *arith_compress_O0(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *arith_uncompress_O0(unsigned char *in, unsigned int in_size,
-				   unsigned char *out, unsigned int out_sz) {
+                                   unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
     int i;
     unsigned int m = in[0] ? in[0] : 256;
@@ -139,15 +139,15 @@ unsigned char *arith_uncompress_O0(unsigned char *in, unsigned int in_size,
     SIMPLE_MODEL(256,_init)(&byte_model, m);
 
     if (!out)
-	out = malloc(out_sz);
+        out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     RC_SetInput(&rc, (char *)in+1, (char *)in+in_size);
     RC_StartDecode(&rc);
 
     for (i = 0; i < out_sz; i++)
-	out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model, &rc);
+        out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model, &rc);
 
     RC_FinishDecode(&rc);
     
@@ -158,34 +158,34 @@ unsigned char *arith_uncompress_O0(unsigned char *in, unsigned int in_size,
 //-----------------------------------------------------------------------------
 static
 unsigned char *arith_compress_O1(unsigned char *in, unsigned int in_size,
-				 unsigned char *out, unsigned int *out_size) {
+                                 unsigned char *out, unsigned int *out_size) {
     int i, bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
     unsigned char *out_free = NULL;
 
     if (!out) {
-	*out_size = bound;
-	out_free = out = malloc(*out_size);
+        *out_size = bound;
+        out_free = out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     SIMPLE_MODEL(256,_) *byte_model =
-	htscodecs_tls_alloc(256 * sizeof(*byte_model));
+        htscodecs_tls_alloc(256 * sizeof(*byte_model));
     if (!byte_model) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
     unsigned int m = 0;
     if (1 || in_size > 1000) {
-	for (i = 0; i < in_size; i++)
-	    if (m < in[i])
-		m = in[i];
-	//fprintf(stderr, "%d max %d\n", in_size, m);
-	m++;
+        for (i = 0; i < in_size; i++)
+            if (m < in[i])
+                m = in[i];
+        //fprintf(stderr, "%d max %d\n", in_size, m);
+        m++;
     }
     *out = m;
     for (i = 0; i < 256; i++)
-	SIMPLE_MODEL(256,_init)(&byte_model[i], m);
+        SIMPLE_MODEL(256,_init)(&byte_model[i], m);
 
     RangeCoder rc;
     RC_SetOutput(&rc, (char *)out+1);
@@ -193,8 +193,8 @@ unsigned char *arith_compress_O1(unsigned char *in, unsigned int in_size,
 
     uint8_t last = 0;
     for (i = 0; i < in_size; i++) {
-	SIMPLE_MODEL(256, _encodeSymbol)(&byte_model[last], &rc, in[i]);
-	last = in[i];
+        SIMPLE_MODEL(256, _encodeSymbol)(&byte_model[last], &rc, in[i]);
+        last = in[i];
     }
 
     RC_FinishEncode(&rc);
@@ -208,34 +208,34 @@ unsigned char *arith_compress_O1(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *arith_uncompress_O1(unsigned char *in, unsigned int in_size,
-				   unsigned char *out, unsigned int out_sz) {
+                                   unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
     unsigned char *out_free = NULL;
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
 
     SIMPLE_MODEL(256,_) *byte_model =
-	htscodecs_tls_alloc(256 * sizeof(*byte_model));
+        htscodecs_tls_alloc(256 * sizeof(*byte_model));
     if (!byte_model) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     unsigned int m = in[0] ? in[0] : 256, i;
     for (i = 0; i < 256; i++)
-	SIMPLE_MODEL(256,_init)(&byte_model[i], m);
+        SIMPLE_MODEL(256,_init)(&byte_model[i], m);
 
     RC_SetInput(&rc, (char *)in+1, (char *)in+in_size);
     RC_StartDecode(&rc);
 
     unsigned char last = 0;
     for (i = 0; i < out_sz; i++) {
-	out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model[last], &rc);
-	last = out[i];
+        out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model[last], &rc);
+        last = out[i];
     }
 
     RC_FinishDecode(&rc);
@@ -251,34 +251,34 @@ unsigned char *arith_uncompress_O1(unsigned char *in, unsigned int in_size,
 
 #if 0
 unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
-				 unsigned char *out, unsigned int *out_size) {
+                                 unsigned char *out, unsigned int *out_size) {
     fprintf(stderr, "WARNING: using undocumented O2 arith\n");
 
     int i, j;
     int bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     unsigned int m = 0;
     if (1 || in_size > 1000) {
-	for (i = 0; i < in_size; i++)
-	    if (m < in[i])
-		m = in[i];
-	//fprintf(stderr, "%d max %d\n", in_size, m);
-	m++;
+        for (i = 0; i < in_size; i++)
+            if (m < in[i])
+                m = in[i];
+        //fprintf(stderr, "%d max %d\n", in_size, m);
+        m++;
     }
     *out = m;
 
     SIMPLE_MODEL(256,_) *byte_model;
     byte_model = malloc(256*256*sizeof(*byte_model));
     for (i = 0; i < 256; i++)
-	for (j = 0; j < 256; j++)
-	    SIMPLE_MODEL(256,_init)(&byte_model[i*256+j], m);
+        for (j = 0; j < 256; j++)
+            SIMPLE_MODEL(256,_init)(&byte_model[i*256+j], m);
 
     RangeCoder rc;
     RC_SetOutput(&rc, (char *)out+1);
@@ -286,9 +286,9 @@ unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
 
     unsigned char last1 = 0, last2 = 0;
     for (i = 0; i < in_size; i++) {
-	SIMPLE_MODEL(256, _encodeSymbol)(&byte_model[last1*256 + last2], &rc, in[i]);
-	last2 = last1;
-	last1 = in[i];
+        SIMPLE_MODEL(256, _encodeSymbol)(&byte_model[last1*256 + last2], &rc, in[i]);
+        last2 = last1;
+        last1 = in[i];
     }
 
     free(byte_model);
@@ -301,37 +301,37 @@ unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
 }
 #else
 unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
-				 unsigned char *out, unsigned int *out_size) {
+                                 unsigned char *out, unsigned int *out_size) {
     fprintf(stderr, "WARNING: using undocumented O2 arith\n");
 
     int i, j;
     int bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     unsigned int m = 0;
     if (1 || in_size > 1000) {
-	for (i = 0; i < in_size; i++)
-	    if (m < in[i])
-		m = in[i];
-	//fprintf(stderr, "%d max %d\n", in_size, m);
-	m++;
+        for (i = 0; i < in_size; i++)
+            if (m < in[i])
+                m = in[i];
+        //fprintf(stderr, "%d max %d\n", in_size, m);
+        m++;
     }
     *out = m;
 
     SIMPLE_MODEL(256,_) *byte_model;
     byte_model = malloc(256*256*sizeof(*byte_model));
     for (i = 0; i < 256; i++)
-	for (j = 0; j < 256; j++)
-	    SIMPLE_MODEL(256,_init)(&byte_model[i*256+j], m);
+        for (j = 0; j < 256; j++)
+            SIMPLE_MODEL(256,_init)(&byte_model[i*256+j], m);
     SIMPLE_MODEL(256,_) byte_model1[256];
     for (i = 0; i < 256; i++)
-	SIMPLE_MODEL(256,_init)(&byte_model1[i], m);
+        SIMPLE_MODEL(256,_init)(&byte_model1[i], m);
 
     RangeCoder rc;
     RC_SetOutput(&rc, (char *)out+1);
@@ -339,16 +339,16 @@ unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
 
     unsigned char last1 = 0, last2 = 0;
     for (i = 0; i < in_size; i++) {
-	// Use Order-1 is order-2 isn't sufficiently advanced yet (75+ symbols)
-	if (byte_model[last1*256+last2].TotFreq <= m+75*16) {
-	    SIMPLE_MODEL(256, _encodeSymbol)(&byte_model1[last1], &rc, in[i]);
-	    SIMPLE_MODEL(256, _updateSymbol)(&byte_model[last1*256 + last2], &rc, in[i]);
-	} else {
-	    SIMPLE_MODEL(256, _encodeSymbol)(&byte_model[last1*256 + last2], &rc, in[i]);
-	    //SIMPLE_MODEL(256, _updateSymbol)(&byte_model1[last1], &rc, in[i]);
-	}
-	last2 = last1;
-	last1 = in[i];
+        // Use Order-1 is order-2 isn't sufficiently advanced yet (75+ symbols)
+        if (byte_model[last1*256+last2].TotFreq <= m+75*16) {
+            SIMPLE_MODEL(256, _encodeSymbol)(&byte_model1[last1], &rc, in[i]);
+            SIMPLE_MODEL(256, _updateSymbol)(&byte_model[last1*256 + last2], &rc, in[i]);
+        } else {
+            SIMPLE_MODEL(256, _encodeSymbol)(&byte_model[last1*256 + last2], &rc, in[i]);
+            //SIMPLE_MODEL(256, _updateSymbol)(&byte_model1[last1], &rc, in[i]);
+        }
+        last2 = last1;
+        last1 = in[i];
     }
 
     free(byte_model);
@@ -362,29 +362,29 @@ unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
 #endif
 
 unsigned char *arith_uncompress_O2(unsigned char *in, unsigned int in_size,
-				   unsigned char *out, unsigned int out_sz) {
+                                   unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
 
     SIMPLE_MODEL(256,_) *byte_model;
     byte_model = malloc(256*256*sizeof(*byte_model));
     unsigned int m = in[0] ? in[0] : 256, i, j;
     for (i = 0; i < 256; i++)
-	for (j = 0; j < 256; j++)
-	    SIMPLE_MODEL(256,_init)(&byte_model[i*256+j], m);
+        for (j = 0; j < 256; j++)
+            SIMPLE_MODEL(256,_init)(&byte_model[i*256+j], m);
     
     if (!out)
-	out = malloc(out_sz);
+        out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     RC_SetInput(&rc, (char *)in+1, (char *)in+in_size);
     RC_StartDecode(&rc);
 
     unsigned char last1 = 0, last2 = 0;
     for (i = 0; i < out_sz; i++) {
-	out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model[last1*256 + last2], &rc);
-	last2 = last1;
-	last1 = out[i];
+        out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model[last1*256 + last2], &rc);
+        last2 = last1;
+        last1 = out[i];
     }
 
     free(byte_model);
@@ -404,21 +404,21 @@ unsigned char *arith_uncompress_O2(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *arith_compress_O0_RLE(unsigned char *in, unsigned int in_size,
-				     unsigned char *out, unsigned int *out_size) {
+                                     unsigned char *out, unsigned int *out_size) {
     int i, bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
     unsigned char *out_free = NULL;
 
     if (!out) {
-	*out_size = bound;
-	out_free = out = malloc(*out_size);
+        *out_size = bound;
+        out_free = out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     unsigned int m = 0;
     for (i = 0; i < in_size; i++)
-	if (m < in[i])
-	    m = in[i];
+        if (m < in[i])
+            m = in[i];
     m++;
     *out = m;
 
@@ -426,14 +426,14 @@ unsigned char *arith_compress_O0_RLE(unsigned char *in, unsigned int in_size,
     SIMPLE_MODEL(256,_init)(&byte_model, m);
 
     SIMPLE_MODEL(NSYM,_) *run_model =
-	htscodecs_tls_alloc(NSYM * sizeof(*run_model));
+        htscodecs_tls_alloc(NSYM * sizeof(*run_model));
     if (!run_model) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     for (i = 0; i < NSYM; i++)
-	SIMPLE_MODEL(NSYM,_init)(&run_model[i], MAX_RUN);
+        SIMPLE_MODEL(NSYM,_init)(&run_model[i], MAX_RUN);
 
     RangeCoder rc;
     RC_SetOutput(&rc, (char *)out+1);
@@ -441,26 +441,26 @@ unsigned char *arith_compress_O0_RLE(unsigned char *in, unsigned int in_size,
 
     unsigned char last = 0;
     for (i = 0; i < in_size;) {
-	//SIMPLE_MODEL(256, _encodeSymbol)(&byte_model, &rc, in[i]);
-	SIMPLE_MODEL(256, _encodeSymbol)(&byte_model, &rc, in[i]);
-	//fprintf(stderr, "lit %c (ctx %c)\n", in[i], last);
-	int run = 0;
-	last = in[i++];
-	while (i < in_size && in[i] == last/* && run < MAX_RUN-1*/)
-	    run++, i++;
-	int rctx = last;
-	do {
-	    int c = run < MAX_RUN ? run : MAX_RUN-1;
-	    SIMPLE_MODEL(NSYM, _encodeSymbol)(&run_model[rctx], &rc, c);
-	    run -= c;
+        //SIMPLE_MODEL(256, _encodeSymbol)(&byte_model, &rc, in[i]);
+        SIMPLE_MODEL(256, _encodeSymbol)(&byte_model, &rc, in[i]);
+        //fprintf(stderr, "lit %c (ctx %c)\n", in[i], last);
+        int run = 0;
+        last = in[i++];
+        while (i < in_size && in[i] == last/* && run < MAX_RUN-1*/)
+            run++, i++;
+        int rctx = last;
+        do {
+            int c = run < MAX_RUN ? run : MAX_RUN-1;
+            SIMPLE_MODEL(NSYM, _encodeSymbol)(&run_model[rctx], &rc, c);
+            run -= c;
 
-	    if (rctx == last)
-		rctx = 256;
-	    else
-		rctx += (rctx < NSYM-1);
-	    if (c == MAX_RUN-1 && run == 0)
-		SIMPLE_MODEL(NSYM, _encodeSymbol)(&run_model[rctx], &rc, 0);
-	} while (run);
+            if (rctx == last)
+                rctx = 256;
+            else
+                rctx += (rctx < NSYM-1);
+            if (c == MAX_RUN-1 && run == 0)
+                SIMPLE_MODEL(NSYM, _encodeSymbol)(&run_model[rctx], &rc, 0);
+        } while (run);
     }
 
     RC_FinishEncode(&rc);
@@ -476,49 +476,49 @@ unsigned char *arith_compress_O0_RLE(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *arith_uncompress_O0_RLE(unsigned char *in, unsigned int in_size,
-				       unsigned char *out, unsigned int out_sz) {
+                                       unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
     int i;
     unsigned int m = in[0] ? in[0] : 256;
     unsigned char *out_free = NULL;
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     SIMPLE_MODEL(256,_) byte_model;
     SIMPLE_MODEL(256,_init)(&byte_model, m);
 
     SIMPLE_MODEL(NSYM,_) *run_model =
-	htscodecs_tls_alloc(NSYM * sizeof(*run_model));
+        htscodecs_tls_alloc(NSYM * sizeof(*run_model));
     if (!run_model) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     for (i = 0; i < NSYM; i++)
-	SIMPLE_MODEL(NSYM,_init)(&run_model[i], MAX_RUN);
+        SIMPLE_MODEL(NSYM,_init)(&run_model[i], MAX_RUN);
 
     RC_SetInput(&rc, (char *)in+1, (char *)in+in_size);
     RC_StartDecode(&rc);
 
     for (i = 0; i < out_sz; i++) {
-	unsigned char last;
-	last = out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model, &rc);
-	//fprintf(stderr, "lit %c\n", last);
-	int run = 0, r = 0, rctx = out[i];
-	do {
-	    r = SIMPLE_MODEL(NSYM, _decodeSymbol)(&run_model[rctx], &rc);
-	    if (rctx == last)
-		rctx = 256;
-	    else
-		rctx += (rctx < NSYM-1);
-	    //fprintf(stderr, "run %d (ctx %d, %d)\n", r, last, l);
-	    run += r;
-	} while (r == MAX_RUN-1 && run < out_sz);
-	while (run-- && i+1 < out_sz)
-	    out[++i] = last;
+        unsigned char last;
+        last = out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model, &rc);
+        //fprintf(stderr, "lit %c\n", last);
+        int run = 0, r = 0, rctx = out[i];
+        do {
+            r = SIMPLE_MODEL(NSYM, _decodeSymbol)(&run_model[rctx], &rc);
+            if (rctx == last)
+                rctx = 256;
+            else
+                rctx += (rctx < NSYM-1);
+            //fprintf(stderr, "run %d (ctx %d, %d)\n", r, last, l);
+            run += r;
+        } while (r == MAX_RUN-1 && run < out_sz);
+        while (run-- && i+1 < out_sz)
+            out[++i] = last;
     }
 
     RC_FinishDecode(&rc);
@@ -529,42 +529,42 @@ unsigned char *arith_uncompress_O0_RLE(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *arith_compress_O1_RLE(unsigned char *in, unsigned int in_size,
-				     unsigned char *out, unsigned int *out_size) {
+                                     unsigned char *out, unsigned int *out_size) {
     int i, bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
     unsigned char *out_free = NULL;
 
     if (!out) {
-	*out_size = bound;
-	out_free = out = malloc(*out_size);
+        *out_size = bound;
+        out_free = out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     unsigned int m = 0;
     for (i = 0; i < in_size; i++)
-	if (m < in[i])
-	    m = in[i];
+        if (m < in[i])
+            m = in[i];
     m++;
     *out = m;
 
     SIMPLE_MODEL(256,_) *byte_model =
-	htscodecs_tls_alloc(256 * sizeof(*byte_model));
+        htscodecs_tls_alloc(256 * sizeof(*byte_model));
     if (!byte_model) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
     for (i = 0; i < 256; i++)
-	SIMPLE_MODEL(256,_init)(&byte_model[i], m);
+        SIMPLE_MODEL(256,_init)(&byte_model[i], m);
 
     SIMPLE_MODEL(NSYM,_) *run_model =
-	htscodecs_tls_alloc(NSYM * sizeof(*run_model));
+        htscodecs_tls_alloc(NSYM * sizeof(*run_model));
     if (!run_model) {
-	htscodecs_tls_free(byte_model);
-	free(out_free);
-	return NULL;
+        htscodecs_tls_free(byte_model);
+        free(out_free);
+        return NULL;
     }
     for (i = 0; i < NSYM; i++)
-	SIMPLE_MODEL(NSYM,_init)(&run_model[i], MAX_RUN);
+        SIMPLE_MODEL(NSYM,_init)(&run_model[i], MAX_RUN);
 
     RangeCoder rc;
     RC_SetOutput(&rc, (char *)out+1);
@@ -572,26 +572,26 @@ unsigned char *arith_compress_O1_RLE(unsigned char *in, unsigned int in_size,
 
     unsigned char last = 0;
     for (i = 0; i < in_size;) {
-	//SIMPLE_MODEL(256, _encodeSymbol)(&byte_model, &rc, in[i]);
-	SIMPLE_MODEL(256, _encodeSymbol)(&byte_model[last], &rc, in[i]);
-	//fprintf(stderr, "lit %c (ctx %c)\n", in[i], last);
-	int run = 0;
-	last = in[i++];
-	while (i < in_size && in[i] == last/* && run < MAX_RUN-1*/)
-	    run++, i++;
-	int rctx = last;
-	do {
-	    int c = run < MAX_RUN ? run : MAX_RUN-1;
-	    SIMPLE_MODEL(NSYM, _encodeSymbol)(&run_model[rctx], &rc, c);
-	    run -= c;
+        //SIMPLE_MODEL(256, _encodeSymbol)(&byte_model, &rc, in[i]);
+        SIMPLE_MODEL(256, _encodeSymbol)(&byte_model[last], &rc, in[i]);
+        //fprintf(stderr, "lit %c (ctx %c)\n", in[i], last);
+        int run = 0;
+        last = in[i++];
+        while (i < in_size && in[i] == last/* && run < MAX_RUN-1*/)
+            run++, i++;
+        int rctx = last;
+        do {
+            int c = run < MAX_RUN ? run : MAX_RUN-1;
+            SIMPLE_MODEL(NSYM, _encodeSymbol)(&run_model[rctx], &rc, c);
+            run -= c;
 
-	    if (rctx == last)
-		rctx = 256;
-	    else
-		rctx += (rctx < NSYM-1);
-	    if (c == MAX_RUN-1 && run == 0)
-		SIMPLE_MODEL(NSYM, _encodeSymbol)(&run_model[rctx], &rc, 0);
-	} while (run);
+            if (rctx == last)
+                rctx = 256;
+            else
+                rctx += (rctx < NSYM-1);
+            if (c == MAX_RUN-1 && run == 0)
+                SIMPLE_MODEL(NSYM, _encodeSymbol)(&run_model[rctx], &rc, 0);
+        } while (run);
     }
 
     RC_FinishEncode(&rc);
@@ -608,56 +608,56 @@ unsigned char *arith_compress_O1_RLE(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *arith_uncompress_O1_RLE(unsigned char *in, unsigned int in_size,
-				       unsigned char *out, unsigned int out_sz) {
+                                       unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
     int i;
     unsigned int m = in[0] ? in[0] : 256;
     unsigned char *out_free = NULL;
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     SIMPLE_MODEL(256,_) *byte_model =
-	htscodecs_tls_alloc(256 * sizeof(*byte_model));
+        htscodecs_tls_alloc(256 * sizeof(*byte_model));
     if (!byte_model) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
     for (i = 0; i < 256; i++)
-	SIMPLE_MODEL(256,_init)(&byte_model[i], m);
+        SIMPLE_MODEL(256,_init)(&byte_model[i], m);
 
     SIMPLE_MODEL(NSYM,_) *run_model =
-	htscodecs_tls_alloc(NSYM * sizeof(*run_model));
+        htscodecs_tls_alloc(NSYM * sizeof(*run_model));
     if (!run_model) {
-	htscodecs_tls_free(byte_model);
-	free(out_free);
-	return NULL;
+        htscodecs_tls_free(byte_model);
+        free(out_free);
+        return NULL;
     }
     for (i = 0; i < NSYM; i++)
-	SIMPLE_MODEL(NSYM,_init)(&run_model[i], MAX_RUN);
+        SIMPLE_MODEL(NSYM,_init)(&run_model[i], MAX_RUN);
 
     RC_SetInput(&rc, (char *)in+1, (char *)in+in_size);
     RC_StartDecode(&rc);
 
     unsigned char last = 0;
     for (i = 0; i < out_sz; i++) {
-	out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model[last], &rc);
-	//fprintf(stderr, "lit %c (ctx %c)\n", out[i], last);
-	last = out[i];
-	int run = 0, r = 0, rctx = last;
+        out[i] = SIMPLE_MODEL(256, _decodeSymbol)(&byte_model[last], &rc);
+        //fprintf(stderr, "lit %c (ctx %c)\n", out[i], last);
+        last = out[i];
+        int run = 0, r = 0, rctx = last;
 
-	do {
-	    r = SIMPLE_MODEL(NSYM, _decodeSymbol)(&run_model[rctx], &rc);
-	    if (rctx == last)
-		rctx = 256;
-	    else
-		rctx += (rctx < NSYM-1);
-	    run += r;
-	} while (r == MAX_RUN-1 && run < out_sz);
-	while (run-- && i+1 < out_sz)
-	    out[++i] = last;
+        do {
+            r = SIMPLE_MODEL(NSYM, _decodeSymbol)(&run_model[rctx], &rc);
+            if (rctx == last)
+                rctx = 256;
+            else
+                rctx += (rctx < NSYM-1);
+            run += r;
+        } while (r == MAX_RUN-1 && run < out_sz);
+        while (run-- && i+1 < out_sz)
+            out[++i] = last;
     }
 
     RC_FinishDecode(&rc);
@@ -673,142 +673,142 @@ unsigned char *arith_uncompress_O1_RLE(unsigned char *in, unsigned int in_size,
  * Smallest is method, <in_size> <input>, so worst case 2 bytes longer.
  */
 unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
-				 unsigned char *out, unsigned int *out_size,
-				 int order) {
+                                 unsigned char *out, unsigned int *out_size,
+                                 int order) {
     unsigned int c_meta_len;
     uint8_t *rle = NULL, *packed = NULL;
 
     if (!out) {
-	*out_size = arith_compress_bound(in_size, order);
-	if (!(out = malloc(*out_size)))
-	    return NULL;
+        *out_size = arith_compress_bound(in_size, order);
+        if (!(out = malloc(*out_size)))
+            return NULL;
     }
     unsigned char *out_end = out + *out_size;
 
     if (in_size <= 20)
-	order &= ~X_STRIPE;
+        order &= ~X_STRIPE;
 
     if (order & X_CAT) {
-	out[0] = X_CAT;
-	c_meta_len = 1 + var_put_u32(&out[1], out_end, in_size);
-	memcpy(out+c_meta_len, in, in_size);
-	*out_size = in_size+c_meta_len;
+        out[0] = X_CAT;
+        c_meta_len = 1 + var_put_u32(&out[1], out_end, in_size);
+        memcpy(out+c_meta_len, in, in_size);
+        *out_size = in_size+c_meta_len;
     }
 
     if (order & X_STRIPE) {
-	int N = (order>>8);
-	if (N == 0) N = 4; // default for compatibility with old tests
+        int N = (order>>8);
+        if (N == 0) N = 4; // default for compatibility with old tests
 
-	if (N > 255)
-	    return NULL;
+        if (N > 255)
+            return NULL;
 
-	unsigned char *transposed = malloc(in_size);
-	unsigned int part_len[256];
-	unsigned int idx[256];
-	if (!transposed)
-	    return NULL;
-	int i, j, x;
+        unsigned char *transposed = malloc(in_size);
+        unsigned int part_len[256];
+        unsigned int idx[256];
+        if (!transposed)
+            return NULL;
+        int i, j, x;
 
-	for (i = 0; i < N; i++) {
-	    part_len[i] = in_size / N + ((in_size % N) > i);
-	    idx[i] = i ? idx[i-1] + part_len[i-1] : 0; // cumulative index
-	}
-
-	for (i = x = 0; i < in_size-N; i += N, x++) {
-	    for (j = 0; j < N; j++)
-		transposed[idx[j]+x] = in[i+j];
-	}
-	for (; i < in_size; i += N, x++) {
-	    for (j = 0; i+j < in_size; j++)
-		transposed[idx[j]+x] = in[i+j];
-	}
-
-	unsigned int olen2;
-	unsigned char *out2, *out2_start;
-	c_meta_len = 1;
-	*out = order & ~X_NOSZ;
-	c_meta_len += var_put_u32(out+c_meta_len, out_end, in_size);
-	out[c_meta_len++] = N;
-
-	out2_start = out2 = out+2+5*N; // shares a buffer with c_meta
         for (i = 0; i < N; i++) {
-	    // Brute force try all methods.
-	    // FIXME: optimise this bit.  Maybe learn over time?
-	    int j, best_j = 0, best_sz = INT_MAX;
+            part_len[i] = in_size / N + ((in_size % N) > i);
+            idx[i] = i ? idx[i-1] + part_len[i-1] : 0; // cumulative index
+        }
 
-	    // Works OK with read names. The first byte is the most important,
-	    // as it has most variability (little-endian).  After that it's
-	    // often quite predictable.
-	    //
-	    // Do we gain in any other context in CRAM? Aux tags maybe?
-	    int m[][4] = {{3, 1,64,0},
-			  {2, 1,0},
-			  {2, 1,128},
-			  {2, 1,128}};
+        for (i = x = 0; i < in_size-N; i += N, x++) {
+            for (j = 0; j < N; j++)
+                transposed[idx[j]+x] = in[i+j];
+        }
+        for (; i < in_size; i += N, x++) {
+            for (j = 0; i+j < in_size; j++)
+                transposed[idx[j]+x] = in[i+j];
+        }
 
-//	    int m[][6] = {{4, 1,64,2,0},  //test of adding in an order-2 codec
-//			  {3, 1,2,0},
-//			  {3, 1,2,128},
-//			  {3, 1,2,128}};
+        unsigned int olen2;
+        unsigned char *out2, *out2_start;
+        c_meta_len = 1;
+        *out = order & ~X_NOSZ;
+        c_meta_len += var_put_u32(out+c_meta_len, out_end, in_size);
+        out[c_meta_len++] = N;
+
+        out2_start = out2 = out+2+5*N; // shares a buffer with c_meta
+        for (i = 0; i < N; i++) {
+            // Brute force try all methods.
+            // FIXME: optimise this bit.  Maybe learn over time?
+            int j, best_j = 0, best_sz = INT_MAX;
+
+            // Works OK with read names. The first byte is the most important,
+            // as it has most variability (little-endian).  After that it's
+            // often quite predictable.
+            //
+            // Do we gain in any other context in CRAM? Aux tags maybe?
+            int m[][4] = {{3, 1,64,0},
+                          {2, 1,0},
+                          {2, 1,128},
+                          {2, 1,128}};
+
+//          int m[][6] = {{4, 1,64,2,0},  //test of adding in an order-2 codec
+//                        {3, 1,2,0},
+//                        {3, 1,2,128},
+//                        {3, 1,2,128}};
 
 // Other possibilities for methods to try.
-//	    int m[][10] = {{8, 1,128,129,64,65,192,193,4,0},
-//			   {8, 1,128,129,64,65,192,193,4,0},
-//			   {8, 1,128,129,64,65,192,193,4,0},
-//			   {8, 1,128,129,64,65,192,193,4,0}};
+//          int m[][10] = {{8, 1,128,129,64,65,192,193,4,0},
+//                         {8, 1,128,129,64,65,192,193,4,0},
+//                         {8, 1,128,129,64,65,192,193,4,0},
+//                         {8, 1,128,129,64,65,192,193,4,0}};
 
-//	    int m[][9] = {{5, 1,128,64,65,0},
-//			  {5, 1,128,64,65,0},
-//			  {5, 1,128,64,65,0},
-//			  {5, 1,128,64,65,0}};
+//          int m[][9] = {{5, 1,128,64,65,0},
+//                        {5, 1,128,64,65,0},
+//                        {5, 1,128,64,65,0},
+//                        {5, 1,128,64,65,0}};
 
-//	    int m[][6] = {{4, 0,1,128,64},
-//			  {5, 0,1,128,65,193},
-//			  {3, 0,1,128},
-//			  {3, 0,1,128}};
+//          int m[][6] = {{4, 0,1,128,64},
+//                        {5, 0,1,128,65,193},
+//                        {3, 0,1,128},
+//                        {3, 0,1,128}};
 
-//	    int m[][6] = {{4, 1,128,64,0},
-//			  {4, 1,128,65,0},
-//			  {2, 128,0},
-//			  {2, 128,0}};
+//          int m[][6] = {{4, 1,128,64,0},
+//                        {4, 1,128,65,0},
+//                        {2, 128,0},
+//                        {2, 128,0}};
 
-//	    int m[][6] = {{2, 64,0},
-//			  {1, 0},
-//			  {1, 128},
-//			  {1, 128}};
+//          int m[][6] = {{2, 64,0},
+//                        {1, 0},
+//                        {1, 128},
+//                        {1, 128}};
 
-//	    int m[][6] = {{1, 0},
-//			  {2, 128,0},
-//			  {1, 128},
-//			  {1, 128}};
+//          int m[][6] = {{1, 0},
+//                        {2, 128,0},
+//                        {1, 128},
+//                        {1, 128}};
 
-	    for (j = 1; j <= m[MIN(i,3)][0]; j++) {
-		olen2 = *out_size - (out2 - out);
-		//fprintf(stderr, "order=%d m=%d\n", order&3, m[MIN(i,4)][j]);
-		if ((order&3) == 0 && (m[MIN(i,3)][j]&1))
-		    continue;
+            for (j = 1; j <= m[MIN(i,3)][0]; j++) {
+                olen2 = *out_size - (out2 - out);
+                //fprintf(stderr, "order=%d m=%d\n", order&3, m[MIN(i,4)][j]);
+                if ((order&3) == 0 && (m[MIN(i,3)][j]&1))
+                    continue;
 
                 arith_compress_to(transposed+idx[i], part_len[i],
-				  out2, &olen2, m[MIN(i,3)][j] | X_NOSZ);
-		if (best_sz > olen2) {
-		    best_sz = olen2;
-		    best_j = j;
-		}
-	    }
-//	    if (best_j == 0) // none desireable
-//		return NULL;
-	    if (best_j != j-1) {
-		olen2 = *out_size - (out2 - out);
-		arith_compress_to(transposed+idx[i], part_len[i],
-				  out2, &olen2, m[MIN(i,3)][best_j] | X_NOSZ);
-	    }
-	    out2 += olen2;
-	    c_meta_len += var_put_u32(out+c_meta_len, out_end, olen2);
-	}
-	memmove(out+c_meta_len, out2_start, out2-out2_start);
-	free(transposed);
-	*out_size = c_meta_len + out2-out2_start;
-	return out;
+                                  out2, &olen2, m[MIN(i,3)][j] | X_NOSZ);
+                if (best_sz > olen2) {
+                    best_sz = olen2;
+                    best_j = j;
+                }
+            }
+//          if (best_j == 0) // none desireable
+//              return NULL;
+            if (best_j != j-1) {
+                olen2 = *out_size - (out2 - out);
+                arith_compress_to(transposed+idx[i], part_len[i],
+                                  out2, &olen2, m[MIN(i,3)][best_j] | X_NOSZ);
+            }
+            out2 += olen2;
+            c_meta_len += var_put_u32(out+c_meta_len, out_end, olen2);
+        }
+        memmove(out+c_meta_len, out2_start, out2-out2_start);
+        free(transposed);
+        *out_size = c_meta_len + out2-out2_start;
+        return out;
     }
 
     int do_pack = order & X_PACK;
@@ -820,7 +820,7 @@ unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
     c_meta_len = 1;
 
     if (!no_size)
-	c_meta_len += var_put_u32(&out[1], out_end, in_size);
+        c_meta_len += var_put_u32(&out[1], out_end, in_size);
 
     order &= 0x3;
 
@@ -830,82 +830,82 @@ unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
     // packed + rle literals.
 
     if (do_pack && in_size) {
-	// PACK 2, 4 or 8 symbols into one byte.
-	int pmeta_len;
-	uint64_t packed_len;
-	packed = hts_pack(in, in_size, out+c_meta_len, &pmeta_len, &packed_len);
-	if (!packed || (pmeta_len == 1 && out[c_meta_len] > 16)) {
-	    out[0] &= ~X_PACK;
-	    do_pack = 0;
-	    free(packed);
-	    packed = NULL;
-	} else {
-	    in = packed;
-	    in_size = packed_len;
-	    c_meta_len += pmeta_len;
+        // PACK 2, 4 or 8 symbols into one byte.
+        int pmeta_len;
+        uint64_t packed_len;
+        packed = hts_pack(in, in_size, out+c_meta_len, &pmeta_len, &packed_len);
+        if (!packed || (pmeta_len == 1 && out[c_meta_len] > 16)) {
+            out[0] &= ~X_PACK;
+            do_pack = 0;
+            free(packed);
+            packed = NULL;
+        } else {
+            in = packed;
+            in_size = packed_len;
+            c_meta_len += pmeta_len;
 
-	    // Could derive this rather than storing verbatim.
-	    // Orig size * 8/nbits (+1 if not multiple of 8/n)
-	    int sz = var_put_u32(out+c_meta_len, out_end, in_size);
-	    c_meta_len += sz;
-	    *out_size -= sz;
-	}
+            // Could derive this rather than storing verbatim.
+            // Orig size * 8/nbits (+1 if not multiple of 8/n)
+            int sz = var_put_u32(out+c_meta_len, out_end, in_size);
+            c_meta_len += sz;
+            *out_size -= sz;
+        }
     } else if (do_pack) {
-	out[0] &= ~X_PACK;
+        out[0] &= ~X_PACK;
     }
 
     if (do_rle && !in_size) {
-	out[0] &= ~X_RLE;
+        out[0] &= ~X_RLE;
     }
 
     *out_size -= c_meta_len;
     if (order && in_size < 8) {
-	out[0] &= ~3;
-	order  &= ~3;
+        out[0] &= ~3;
+        order  &= ~3;
     }
 
     if (do_ext) {
-	// Use an external compression library instead.
-	// For now, bzip2
+        // Use an external compression library instead.
+        // For now, bzip2
 #ifdef HAVE_LIBBZ2
-	if (BZ_OK != BZ2_bzBuffToBuffCompress((char *)out+c_meta_len, out_size,
-					      (char *)in, in_size, 9, 0, 30))
-	    *out_size = in_size; // Didn't fit with bz2; force X_CAT below instead
+        if (BZ_OK != BZ2_bzBuffToBuffCompress((char *)out+c_meta_len, out_size,
+                                              (char *)in, in_size, 9, 0, 30))
+            *out_size = in_size; // Didn't fit with bz2; force X_CAT below instead
 #else
-	fprintf(stderr, "Htscodecs has been compiled without libbz2 support\n");
-	free(out);
-	return NULL;
+        fprintf(stderr, "Htscodecs has been compiled without libbz2 support\n");
+        free(out);
+        return NULL;
 #endif
 
 //      // lzma doesn't help generally, at least not for the name tokeniser
-//	size_t lzma_size = 0;
-//	lzma_easy_buffer_encode(9, LZMA_CHECK_CRC32, NULL,
-//				in, in_size, out+c_meta_len, &lzma_size,
-//				*out_size);
-//	*out_size = lzma_size;
+//      size_t lzma_size = 0;
+//      lzma_easy_buffer_encode(9, LZMA_CHECK_CRC32, NULL,
+//                              in, in_size, out+c_meta_len, &lzma_size,
+//                              *out_size);
+//      *out_size = lzma_size;
 
     } else {
-	if (do_rle) {
-	    if (order == 0)
-		arith_compress_O0_RLE(in, in_size, out+c_meta_len, out_size);
-	    else
-		arith_compress_O1_RLE(in, in_size, out+c_meta_len, out_size);
-	} else {
-	    //if (order == 2)
-	    //	arith_compress_O2(in, in_size, out+c_meta_len, out_size);
-	    //else
-	    if (order == 1)
-		arith_compress_O1(in, in_size, out+c_meta_len, out_size);
-	    else
-		arith_compress_O0(in, in_size, out+c_meta_len, out_size);
-	}
+        if (do_rle) {
+            if (order == 0)
+                arith_compress_O0_RLE(in, in_size, out+c_meta_len, out_size);
+            else
+                arith_compress_O1_RLE(in, in_size, out+c_meta_len, out_size);
+        } else {
+            //if (order == 2)
+            //  arith_compress_O2(in, in_size, out+c_meta_len, out_size);
+            //else
+            if (order == 1)
+                arith_compress_O1(in, in_size, out+c_meta_len, out_size);
+            else
+                arith_compress_O0(in, in_size, out+c_meta_len, out_size);
+        }
     }
 
     if (*out_size >= in_size) {
-	out[0] &= ~(3|X_EXT); // no entropy encoding, but keep e.g. PACK
-	out[0] |= X_CAT | no_size;
-	memcpy(out+c_meta_len, in, in_size);
-	*out_size = in_size;
+        out[0] &= ~(3|X_EXT); // no entropy encoding, but keep e.g. PACK
+        out[0] |= X_CAT | no_size;
+        memcpy(out+c_meta_len, in, in_size);
+        *out_size = in_size;
     }
 
     free(rle);
@@ -917,94 +917,94 @@ unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
 }
 
 unsigned char *arith_compress(unsigned char *in, unsigned int in_size,
-			      unsigned int *out_size, int order) {
+                              unsigned int *out_size, int order) {
     return arith_compress_to(in, in_size, NULL, out_size, order);
 }
 
 unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
-				   unsigned char *out, unsigned int *out_size) {
+                                   unsigned char *out, unsigned int *out_size) {
     unsigned char *in_end = in + in_size;
     unsigned char *out_free = NULL;
     unsigned char *tmp_free = NULL;
 
     if (in_size == 0)
-	return NULL;
+        return NULL;
 
     if (*in & X_STRIPE) {
-	unsigned int ulen, olen, c_meta_len = 1;
-	int i;
-	uint64_t clen_tot = 0;
+        unsigned int ulen, olen, c_meta_len = 1;
+        int i;
+        uint64_t clen_tot = 0;
 
-	// Decode lengths
-	c_meta_len += var_get_u32(in+c_meta_len, in_end, &ulen);
-	if (c_meta_len >= in_size)
-	    return NULL;
-	unsigned int N = in[c_meta_len++];
+        // Decode lengths
+        c_meta_len += var_get_u32(in+c_meta_len, in_end, &ulen);
+        if (c_meta_len >= in_size)
+            return NULL;
+        unsigned int N = in[c_meta_len++];
         if (N < 1)  // Must be at least one stripe
             return NULL;
-	unsigned int clenN[256], ulenN[256], idxN[256];
-	if (!out) {
-	    if (ulen >= INT_MAX)
-		return NULL;
-	    if (!(out_free = out = malloc(ulen))) {
-		return NULL;
-	    }
-	    *out_size = ulen;
-	}
-	if (ulen != *out_size) {
-	    free(out_free);
-	    return NULL;
-	}
+        unsigned int clenN[256], ulenN[256], idxN[256];
+        if (!out) {
+            if (ulen >= INT_MAX)
+                return NULL;
+            if (!(out_free = out = malloc(ulen))) {
+                return NULL;
+            }
+            *out_size = ulen;
+        }
+        if (ulen != *out_size) {
+            free(out_free);
+            return NULL;
+        }
 
-	for (i = 0; i < N; i++) {
-	    ulenN[i] = ulen / N + ((ulen % N) > i);
-	    idxN[i] = i ? idxN[i-1] + ulenN[i-1] : 0;
-	    c_meta_len += var_get_u32(in+c_meta_len, in_end, &clenN[i]);
-	    clen_tot += clenN[i];
-	    if (c_meta_len > in_size || clenN[i] > in_size || clenN[i] < 1) {
-		free(out_free);
-		return NULL;
-	    }
-	}
+        for (i = 0; i < N; i++) {
+            ulenN[i] = ulen / N + ((ulen % N) > i);
+            idxN[i] = i ? idxN[i-1] + ulenN[i-1] : 0;
+            c_meta_len += var_get_u32(in+c_meta_len, in_end, &clenN[i]);
+            clen_tot += clenN[i];
+            if (c_meta_len > in_size || clenN[i] > in_size || clenN[i] < 1) {
+                free(out_free);
+                return NULL;
+            }
+        }
 
-	// We can call this with a larger buffer, but once we've determined
-	// how much we really use we limit it so the recursion becomes easier
-	// to limit.
-	if (c_meta_len + clen_tot > in_size) {
-	    free(out_free);
-	    return NULL;
-	}
-	in_size = c_meta_len + clen_tot;
+        // We can call this with a larger buffer, but once we've determined
+        // how much we really use we limit it so the recursion becomes easier
+        // to limit.
+        if (c_meta_len + clen_tot > in_size) {
+            free(out_free);
+            return NULL;
+        }
+        in_size = c_meta_len + clen_tot;
 
-	//fprintf(stderr, "    stripe meta %d\n", c_meta_len); //c-size
+        //fprintf(stderr, "    stripe meta %d\n", c_meta_len); //c-size
 
-	// Uncompress the N streams
-	unsigned char *outN = malloc(ulen);
-	if (!outN) {
-	    free(out_free);
-	    return NULL;
-	}
-	for (i = 0; i < N; i++) {
-	    olen = ulenN[i];
-	    if (in_size < c_meta_len) {
-		free(out_free);
-		free(outN);
-		return NULL;
-	    }
-	    if (!arith_uncompress_to(in+c_meta_len, in_size-c_meta_len, outN + idxN[i], &olen)
-		|| olen != ulenN[i]) {
-		free(out_free);
-		free(outN);
-		return NULL;
-	    }
-	    c_meta_len += clenN[i];
-	}
+        // Uncompress the N streams
+        unsigned char *outN = malloc(ulen);
+        if (!outN) {
+            free(out_free);
+            return NULL;
+        }
+        for (i = 0; i < N; i++) {
+            olen = ulenN[i];
+            if (in_size < c_meta_len) {
+                free(out_free);
+                free(outN);
+                return NULL;
+            }
+            if (!arith_uncompress_to(in+c_meta_len, in_size-c_meta_len, outN + idxN[i], &olen)
+                || olen != ulenN[i]) {
+                free(out_free);
+                free(outN);
+                return NULL;
+            }
+            c_meta_len += clenN[i];
+        }
 
-	unstripe(out, outN, ulen, N, idxN);
+        unstripe(out, outN, ulen, N, idxN);
 
-	free(outN);
-	*out_size = ulen;
-	return out;
+        free(outN);
+        *out_size = ulen;
+        return out;
     }
 
     int order = *in++;  in_size--;
@@ -1018,32 +1018,32 @@ unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
     int sz = 0;
     unsigned int osz;
     if (!no_size)
-	sz = var_get_u32(in, in_end, &osz);
+        sz = var_get_u32(in, in_end, &osz);
     else
-	sz = 0, osz = *out_size;
+        sz = 0, osz = *out_size;
     in += sz;
     in_size -= sz;
 
     if (osz >= INT_MAX)
-	return NULL;
+        return NULL;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-	// Limit maximum size to get fast turnaround on fuzzing test cases
-	if (osz > 100000)
-	    goto err;
+        // Limit maximum size to get fast turnaround on fuzzing test cases
+        if (osz > 100000)
+            goto err;
 #endif
 
     if (no_size && !out)
-	return NULL; // Need one or the other
+        return NULL; // Need one or the other
 
     if (!out) {
-	*out_size = osz;
-	if (!(out_free = out = malloc(*out_size)))
-	    return NULL;
+        *out_size = osz;
+        if (!(out_free = out = malloc(*out_size)))
+            return NULL;
     } else {
-	if (*out_size < osz)
-	    return NULL;
-	*out_size = osz;
+        if (*out_size < osz)
+            return NULL;
+        *out_size = osz;
     }
 
     uint32_t c_meta_size = 0;
@@ -1061,15 +1061,15 @@ unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
 
     // Format is pack meta data if present, followed by compressed data.
     if (do_pack) {
-	if (!(tmp_free = tmp = malloc(*out_size)))
-	    goto err;
-	tmp1 = tmp;  // uncompress
-	tmp2 = out;  // unpack
+        if (!(tmp_free = tmp = malloc(*out_size)))
+            goto err;
+        tmp1 = tmp;  // uncompress
+        tmp2 = out;  // unpack
     } else {
-	// no pack
-	tmp  = NULL;
-	tmp1 = out;  // uncompress
-	tmp2 = out;  // NOP
+        // no pack
+        tmp  = NULL;
+        tmp1 = out;  // uncompress
+        tmp2 = out;  // NOP
     }
 
     
@@ -1078,23 +1078,23 @@ unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
     int npacked_sym = 0;
     uint64_t unpacked_sz = 0; // FIXME: rename to packed_per_byte
     if (do_pack) {
-	c_meta_size = hts_unpack_meta(in, in_size, *out_size, map, &npacked_sym);
-	if (c_meta_size == 0)
-	    goto err;
+        c_meta_size = hts_unpack_meta(in, in_size, *out_size, map, &npacked_sym);
+        if (c_meta_size == 0)
+            goto err;
 
-	unpacked_sz = osz;
-	in      += c_meta_size;
-	in_size -= c_meta_size;
+        unpacked_sz = osz;
+        in      += c_meta_size;
+        in_size -= c_meta_size;
 
-	// New unpacked size.  We could derive this bit from *out_size
-	// and npacked_sym.
-	unsigned int osz;
-	sz = var_get_u32(in, in_end, &osz);
-	in += sz;
-	in_size -= sz;
-	if (osz > tmp1_size)
-	    goto err;
-	tmp1_size = osz;
+        // New unpacked size.  We could derive this bit from *out_size
+        // and npacked_sym.
+        unsigned int osz;
+        sz = var_get_u32(in, in_end, &osz);
+        in += sz;
+        in_size -= sz;
+        if (osz > tmp1_size)
+            goto err;
+        tmp1_size = osz;
     }
 
     //fprintf(stderr, "    meta_size %d bytes\n", (int)(in - orig_in)); //c-size
@@ -1102,62 +1102,62 @@ unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
     // uncompress RLE data.  in -> tmp1
     if (in_size) {
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-	// Limit maximum size to get fast turnaround on fuzzing test cases
-	if (tmp1_size > 100000)
-	    goto err;
+        // Limit maximum size to get fast turnaround on fuzzing test cases
+        if (tmp1_size > 100000)
+            goto err;
 #endif
-	if (do_cat) {
-	    //fprintf(stderr, "    CAT %d\n", tmp1_size); //c-size
-	    if (tmp1_size > in_size)
-		goto err;
-	    if (tmp1_size > *out_size)
-		goto err;
-	    memcpy(tmp1, in, tmp1_size);
-	} else if (do_ext) {
+        if (do_cat) {
+            //fprintf(stderr, "    CAT %d\n", tmp1_size); //c-size
+            if (tmp1_size > in_size)
+                goto err;
+            if (tmp1_size > *out_size)
+                goto err;
+            memcpy(tmp1, in, tmp1_size);
+        } else if (do_ext) {
 #ifdef HAVE_LIBBZ2
-	    if (BZ_OK != BZ2_bzBuffToBuffDecompress((char *)tmp1, &tmp1_size,
-						    (char *)in, in_size, 0, 0))
-		goto err;
+            if (BZ_OK != BZ2_bzBuffToBuffDecompress((char *)tmp1, &tmp1_size,
+                                                    (char *)in, in_size, 0, 0))
+                goto err;
 #else
-	    fprintf(stderr, "Htscodecs has been compiled without libbz2 support\n");
-	    goto err;
+            fprintf(stderr, "Htscodecs has been compiled without libbz2 support\n");
+            goto err;
 #endif
-	  } else {
-	    // in -> tmp1
-	    if (do_rle) {
-		tmp1 = order == 1
-		    ? arith_uncompress_O1_RLE(in, in_size, tmp1, tmp1_size)
-		    : arith_uncompress_O0_RLE(in, in_size, tmp1, tmp1_size);
-	    } else {
-		//if (order == 2)
-		//    tmp1 = arith_uncompress_O2(in, in_size, tmp1, tmp1_size)
-		//else
-		tmp1 = order == 1
-		    ? arith_uncompress_O1(in, in_size, tmp1, tmp1_size)
-		    : arith_uncompress_O0(in, in_size, tmp1, tmp1_size);
-	    }
-	    if (!tmp1)
-		goto err;
-	}
+          } else {
+            // in -> tmp1
+            if (do_rle) {
+                tmp1 = order == 1
+                    ? arith_uncompress_O1_RLE(in, in_size, tmp1, tmp1_size)
+                    : arith_uncompress_O0_RLE(in, in_size, tmp1, tmp1_size);
+            } else {
+                //if (order == 2)
+                //    tmp1 = arith_uncompress_O2(in, in_size, tmp1, tmp1_size)
+                //else
+                tmp1 = order == 1
+                    ? arith_uncompress_O1(in, in_size, tmp1, tmp1_size)
+                    : arith_uncompress_O0(in, in_size, tmp1, tmp1_size);
+            }
+            if (!tmp1)
+                goto err;
+        }
     } else {
-	tmp1_size = 0;
+        tmp1_size = 0;
     }
 
     if (do_pack) {
-	// Unpack bits via pack-map.  tmp1 -> tmp2
-	if (npacked_sym == 1)
-	    unpacked_sz = tmp1_size;
-	//uint8_t *porig = unpack(tmp2, tmp2_size, unpacked_sz, npacked_sym, map);
-	//memcpy(tmp3, porig, unpacked_sz);
-	if (!hts_unpack(tmp1, tmp1_size, tmp2, unpacked_sz, npacked_sym, map))
-	    goto err;
-	tmp2_size = unpacked_sz;
+        // Unpack bits via pack-map.  tmp1 -> tmp2
+        if (npacked_sym == 1)
+            unpacked_sz = tmp1_size;
+        //uint8_t *porig = unpack(tmp2, tmp2_size, unpacked_sz, npacked_sym, map);
+        //memcpy(tmp3, porig, unpacked_sz);
+        if (!hts_unpack(tmp1, tmp1_size, tmp2, unpacked_sz, npacked_sym, map))
+            goto err;
+        tmp2_size = unpacked_sz;
     } else {
-	tmp2_size = tmp1_size;
+        tmp2_size = tmp1_size;
     }
 
     if (tmp)
-	free(tmp);
+        free(tmp);
 
     *out_size = tmp2_size;
     return tmp2;
@@ -1169,6 +1169,6 @@ unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
 }
 
 unsigned char *arith_uncompress(unsigned char *in, unsigned int in_size,
-				unsigned int *out_size) {
+                                unsigned int *out_size) {
     return arith_uncompress_to(in, in_size, NULL, out_size);
 }

--- a/htscodecs/arith_dynamic.h
+++ b/htscodecs/arith_dynamic.h
@@ -39,17 +39,17 @@ extern "C" {
 #endif
 
 unsigned char *arith_compress(unsigned char *in, unsigned int in_size,
-			      unsigned int *out_size, int order);
+                              unsigned int *out_size, int order);
 
 unsigned char *arith_uncompress(unsigned char *in, unsigned int in_size,
-				unsigned int *out_size);
+                                unsigned int *out_size);
 
 unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
-				 unsigned char *out, unsigned int *out_size,
-				 int order);
+                                 unsigned char *out, unsigned int *out_size,
+                                 int order);
 
 unsigned char *arith_uncompress_to(unsigned char *in, unsigned int in_size,
-				   unsigned char *out, unsigned int *out_sz);
+                                   unsigned char *out, unsigned int *out_sz);
 
 unsigned int arith_compress_bound(unsigned int size, int order);
 

--- a/htscodecs/c_range_coder.h
+++ b/htscodecs/c_range_coder.h
@@ -17,8 +17,8 @@
 #ifndef C_RANGER_CODER_H
 #define C_RANGER_CODER_H
 
-#define  DO(n)	   int _;for (_=0; _<n; _++)
-#define  TOP	   (1<<24)
+#define  DO(n)     int _;for (_=0; _<n; _++)
+#define  TOP       (1<<24)
 #define  Thres (unsigned)255*TOP
 
 typedef unsigned char uc;
@@ -70,20 +70,20 @@ static inline void RC_StartDecode(RangeCoder *rc)
 
 static inline void RC_ShiftLow(RangeCoder *rc) {
     if (rc->low < Thres || rc->Carry) {
-	*rc->out_buf++ = rc->Cache + rc->Carry;
+        *rc->out_buf++ = rc->Cache + rc->Carry;
 
-	// Flush any stored FFs
-	while (rc->FFNum) {
-	    *rc->out_buf++ = rc->Carry-1; // (Carry-1)&255;
-	    rc->FFNum--;
-	}
+        // Flush any stored FFs
+        while (rc->FFNum) {
+            *rc->out_buf++ = rc->Carry-1; // (Carry-1)&255;
+            rc->FFNum--;
+        }
 
-	// Take copy of top byte ready for next flush
-	rc->Cache = rc->low >> 24;
-	rc->Carry = 0;
+        // Take copy of top byte ready for next flush
+        rc->Cache = rc->low >> 24;
+        rc->Carry = 0;
     } else {
-	// Low if FFxx xxxx.  Bump FF count and shift in as before
-	rc->FFNum++;
+        // Low if FFxx xxxx.  Bump FF count and shift in as before
+        rc->FFNum++;
     }
     rc->low = rc->low<<8;
 }
@@ -104,8 +104,8 @@ static inline void RC_Encode (RangeCoder *rc, uint32_t cumFreq, uint32_t freq, u
     rc->Carry += rc->low<tmp; // Overflow
 
     while (rc->range < TOP) {
-	rc->range <<= 8;
-	RC_ShiftLow(rc);
+        rc->range <<= 8;
+        RC_ShiftLow(rc);
     }
 }
 
@@ -121,8 +121,8 @@ static inline void RC_Decode (RangeCoder *rc, uint32_t cumFreq, uint32_t freq, u
     while (rc->range < TOP) {
         if (rc->in_buf >= rc->in_end)
             return; // FIXME: could signal error, instead of caller just generating nonsense
-	rc->code = (rc->code<<8) + *rc->in_buf++;
-	rc->range <<= 8;
+        rc->code = (rc->code<<8) + *rc->in_buf++;
+        rc->range <<= 8;
     }
 }
 

--- a/htscodecs/c_simple_model.h
+++ b/htscodecs/c_simple_model.h
@@ -86,12 +86,12 @@ static inline void SIMPLE_MODEL(NSYM,_init)(SIMPLE_MODEL(NSYM,_) *m, int max_sym
     int i;
     
     for (i=0; i<max_sym; i++) {
-	m->F[i].Symbol = i;
-	m->F[i].Freq   = 1;
+        m->F[i].Symbol = i;
+        m->F[i].Freq   = 1;
     }
     for (; i<NSYM; i++) {
-	m->F[i].Symbol = i;
-	m->F[i].Freq   = 0;
+        m->F[i].Symbol = i;
+        m->F[i].Freq   = 0;
     }
 
     m->TotFreq         = max_sym;
@@ -109,8 +109,8 @@ static inline void SIMPLE_MODEL(NSYM,_normalize)(SIMPLE_MODEL(NSYM,_) *m) {
     /* Faster than F[i].Freq for 0 <= i < NSYM */
     m->TotFreq=0;
     for (s = m->F; s->Freq; s++) {
-	s->Freq -= s->Freq>>1;
-	m->TotFreq += s->Freq;
+        s->Freq -= s->Freq>>1;
+        m->TotFreq += s->Freq;
     }
 }
 
@@ -126,7 +126,7 @@ static inline void SIMPLE_MODEL(NSYM,_encodeSymbol)(SIMPLE_MODEL(NSYM,_) *m,
     uint32_t AccFreq  = 0;
 
     while (s->Symbol != sym) {
-	AccFreq += s++->Freq;
+        AccFreq += s++->Freq;
         _mm_prefetch((const char *)(s+1), _MM_HINT_T0);
     }
 
@@ -135,13 +135,13 @@ static inline void SIMPLE_MODEL(NSYM,_encodeSymbol)(SIMPLE_MODEL(NSYM,_) *m,
     m->TotFreq += STEP;
 
     if (m->TotFreq > MAX_FREQ)
-	SIMPLE_MODEL(NSYM,_normalize)(m);
+        SIMPLE_MODEL(NSYM,_normalize)(m);
 
     /* Keep approx sorted */
     if (s[0].Freq > s[-1].Freq) {
-	SymFreqs t = s[0];
-	s[0] = s[-1];
-	s[-1] = t;
+        SymFreqs t = s[0];
+        s[0] = s[-1];
+        s[-1] = t;
     }
 }
 
@@ -165,14 +165,14 @@ static inline uint16_t SIMPLE_MODEL(NSYM,_decodeSymbol)(SIMPLE_MODEL(NSYM,_) *m,
     m->TotFreq += STEP;
 
     if (m->TotFreq > MAX_FREQ)
-	SIMPLE_MODEL(NSYM,_normalize)(m);
+        SIMPLE_MODEL(NSYM,_normalize)(m);
 
     /* Keep approx sorted */
     if (s[0].Freq > s[-1].Freq) {
-	SymFreqs t = s[0];
-	s[0] = s[-1];
-	s[-1] = t;
-	return t.Symbol;
+        SymFreqs t = s[0];
+        s[0] = s[-1];
+        s[-1] = t;
+        return t.Symbol;
     }
 
     return s->Symbol;

--- a/htscodecs/fqzcomp_qual.c
+++ b/htscodecs/fqzcomp_qual.c
@@ -104,41 +104,41 @@ static int store_array(unsigned char *out, unsigned int *array, int size) {
 
     int i, j, k;
     for (i = j = k = 0; i < size; j++) {
-	int run_len = i;
-	while (i < size && array[i] == j)
-	    i++;
-	run_len = i-run_len;
+        int run_len = i;
+        while (i < size && array[i] == j)
+            i++;
+        run_len = i-run_len;
 
-	int r;
-	do {
-	    r = MIN(255, run_len);
-	    tmp[k++] = r;
-	    run_len -= r;
-	} while (r == 255);
+        int r;
+        do {
+            r = MIN(255, run_len);
+            tmp[k++] = r;
+            run_len -= r;
+        } while (r == 255);
     }
     while (i < size)
-	tmp[k++] = 0, j++;
+        tmp[k++] = 0, j++;
 
     // RLE on out.
     //    1 2 3 3 3 3 3 4 4    5
     // => 1 2 3 3 +3... 4 4 +0 5
     int last = -1;
     for (i = j = 0; j < k; i++) {
-	out[i] = tmp[j++];
-	if (out[i] == last) {
-	    int n = j;
-	    while (j < k && tmp[j] == last)
-		j++;
-	    out[++i] = j-n;
-	} else {
-	    last = out[i];
-	}
+        out[i] = tmp[j++];
+        if (out[i] == last) {
+            int n = j;
+            while (j < k && tmp[j] == last)
+                j++;
+            out[++i] = j-n;
+        } else {
+            last = out[i];
+        }
     }
     k = i;
 
 //    fprintf(stderr, "Store_array %d => %d {", size, k);
 //    for (i = 0; i < k; i++)
-//	fprintf(stderr, "%d,", out[i]);
+//      fprintf(stderr, "%d,", out[i]);
 //    fprintf(stderr, "}\n");
     return k;
 }
@@ -151,39 +151,39 @@ static int read_array(unsigned char *in, size_t in_size, unsigned int *array, in
 
     // Remove level one of run-len encoding
     for (i = j = z = 0; z < size && i < in_size; i++) {
-	int run = in[i];
-	R[j++] = run;
-	z += run;
-	if (run == last) {
-	    if (i+1 >= in_size)
-		return -1;
-	    int copy = in[++i];
-	    z += run * copy;
-	    while (copy-- && z <= size && j < 1024)
-		R[j++] = run;
-	}
-	if (j >= 1024)
-	    return -1;
-	last = run;
+        int run = in[i];
+        R[j++] = run;
+        z += run;
+        if (run == last) {
+            if (i+1 >= in_size)
+                return -1;
+            int copy = in[++i];
+            z += run * copy;
+            while (copy-- && z <= size && j < 1024)
+                R[j++] = run;
+        }
+        if (j >= 1024)
+            return -1;
+        last = run;
     }
     nb = i;
 
     // Now expand inner level of run-length encoding
     int R_max = j;
     for (i = j = z = 0; j < size; i++) {
-	int run_len = 0;
-	int run_part;
-	if (z >= R_max)
-	    return -1;
-	do {
-	    run_part = R[z++];
-	    run_len += run_part;
-	} while (run_part == 255 && z < R_max);
-	if (run_part == 255)
-	    return -1;
+        int run_len = 0;
+        int run_part;
+        if (z >= R_max)
+            return -1;
+        do {
+            run_part = R[z++];
+            run_len += run_part;
+        } while (run_part == 255 && z < R_max);
+        if (run_part == 255)
+            return -1;
 
-	while (run_len && j < size)
-	    run_len--, array[j++] = i;
+        while (run_len && j < size)
+            run_len--, array[j++] = i;
     }
 
     return nb;
@@ -223,34 +223,34 @@ static void dump_table(unsigned int *tab, int size, char *name) {
     int i, last = -99, run = 0;
     fprintf(stderr, "\t%s\t{", name);
     for (i = 0; i < size; i++) {
-	if (tab[i] == last) {
-	    run++;
-	} else if (run == 1 && tab[i] == last+1) {
-	    int first = last;
-	    do {
-		last = tab[i];
-		i++;
-	    } while (i < size && tab[i] == last+1);
-	    i--;
+        if (tab[i] == last) {
+            run++;
+        } else if (run == 1 && tab[i] == last+1) {
+            int first = last;
+            do {
+                last = tab[i];
+                i++;
+            } while (i < size && tab[i] == last+1);
+            i--;
 
-	    // Want 0,1,2,3,3,3 as 0..2 3x3, not 0..3 3x2
-	    if (tab[i] == tab[i+1])
-		i--;
-	    if (tab[i] != first)
-		fprintf(stderr, "..%d", tab[i]);
-	    run = 1;
-	    last = -99;
-	} else {
-	    if (run > 1)
-		fprintf(stderr, " x %d%s%d", run, i?", ":"", tab[i]);
-	    else
-		fprintf(stderr, "%s%d", i?", ":"", tab[i]);
-	    run = 1;
-	    last = tab[i];
-	}
+            // Want 0,1,2,3,3,3 as 0..2 3x3, not 0..3 3x2
+            if (tab[i] == tab[i+1])
+                i--;
+            if (tab[i] != first)
+                fprintf(stderr, "..%d", tab[i]);
+            run = 1;
+            last = -99;
+        } else {
+            if (run > 1)
+                fprintf(stderr, " x %d%s%d", run, i?", ":"", tab[i]);
+            else
+                fprintf(stderr, "%s%d", i?", ":"", tab[i]);
+            run = 1;
+            last = tab[i];
+        }
     }
     if (run > 1)
-	fprintf(stderr, " x %d", run);
+        fprintf(stderr, " x %d", run);
     fprintf(stderr, "}\n");
 }
 
@@ -258,8 +258,8 @@ static void dump_map(unsigned int *map, int size, char *name) {
     int i, c = 0;
     fprintf(stderr, "\t%s\t{", name);
     for (i = 0; i < size; i++)
-	if (map[i] != INT_MAX)
-	    fprintf(stderr, "%s%d=%d", c++?", ":"", i, map[i]);
+        if (map[i] != INT_MAX)
+            fprintf(stderr, "%s%d=%d", c++?", ":"", i, map[i]);
     fprintf(stderr, "}\n");
 }
 
@@ -272,33 +272,33 @@ static void dump_params(fqz_gparams *gp) {
     fprintf(stderr, "\tmax_sel\t%d\n", gp->max_sel);
     fprintf(stderr, "\tmax_sym\t%d\n", gp->max_sym);
     if (gp->gflags & GFLAG_HAVE_STAB)
-	dump_table(gp->stab, 256, "stab");
+        dump_table(gp->stab, 256, "stab");
     fprintf(stderr, "}\n");
 
     int i;
     for (i = 0; i < gp->nparam; i++) {
-	fqz_param *pm = &gp->p[i];
-	fprintf(stderr, "\nParam[%d] = {\n", i);
-	fprintf(stderr, "\tcontext\t0x%04x\n", pm->context);
-	fprintf(stderr, "\tpflags\t0x%02x\n",  pm->pflags);
-	fprintf(stderr, "\tmax_sym\t%d\n",  pm->max_sym);
-	fprintf(stderr, "\tqbits\t%d\n",   pm->qbits);
-	fprintf(stderr, "\tqshift\t%d\n",  pm->qshift);
-	fprintf(stderr, "\tqloc\t%d\n",    pm->qloc);
-	fprintf(stderr, "\tsloc\t%d\n",    pm->sloc);
-	fprintf(stderr, "\tploc\t%d\n",    pm->ploc);
-	fprintf(stderr, "\tdloc\t%d\n",    pm->dloc);
+        fqz_param *pm = &gp->p[i];
+        fprintf(stderr, "\nParam[%d] = {\n", i);
+        fprintf(stderr, "\tcontext\t0x%04x\n", pm->context);
+        fprintf(stderr, "\tpflags\t0x%02x\n",  pm->pflags);
+        fprintf(stderr, "\tmax_sym\t%d\n",  pm->max_sym);
+        fprintf(stderr, "\tqbits\t%d\n",   pm->qbits);
+        fprintf(stderr, "\tqshift\t%d\n",  pm->qshift);
+        fprintf(stderr, "\tqloc\t%d\n",    pm->qloc);
+        fprintf(stderr, "\tsloc\t%d\n",    pm->sloc);
+        fprintf(stderr, "\tploc\t%d\n",    pm->ploc);
+        fprintf(stderr, "\tdloc\t%d\n",    pm->dloc);
 
-	if (pm->pflags & PFLAG_HAVE_QMAP)
-	    dump_map(pm->qmap, 256, "qmap");
+        if (pm->pflags & PFLAG_HAVE_QMAP)
+            dump_map(pm->qmap, 256, "qmap");
 
-	if (pm->pflags & PFLAG_HAVE_QTAB)
-	    dump_table(pm->qtab, 256, "qtab");
-	if (pm->pflags & PFLAG_HAVE_PTAB)
-	    dump_table(pm->ptab, 1024, "ptab");
-	if (pm->pflags & PFLAG_HAVE_DTAB)
-	    dump_table(pm->dtab, 256, "dtab");
-	fprintf(stderr, "}\n");
+        if (pm->pflags & PFLAG_HAVE_QTAB)
+            dump_table(pm->qtab, 256, "qtab");
+        if (pm->pflags & PFLAG_HAVE_PTAB)
+            dump_table(pm->ptab, 1024, "ptab");
+        if (pm->pflags & PFLAG_HAVE_DTAB)
+            dump_table(pm->dtab, 256, "dtab");
+        fprintf(stderr, "}\n");
     }
 }
 
@@ -314,18 +314,18 @@ static int fqz_create_models(fqz_model *m, fqz_gparams *gp) {
     int i;
 
     if (!(m->qual = htscodecs_tls_alloc(sizeof(*m->qual) * CTX_SIZE)))
-	return -1;
+        return -1;
 
     for (i = 0; i < CTX_SIZE; i++)
-	SIMPLE_MODEL(QMAX,_init)(&m->qual[i], gp->max_sym+1);
+        SIMPLE_MODEL(QMAX,_init)(&m->qual[i], gp->max_sym+1);
 
     for (i = 0; i < 4; i++)
-	SIMPLE_MODEL(256,_init)(&m->len[i],256);
+        SIMPLE_MODEL(256,_init)(&m->len[i],256);
 
     SIMPLE_MODEL(2,_init)(&m->revcomp,2);
     SIMPLE_MODEL(2,_init)(&m->dup,2);
     if (gp->max_sel > 0)
-	SIMPLE_MODEL(256,_init)(&m->sel, gp->max_sel+1);
+        SIMPLE_MODEL(256,_init)(&m->sel, gp->max_sel+1);
 
     return 0;
 }
@@ -357,14 +357,14 @@ static inline unsigned int fqz_update_ctx(fqz_param *pm, fqz_state *state, int q
     // vs 2 bit selector (no delta)             7199153 (-x 0x7270000e70) -0.8%
     // vs 2 bit selector (no delta)             7219668 (-x 0xa243000ea0)
     //{
-    //	double qa = state->qtot / (state->qlen+.01);
-    //	//fprintf(stderr, "%f\n", qa);
-    //	int x = 0;
-    //	if (qa>=Q1) x=3;
-    //	else if (qa>=Q2) x=2;
-    //	else if (qa>=Q3) x=1;
-    //	else x=0;
-    //	last += x << pm->dloc; // tmp reuse of delta pos
+    //  double qa = state->qtot / (state->qlen+.01);
+    //  //fprintf(stderr, "%f\n", qa);
+    //  int x = 0;
+    //  if (qa>=Q1) x=3;
+    //  else if (qa>=Q2) x=2;
+    //  else if (qa>=Q3) x=1;
+    //  else x=0;
+    //  last += x << pm->dloc; // tmp reuse of delta pos
     //  state->qtot += q*q;
     //  state->qlen++;
     //}
@@ -386,10 +386,10 @@ static inline unsigned int fqz_update_ctx(fqz_param *pm, fqz_state *state, int q
 // on one specific selector parameter.  Used only in TEST_MAIN via
 // fqz_manual_parameters at the moment.
 void fqz_qual_stats(fqz_slice *s,
-		    unsigned char *in, size_t in_size,
-		    fqz_param *pm,
-		    uint32_t qhist[256],
-		    int one_param) {
+                    unsigned char *in, size_t in_size,
+                    fqz_param *pm,
+                    uint32_t qhist[256],
+                    int one_param) {
 #define NP 128
     uint32_t qhistb[NP][256] = {{0}};  // both
     uint32_t qhist1[NP][256] = {{0}};  // READ1 only
@@ -411,56 +411,56 @@ void fqz_qual_stats(fqz_slice *s,
     int max_sel = 0;
     int has_r2 = 0;
     for (rec = 0; rec < s->num_records; rec++) {
-	if (one_param >= 0 && (s->flags[rec] >> 16) != one_param)
-	    continue;
-	num_rec++;
-	if (max_sel < (s->flags[rec] >> 16))
-	    max_sel = (s->flags[rec] >> 16);
-	if (s->flags[rec] & FQZ_FREAD2)
-	    has_r2 = 1;
+        if (one_param >= 0 && (s->flags[rec] >> 16) != one_param)
+            continue;
+        num_rec++;
+        if (max_sel < (s->flags[rec] >> 16))
+            max_sel = (s->flags[rec] >> 16);
+        if (s->flags[rec] & FQZ_FREAD2)
+            has_r2 = 1;
     }
 
     // Dedup detection and histogram stats gathering
     int *avg_qual = calloc((s->num_records+1), sizeof(int));
     if (!avg_qual)
-	return;
+        return;
 
     rec = i = j = 0;
     while (i < in_size) {
-	if (one_param >= 0 && (s->flags[rec] >> 16) != one_param) {
-	    avg_qual[rec] = 0;
-	    i += s->len[rec++];
-	    continue;
-	}
-	if (rec < s->num_records) {
-	    j = s->len[rec];
-	    dir = s->flags[rec] & FQZ_FREAD2 ? 1 : 0;
-	    if (i > 0 && j == last_len
-		&& !memcmp(in+i-last_len, in+i, j))
-		do_dedup++; // cache which records are dup?
-	} else {
-	    j = in_size - i;
-	    dir = 0;
-	}
-	last_len = j;
+        if (one_param >= 0 && (s->flags[rec] >> 16) != one_param) {
+            avg_qual[rec] = 0;
+            i += s->len[rec++];
+            continue;
+        }
+        if (rec < s->num_records) {
+            j = s->len[rec];
+            dir = s->flags[rec] & FQZ_FREAD2 ? 1 : 0;
+            if (i > 0 && j == last_len
+                && !memcmp(in+i-last_len, in+i, j))
+                do_dedup++; // cache which records are dup?
+        } else {
+            j = in_size - i;
+            dir = 0;
+        }
+        last_len = j;
 
-	uint32_t (*qh)[256] = dir ? qhist2 : qhist1;
-	uint64_t *th        = dir ? t2     : t1;
+        uint32_t (*qh)[256] = dir ? qhist2 : qhist1;
+        uint64_t *th        = dir ? t2     : t1;
 
-	uint32_t tot = 0;
-	for (; i < in_size && j > 0; i++, j--) {
-	    tot += in[i];
-	    qhist[in[i]]++;
-	    qhistb[j & (NP-1)][in[i]]++;
-	    qh[j & (NP-1)][in[i]]++;
-	    th[j & (NP-1)]++;
-	}
-	tot = last_len ? (tot*10.0)/last_len+.5 : 0;
+        uint32_t tot = 0;
+        for (; i < in_size && j > 0; i++, j--) {
+            tot += in[i];
+            qhist[in[i]]++;
+            qhistb[j & (NP-1)][in[i]]++;
+            qh[j & (NP-1)][in[i]]++;
+            th[j & (NP-1)]++;
+        }
+        tot = last_len ? (tot*10.0)/last_len+.5 : 0;
 
-	avg_qual[rec] = tot;
-	avg[MIN(2559, tot)]++;
+        avg_qual[rec] = tot;
+        avg[MIN(2559, tot)]++;
 
-	rec++;
+        rec++;
     }
     pm->do_dedup = ((rec+1)/(do_dedup+1) < 500);
 
@@ -468,195 +468,195 @@ void fqz_qual_stats(fqz_slice *s,
 
     // Unique symbol count
     for (i = pm->max_sym = pm->nsym = 0; i < 256; i++) {
-	if (qhist[i])
-	    pm->max_sym = i, pm->nsym++;
+        if (qhist[i])
+            pm->max_sym = i, pm->nsym++;
     }
 
 
     // Auto tune: does average quality helps us?
     if (pm->do_qa != 0) {
-	// Histogram of average qual in avg[]
-	// NB: we convert avg[] from count to selector index
+        // Histogram of average qual in avg[]
+        // NB: we convert avg[] from count to selector index
 
-	// Few symbols means high compression which means
-	// selector bits become more significant fraction.
-	// Reduce selector bits by skewing the distribution
-	// to not be even binning.
-	double qf0 = pm->nsym > 8 ? 0.2 : 0.05;
-	double qf1 = pm->nsym > 8 ? 0.5 : 0.22;
-	double qf2 = pm->nsym > 8 ? 0.8 : 0.60;
+        // Few symbols means high compression which means
+        // selector bits become more significant fraction.
+        // Reduce selector bits by skewing the distribution
+        // to not be even binning.
+        double qf0 = pm->nsym > 8 ? 0.2 : 0.05;
+        double qf1 = pm->nsym > 8 ? 0.5 : 0.22;
+        double qf2 = pm->nsym > 8 ? 0.8 : 0.60;
 
-	int total = 0;
-	i = 0;
-	while (i < 2560) {
-	    total += avg[i];
-	    if (total > qf0 * num_rec) {
-		//fprintf(stderr, "Q1=%d\n", (int)i);
-		break;
-	    }
-	    avg[i++] = 0;
-	}
-	while (i < 2560) {
-	    total += avg[i];
-	    if (total > qf1 * num_rec) {
-		//fprintf(stderr, "Q2=%d\n", (int)i);
-		break;
-	    }
-	    avg[i++] = 1;
-	}
-	while (i < 2560) {
-	    total += avg[i];
-	    if (total > qf2 * num_rec) {
-		//fprintf(stderr, "Q3=%d\n", (int)i);
-		break;
-	    }
-	    avg[i++] = 2;
-	}
-	while (i < 2560)
-	    avg[i++] = 3;
-
-	// Compute simple entropy of merged signal vs split signal.
+        int total = 0;
         i = 0;
-	rec = 0;
+        while (i < 2560) {
+            total += avg[i];
+            if (total > qf0 * num_rec) {
+                //fprintf(stderr, "Q1=%d\n", (int)i);
+                break;
+            }
+            avg[i++] = 0;
+        }
+        while (i < 2560) {
+            total += avg[i];
+            if (total > qf1 * num_rec) {
+                //fprintf(stderr, "Q2=%d\n", (int)i);
+                break;
+            }
+            avg[i++] = 1;
+        }
+        while (i < 2560) {
+            total += avg[i];
+            if (total > qf2 * num_rec) {
+                //fprintf(stderr, "Q3=%d\n", (int)i);
+                break;
+            }
+            avg[i++] = 2;
+        }
+        while (i < 2560)
+            avg[i++] = 3;
 
-	int qbin4[4][NP][256] = {{{0}}};
-	int qbin2[2][NP][256] = {{{0}}};
-	int qbin1   [NP][256] = {{0}};
-	int qcnt4[4][NP] = {{0}};
-	int qcnt2[4][NP] = {{0}};
-	int qcnt1   [NP] = {0};
+        // Compute simple entropy of merged signal vs split signal.
+        i = 0;
+        rec = 0;
+
+        int qbin4[4][NP][256] = {{{0}}};
+        int qbin2[2][NP][256] = {{{0}}};
+        int qbin1   [NP][256] = {{0}};
+        int qcnt4[4][NP] = {{0}};
+        int qcnt2[4][NP] = {{0}};
+        int qcnt1   [NP] = {0};
         while (i < in_size) {
-	    if (one_param >= 0 && (s->flags[rec] >> 16) != one_param) {
-		i += s->len[rec++];
-		continue;
-	    }
-	    if (rec < s->num_records)
-		j = s->len[rec];
-	    else
-		j = in_size - i;
-	    last_len = j;
+            if (one_param >= 0 && (s->flags[rec] >> 16) != one_param) {
+                i += s->len[rec++];
+                continue;
+            }
+            if (rec < s->num_records)
+                j = s->len[rec];
+            else
+                j = in_size - i;
+            last_len = j;
 
-	    uint32_t tot = avg_qual[rec];
-	    int qb4 = avg[MIN(2559, tot)];
-	    int qb2 = qb4/2;
+            uint32_t tot = avg_qual[rec];
+            int qb4 = avg[MIN(2559, tot)];
+            int qb2 = qb4/2;
 
-	    for (; i < in_size && j > 0; i++, j--) {
-		int x = j & (NP-1);
-		qbin4[qb4][x][in[i]]++;  qcnt4[qb4][x]++;
-		qbin2[qb2][x][in[i]]++;  qcnt2[qb2][x]++;
-		qbin1     [x][in[i]]++;  qcnt1     [x]++;
-	    }
-	    rec++;
-	}
+            for (; i < in_size && j > 0; i++, j--) {
+                int x = j & (NP-1);
+                qbin4[qb4][x][in[i]]++;  qcnt4[qb4][x]++;
+                qbin2[qb2][x][in[i]]++;  qcnt2[qb2][x]++;
+                qbin1     [x][in[i]]++;  qcnt1     [x]++;
+            }
+            rec++;
+        }
 
-	double e1 = 0, e2 = 0, e4 = 0;
-	for (j = 0; j < NP; j++) {
-	    for (i = 0; i < 256; i++) {
-		if (qbin1   [j][i]) e1 += qbin1   [j][i] * log(qbin1   [j][i] / (double)qcnt1   [j]);
-		if (qbin2[0][j][i]) e2 += qbin2[0][j][i] * log(qbin2[0][j][i] / (double)qcnt2[0][j]);
-		if (qbin2[1][j][i]) e2 += qbin2[1][j][i] * log(qbin2[1][j][i] / (double)qcnt2[1][j]);
-		if (qbin4[0][j][i]) e4 += qbin4[0][j][i] * log(qbin4[0][j][i] / (double)qcnt4[0][j]);
-		if (qbin4[1][j][i]) e4 += qbin4[1][j][i] * log(qbin4[1][j][i] / (double)qcnt4[1][j]);
-		if (qbin4[2][j][i]) e4 += qbin4[2][j][i] * log(qbin4[2][j][i] / (double)qcnt4[2][j]);
-		if (qbin4[3][j][i]) e4 += qbin4[3][j][i] * log(qbin4[3][j][i] / (double)qcnt4[3][j]);
-	    }
-	}
-	e1 /= -log(2)/8;
-	e2 /= -log(2)/8;
-	e4 /= -log(2)/8;
-	//fprintf(stderr, "E1=%f E2=%f E4=%f\n", e1, e2+s->num_records/8, e4+s->num_records/4);
+        double e1 = 0, e2 = 0, e4 = 0;
+        for (j = 0; j < NP; j++) {
+            for (i = 0; i < 256; i++) {
+                if (qbin1   [j][i]) e1 += qbin1   [j][i] * log(qbin1   [j][i] / (double)qcnt1   [j]);
+                if (qbin2[0][j][i]) e2 += qbin2[0][j][i] * log(qbin2[0][j][i] / (double)qcnt2[0][j]);
+                if (qbin2[1][j][i]) e2 += qbin2[1][j][i] * log(qbin2[1][j][i] / (double)qcnt2[1][j]);
+                if (qbin4[0][j][i]) e4 += qbin4[0][j][i] * log(qbin4[0][j][i] / (double)qcnt4[0][j]);
+                if (qbin4[1][j][i]) e4 += qbin4[1][j][i] * log(qbin4[1][j][i] / (double)qcnt4[1][j]);
+                if (qbin4[2][j][i]) e4 += qbin4[2][j][i] * log(qbin4[2][j][i] / (double)qcnt4[2][j]);
+                if (qbin4[3][j][i]) e4 += qbin4[3][j][i] * log(qbin4[3][j][i] / (double)qcnt4[3][j]);
+            }
+        }
+        e1 /= -log(2)/8;
+        e2 /= -log(2)/8;
+        e4 /= -log(2)/8;
+        //fprintf(stderr, "E1=%f E2=%f E4=%f\n", e1, e2+s->num_records/8, e4+s->num_records/4);
 
-	// Note by using the selector we're robbing bits from elsewhere in
-	// the context, which may reduce compression better.
-	// We don't know how much by, so this is basically a guess!
-	// For now we just say need 5% saving here.
-	double qm = pm->do_qa > 0 ? 1 : 0.98;
-	if ((pm->do_qa == -1 || pm->do_qa >= 4) &&
-	    e4 + s->num_records/4 < e2*qm + s->num_records/8 &&
-	    e4 + s->num_records/4 < e1*qm) {
-	    //fprintf(stderr, "do q4\n");
-	    for (i = 0; i < s->num_records; i++) {
-		//fprintf(stderr, "%d -> %d -> %d, %d\n", (int)i, avg_qual[i], avg[MIN(2559, avg_qual[i])], s->flags[i]>>16);
-		s->flags[i] |= avg[MIN(2559, avg_qual[i])] <<16;
-	    }
-	    pm->do_sel = 1;
-	    max_sel = 3;
-	} else if ((pm->do_qa == -1 || pm->do_qa >= 2) && e2 + s->num_records/8 < e1*qm) {
-	    //fprintf(stderr, "do q2\n");
-	    for (i = 0; i < s->num_records; i++)
-		s->flags[i] |= (avg[MIN(2559, avg_qual[i])]>>1) <<16;
-	    pm->do_sel = 1;
-	    max_sel = 1;
-	}
+        // Note by using the selector we're robbing bits from elsewhere in
+        // the context, which may reduce compression better.
+        // We don't know how much by, so this is basically a guess!
+        // For now we just say need 5% saving here.
+        double qm = pm->do_qa > 0 ? 1 : 0.98;
+        if ((pm->do_qa == -1 || pm->do_qa >= 4) &&
+            e4 + s->num_records/4 < e2*qm + s->num_records/8 &&
+            e4 + s->num_records/4 < e1*qm) {
+            //fprintf(stderr, "do q4\n");
+            for (i = 0; i < s->num_records; i++) {
+                //fprintf(stderr, "%d -> %d -> %d, %d\n", (int)i, avg_qual[i], avg[MIN(2559, avg_qual[i])], s->flags[i]>>16);
+                s->flags[i] |= avg[MIN(2559, avg_qual[i])] <<16;
+            }
+            pm->do_sel = 1;
+            max_sel = 3;
+        } else if ((pm->do_qa == -1 || pm->do_qa >= 2) && e2 + s->num_records/8 < e1*qm) {
+            //fprintf(stderr, "do q2\n");
+            for (i = 0; i < s->num_records; i++)
+                s->flags[i] |= (avg[MIN(2559, avg_qual[i])]>>1) <<16;
+            pm->do_sel = 1;
+            max_sel = 1;
+        }
 
-	if (pm->do_qa == -1) {
-	    // assume qual, pos, delta in that order.
-	    if (pm->pbits > 0 && pm->dbits > 0) {
-		// 1 from pos/delta
-		pm->sloc = pm->dloc-1;
-		pm->pbits--;
-		pm->dbits--;
-		pm->dloc++;
-	    } else if (pm->dbits >= 2) {
-		// 2 from delta
-		pm->sloc = pm->dloc;
-		pm->dbits -= 2;
-		pm->dloc += 2;
-	    } else if (pm->qbits >= 2) {
-		pm->qbits -= 2;
-		pm->ploc -= 2;
-		pm->sloc = 16-2 - pm->do_r2;
-		if (pm->qbits == 6 && pm->qshift == 5)
-		    pm->qbits--;
-	    }
-	    pm->do_qa = 4;
-	}
+        if (pm->do_qa == -1) {
+            // assume qual, pos, delta in that order.
+            if (pm->pbits > 0 && pm->dbits > 0) {
+                // 1 from pos/delta
+                pm->sloc = pm->dloc-1;
+                pm->pbits--;
+                pm->dbits--;
+                pm->dloc++;
+            } else if (pm->dbits >= 2) {
+                // 2 from delta
+                pm->sloc = pm->dloc;
+                pm->dbits -= 2;
+                pm->dloc += 2;
+            } else if (pm->qbits >= 2) {
+                pm->qbits -= 2;
+                pm->ploc -= 2;
+                pm->sloc = 16-2 - pm->do_r2;
+                if (pm->qbits == 6 && pm->qshift == 5)
+                    pm->qbits--;
+            }
+            pm->do_qa = 4;
+        }
     }
 
     // Auto tune: does splitting up READ1 and READ2 help us?
     if (has_r2 || pm->do_r2) { // FIXME: && but debug for now
-	double e1 = 0, e2 = 0; // entropy sum
+        double e1 = 0, e2 = 0; // entropy sum
 
-	for (j = 0; j < NP; j++) {
-	    if (!t1[j] || !t2[j]) continue;
-	    for (i = 0; i < 256; i++) {
-		if (!qhistb[j][i]) continue;
-		e1 -= (qhistb[j][i])*log(qhistb[j][i] / (double)(t1[j]+t2[j]));
-		if (qhist1[j][i])
-		    e2 -= qhist1[j][i] * log(qhist1[j][i] / (double)t1[j]);
-		if (qhist2[j][i])
-		    e2 -= qhist2[j][i] * log(qhist2[j][i] / (double)t2[j]);
-	    }
-	}
-	e1 /= log(2)*8; // bytes
-	e2 /= log(2)*8;
+        for (j = 0; j < NP; j++) {
+            if (!t1[j] || !t2[j]) continue;
+            for (i = 0; i < 256; i++) {
+                if (!qhistb[j][i]) continue;
+                e1 -= (qhistb[j][i])*log(qhistb[j][i] / (double)(t1[j]+t2[j]));
+                if (qhist1[j][i])
+                    e2 -= qhist1[j][i] * log(qhist1[j][i] / (double)t1[j]);
+                if (qhist2[j][i])
+                    e2 -= qhist2[j][i] * log(qhist2[j][i] / (double)t2[j]);
+            }
+        }
+        e1 /= log(2)*8; // bytes
+        e2 /= log(2)*8;
 
-	//fprintf(stderr, "read1/2 entropy merge %f split %f\n", e1, e2);
+        //fprintf(stderr, "read1/2 entropy merge %f split %f\n", e1, e2);
 
-	// Note by using the selector we're robbing bits from elsewhere in
-	// the context, which may reduce compression better.
-	// We don't know how much by, so this is basically a guess!
-	// For now we just say need 5% saving here.
-	double qm = pm->do_r2 > 0 ? 1 : 0.95;
-	if (e2 + (8+s->num_records/8) < e1*qm) {
-	    for (rec = 0; rec < s->num_records; rec++) {
-		if (one_param >= 0 && (s->flags[rec] >> 16) != one_param)
-		    continue;
-		int sel = s->flags[rec] >> 16;
-		s->flags[rec] =  (s->flags[rec] & 0xffff)
-		    | ((s->flags[rec] & FQZ_FREAD2)
-		       ? ((sel*2)+1) << 16
-		       : ((sel*2)+0) << 16);
-		if (max_sel < (s->flags[rec]>>16))
-		    max_sel = (s->flags[rec]>>16);
-	    }
-	}
+        // Note by using the selector we're robbing bits from elsewhere in
+        // the context, which may reduce compression better.
+        // We don't know how much by, so this is basically a guess!
+        // For now we just say need 5% saving here.
+        double qm = pm->do_r2 > 0 ? 1 : 0.95;
+        if (e2 + (8+s->num_records/8) < e1*qm) {
+            for (rec = 0; rec < s->num_records; rec++) {
+                if (one_param >= 0 && (s->flags[rec] >> 16) != one_param)
+                    continue;
+                int sel = s->flags[rec] >> 16;
+                s->flags[rec] =  (s->flags[rec] & 0xffff)
+                    | ((s->flags[rec] & FQZ_FREAD2)
+                       ? ((sel*2)+1) << 16
+                       : ((sel*2)+0) << 16);
+                if (max_sel < (s->flags[rec]>>16))
+                    max_sel = (s->flags[rec]>>16);
+            }
+        }
     }
 
     // We provided explicit selector data or auto-tuned it
     if (max_sel > 0) {
-	pm->do_sel = 1;
-	pm->max_sel = max_sel;
+        pm->do_sel = 1;
+        pm->max_sel = max_sel;
     }
 
     free(avg_qual);
@@ -678,22 +678,22 @@ int fqz_store_parameters1(fqz_param *pm, unsigned char *comp) {
     comp[comp_idx++] = (pm->ploc<<4)|pm->dloc;
 
     if (pm->store_qmap) {
-	for (i = j = 0; i < 256; i++)
-	    if (pm->qmap[i] != INT_MAX)
-		comp[comp_idx++] = i;
+        for (i = j = 0; i < 256; i++)
+            if (pm->qmap[i] != INT_MAX)
+                comp[comp_idx++] = i;
     }
 
     if (pm->qbits && pm->use_qtab)
-	// custom qtab
-	comp_idx += store_array(comp+comp_idx, pm->qtab, 256);
+        // custom qtab
+        comp_idx += store_array(comp+comp_idx, pm->qtab, 256);
 
     if (pm->pbits && pm->use_ptab)
-	// custom ptab
-	comp_idx += store_array(comp+comp_idx, pm->ptab, 1024);
+        // custom ptab
+        comp_idx += store_array(comp+comp_idx, pm->ptab, 1024);
 
     if (pm->dbits && pm->use_dtab)
-	// custom dtab
-	comp_idx += store_array(comp+comp_idx, pm->dtab, 256);
+        // custom dtab
+        comp_idx += store_array(comp+comp_idx, pm->dtab, 256);
 
     return comp_idx;
 }
@@ -706,16 +706,16 @@ int fqz_store_parameters(fqz_gparams *gp, unsigned char *comp) {
     comp[comp_idx++] = gp->gflags;
 
     if (gp->gflags & GFLAG_MULTI_PARAM)
-	comp[comp_idx++] = gp->nparam;
+        comp[comp_idx++] = gp->nparam;
 
     if (gp->gflags & GFLAG_HAVE_STAB) {
-	comp[comp_idx++] = gp->max_sel;
-	comp_idx += store_array(comp+comp_idx, gp->stab, 256);
+        comp[comp_idx++] = gp->max_sel;
+        comp_idx += store_array(comp+comp_idx, gp->stab, 256);
     }
 
     int i;
     for (i = 0; i < gp->nparam; i++)
-	comp_idx += fqz_store_parameters1(&gp->p[i], comp+comp_idx);
+        comp_idx += fqz_store_parameters1(&gp->p[i], comp+comp_idx);
 
     //fprintf(stderr, "Encoded %d bytes of param\n", comp_idx);
     return comp_idx;
@@ -725,17 +725,17 @@ int fqz_store_parameters(fqz_gparams *gp, unsigned char *comp) {
 // some predefined options (selected via "strat").
 static inline
 int fqz_pick_parameters(fqz_gparams *gp,
-			int vers,
-			int strat,
-			fqz_slice *s,
-			unsigned char *in,
-			size_t in_size) {
+                        int vers,
+                        int strat,
+                        fqz_slice *s,
+                        unsigned char *in,
+                        size_t in_size) {
     //approx sqrt(delta), must be sequential
     int dsqr[] = {
-	0, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3,
-	4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5,
-	5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
-	6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7
+        0, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+        6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7
     };
     uint32_t qhist[256] = {0};
 
@@ -747,12 +747,12 @@ int fqz_pick_parameters(fqz_gparams *gp,
     gp->vers = FQZ_VERS;
 
     if (!(gp->p = calloc(1, sizeof(fqz_param))))
-	return -1;
+        return -1;
     gp->nparam = 1;
     gp->max_sel = 0;
 
     if (vers == 3) // V3.0 doesn't store qual in original orientation
-	gp->gflags |= GFLAG_DO_REV;
+        gp->gflags |= GFLAG_DO_REV;
 
     fqz_param *pm = gp->p;
 
@@ -776,14 +776,14 @@ int fqz_pick_parameters(fqz_gparams *gp,
     // Validity check input lengths and buffer size
     size_t tlen = 0, i;
     for (i = 0; i < s->num_records; i++) {
-	if (tlen + s->len[i] > in_size)
-	    // Oversized buffer
-	    s->len[i] = in_size - tlen;
-	tlen += s->len[i];
+        if (tlen + s->len[i] > in_size)
+            // Oversized buffer
+            s->len[i] = in_size - tlen;
+        tlen += s->len[i];
     }
     if (s->num_records > 0 && tlen < in_size)
-	// Undersized buffer
-	s->len[s->num_records-1] += in_size - tlen;
+        // Undersized buffer
+        s->len[s->num_records-1] += in_size - tlen;
 
     // Quality metrics, for all recs
     fqz_qual_stats(s, in, in_size, pm, qhist, -1);
@@ -793,122 +793,122 @@ int fqz_pick_parameters(fqz_gparams *gp,
     // Check for fixed length.
     uint32_t first_len = s->len[0];
     for (i = 1; i < s->num_records; i++) {
-	if (s->len[i] != first_len)
-	    break;
+        if (s->len[i] != first_len)
+            break;
     }
     pm->fixed_len = (i == s->num_records);
     pm->use_qtab = 0; // unused by current encoder
 
     if (strat >= nstrats-1)
-	goto manually_set; // used in TEST_MAIN for debugging
+        goto manually_set; // used in TEST_MAIN for debugging
 
     if (pm->pshift < 0)
-	pm->pshift = MAX(0, log((double)s->len[0]/(1<<pm->pbits))/log(2)+.5);
+        pm->pshift = MAX(0, log((double)s->len[0]/(1<<pm->pbits))/log(2)+.5);
 
     if (pm->nsym <= 4) {
-	// NovaSeq
-	pm->qshift = 2; // qmax 64, although we can store up to 256 if needed
-	if (in_size < 5000000) {
-	    pm->pbits =2;
-	    pm->pshift=5;
-	}
+        // NovaSeq
+        pm->qshift = 2; // qmax 64, although we can store up to 256 if needed
+        if (in_size < 5000000) {
+            pm->pbits =2;
+            pm->pshift=5;
+        }
     } else if (pm->nsym <= 8) {
-	// HiSeqX
-	pm->qbits =MIN(pm->qbits,9);
-	pm->qshift=3;
-	if (in_size < 5000000)
-	    pm->qbits =6;
+        // HiSeqX
+        pm->qbits =MIN(pm->qbits,9);
+        pm->qshift=3;
+        if (in_size < 5000000)
+            pm->qbits =6;
     }
 
     if (in_size < 300000) {
-	pm->qbits=pm->qshift;
-	pm->dbits=2;
+        pm->qbits=pm->qshift;
+        pm->dbits=2;
     }
 
  manually_set:
 //    fprintf(stderr, "-x 0x%x%x%x%x%x%x%x%x%x%x%x%x\n",
-//	    pm->qbits, pm->qshift,
-//	    pm->pbits, pm->pshift,
-//	    pm->dbits, pm->dshift,
-//	    pm->qloc, pm->sloc, pm->ploc, pm->dloc,
-//	    pm->do_r2, pm->do_qa);
+//          pm->qbits, pm->qshift,
+//          pm->pbits, pm->pshift,
+//          pm->dbits, pm->dshift,
+//          pm->qloc, pm->sloc, pm->ploc, pm->dloc,
+//          pm->do_r2, pm->do_qa);
 
     for (i = 0; i < sizeof(dsqr)/sizeof(*dsqr); i++)
-	if (dsqr[i] > (1<<pm->dbits)-1)
-	    dsqr[i] = (1<<pm->dbits)-1;
+        if (dsqr[i] > (1<<pm->dbits)-1)
+            dsqr[i] = (1<<pm->dbits)-1;
 
     if (pm->store_qmap) {
-	int j;
-	for (i = j = 0; i < 256; i++)
-	    if (qhist[i])
-		pm->qmap[i] = j++;
-	    else
-		pm->qmap[i] = INT_MAX;
-	pm->max_sym = pm->nsym;
+        int j;
+        for (i = j = 0; i < 256; i++)
+            if (qhist[i])
+                pm->qmap[i] = j++;
+            else
+                pm->qmap[i] = INT_MAX;
+        pm->max_sym = pm->nsym;
     } else {
-	pm->nsym = 255;
-	for (i = 0; i < 256; i++)
-	    pm->qmap[i] = i;
+        pm->nsym = 255;
+        for (i = 0; i < 256; i++)
+            pm->qmap[i] = i;
     }
     if (gp->max_sym < pm->max_sym)
-	gp->max_sym = pm->max_sym;
+        gp->max_sym = pm->max_sym;
 
     // Produce ptab from pshift.
     if (pm->qbits) {
-	for (i = 0; i < 256; i++) {
-	    pm->qtab[i] = i; // 1:1
+        for (i = 0; i < 256; i++) {
+            pm->qtab[i] = i; // 1:1
 
-	    // Alternative mappings:
-	    //qtab[i] = i > 30 ? MIN(max_sym,i)-15 : i/2;  // eg for 9827 BAM
-	}
+            // Alternative mappings:
+            //qtab[i] = i > 30 ? MIN(max_sym,i)-15 : i/2;  // eg for 9827 BAM
+        }
 
     }
     pm->qmask = (1<<pm->qbits)-1;
 
     if (pm->pbits) {
-	for (i = 0; i < 1024; i++)
-	    pm->ptab[i] = MIN((1<<pm->pbits)-1, i>>pm->pshift);
+        for (i = 0; i < 1024; i++)
+            pm->ptab[i] = MIN((1<<pm->pbits)-1, i>>pm->pshift);
 
-	// Alternatively via analysis of quality distributions we
-	// may select a bunch of positions that are special and
-	// have a non-uniform ptab[].
-	// Manual experimentation on a NovaSeq run saved 2.8% here.
+        // Alternatively via analysis of quality distributions we
+        // may select a bunch of positions that are special and
+        // have a non-uniform ptab[].
+        // Manual experimentation on a NovaSeq run saved 2.8% here.
     }
 
     if (pm->dbits) {
-	for (i = 0; i < 256; i++)
-	    pm->dtab[i] = dsqr[MIN(sizeof(dsqr)/sizeof(*dsqr)-1, i>>pm->dshift)];
+        for (i = 0; i < 256; i++)
+            pm->dtab[i] = dsqr[MIN(sizeof(dsqr)/sizeof(*dsqr)-1, i>>pm->dshift)];
     }
 
     pm->use_ptab = (pm->pbits > 0);
     pm->use_dtab = (pm->dbits > 0);
 
     pm->pflags =
-	(pm->use_qtab   ?PFLAG_HAVE_QTAB :0)|
-	(pm->use_dtab   ?PFLAG_HAVE_DTAB :0)|
-	(pm->use_ptab   ?PFLAG_HAVE_PTAB :0)|
-	(pm->do_sel     ?PFLAG_DO_SEL    :0)|
-	(pm->fixed_len  ?PFLAG_DO_LEN    :0)|
-	(pm->do_dedup   ?PFLAG_DO_DEDUP  :0)|
-	(pm->store_qmap ?PFLAG_HAVE_QMAP :0);
+        (pm->use_qtab   ?PFLAG_HAVE_QTAB :0)|
+        (pm->use_dtab   ?PFLAG_HAVE_DTAB :0)|
+        (pm->use_ptab   ?PFLAG_HAVE_PTAB :0)|
+        (pm->do_sel     ?PFLAG_DO_SEL    :0)|
+        (pm->fixed_len  ?PFLAG_DO_LEN    :0)|
+        (pm->do_dedup   ?PFLAG_DO_DEDUP  :0)|
+        (pm->store_qmap ?PFLAG_HAVE_QMAP :0);
 
     gp->max_sel = 0;
     if (pm->do_sel) {
-	// 2 selectors values, but 1 parameter block.
-	// We'll use the sloc instead to encode the selector bits into
-	// the context.
-	gp->max_sel = 1; // indicator to check recs
-	gp->gflags |= GFLAG_HAVE_STAB;
-	// NB: stab is already all zero
+        // 2 selectors values, but 1 parameter block.
+        // We'll use the sloc instead to encode the selector bits into
+        // the context.
+        gp->max_sel = 1; // indicator to check recs
+        gp->gflags |= GFLAG_HAVE_STAB;
+        // NB: stab is already all zero
     }
 
     if (gp->max_sel) {
-	int max = 0;
-	for (i = 0; i < s->num_records; i++) {
-	    if (max < (s->flags[i] >> 16))
-		max = (s->flags[i] >> 16);
-	}
-	gp->max_sel = max;
+        int max = 0;
+        for (i = 0; i < s->num_records; i++) {
+            if (max < (s->flags[i] >> 16))
+                max = (s->flags[i] >> 16);
+        }
+        gp->max_sel = max;
     }
 
     return 0;
@@ -920,12 +920,12 @@ static void fqz_free_parameters(fqz_gparams *gp) {
 
 static
 unsigned char *compress_block_fqz2f(int vers,
-				    int strat,
-				    fqz_slice *s,
-				    unsigned char *in,
-				    size_t in_size,
-				    size_t *out_size,
-				    fqz_gparams *gp) {
+                                    int strat,
+                                    fqz_slice *s,
+                                    unsigned char *in,
+                                    size_t in_size,
+                                    size_t *out_size,
+                                    fqz_gparams *gp) {
     fqz_gparams local_gp;
     int free_params = 0;
 
@@ -940,14 +940,14 @@ unsigned char *compress_block_fqz2f(int vers,
     unsigned char *comp = (unsigned char *)malloc(in_size*1.1+100000);
     unsigned char *compe = comp + (size_t)(in_size*1.1+100000);
     if (!comp)
-	return NULL;
+        return NULL;
 
     // Pick and store params
     if (!gp) {
-	gp = &local_gp;
-	if (fqz_pick_parameters(gp, vers, strat, s, in, in_size) < 0)
-	    return NULL;
-	free_params = 1;
+        gp = &local_gp;
+        if (fqz_pick_parameters(gp, vers, strat, s, in, in_size) < 0)
+            return NULL;
+        free_params = 1;
     }
 
     //dump_params(gp);
@@ -958,19 +958,19 @@ unsigned char *compress_block_fqz2f(int vers,
 
     // Optimise tables to remove shifts in loop (NB: cannot do this in next vers)
     for (j = 0; j < gp->nparam; j++) {
-	pm = &gp->p[j];
+        pm = &gp->p[j];
 
-	for (i = 0; i < 1024; i++)
-	    pm->ptab[i] <<= pm->ploc;
+        for (i = 0; i < 1024; i++)
+            pm->ptab[i] <<= pm->ploc;
 
-	for (i = 0; i < 256; i++)
-	    pm->dtab[i] <<= pm->dloc;
+        for (i = 0; i < 256; i++)
+            pm->dtab[i] <<= pm->dloc;
     }
 
     // Create models and initialise range coder
     fqz_model model;
     if (fqz_create_models(&model, gp) < 0)
-	return NULL;
+        return NULL;
 
     RC_SetOutput(&rc, (char *)comp+comp_idx);
     RC_StartEncode(&rc);
@@ -978,27 +978,27 @@ unsigned char *compress_block_fqz2f(int vers,
     // For CRAM3.1, reverse upfront if needed
     pm = &gp->p[0];
     if (gp->gflags & GFLAG_DO_REV) {
-	i = rec = j = 0;
-	while (i < in_size) {
-	    int len = rec < s->num_records-1
-		? s->len[rec] : in_size - i;
+        i = rec = j = 0;
+        while (i < in_size) {
+            int len = rec < s->num_records-1
+                ? s->len[rec] : in_size - i;
 
-	    if (s->flags[rec] & FQZ_FREVERSE) {
-		// Reverse complement sequence - note: modifies buffer
-		int I,J;
-		unsigned char *cp = in+i;
-		for (I = 0, J = len-1; I < J; I++, J--) {
-		    unsigned char c;
-		    c = cp[I];
-		    cp[I] = cp[J];
-		    cp[J] = c;
-		}
-	    }
+            if (s->flags[rec] & FQZ_FREVERSE) {
+                // Reverse complement sequence - note: modifies buffer
+                int I,J;
+                unsigned char *cp = in+i;
+                for (I = 0, J = len-1; I < J; I++, J--) {
+                    unsigned char c;
+                    c = cp[I];
+                    cp[I] = cp[J];
+                    cp[J] = c;
+                }
+            }
 
-	    i += len;
-	    rec++;
-	}
-	rec = 0;
+            i += len;
+            rec++;
+        }
+        rec = 0;
     }
 
     fqz_state state = {0};
@@ -1008,117 +1008,117 @@ unsigned char *compress_block_fqz2f(int vers,
     int x;
 
     for (i = 0; i < in_size; i++) {
-	if (state.p == 0) {
-	    if (pm->do_sel || (gp->gflags & GFLAG_MULTI_PARAM)) {
-		state.s = rec < s->num_records
-		    ? s->flags[rec] >> 16 // reuse spare bits
-		    : 0;
-		SIMPLE_MODEL(256,_encodeSymbol)(&model.sel, &rc, state.s);
-		//fprintf(stderr, "State %d\n", state.s);
-	    } else {
-		state.s = 0;
-	    }
-	    x = (gp->gflags & GFLAG_HAVE_STAB) ? gp->stab[state.s] : state.s;
-	    pm = &gp->p[x];
+        if (state.p == 0) {
+            if (pm->do_sel || (gp->gflags & GFLAG_MULTI_PARAM)) {
+                state.s = rec < s->num_records
+                    ? s->flags[rec] >> 16 // reuse spare bits
+                    : 0;
+                SIMPLE_MODEL(256,_encodeSymbol)(&model.sel, &rc, state.s);
+                //fprintf(stderr, "State %d\n", state.s);
+            } else {
+                state.s = 0;
+            }
+            x = (gp->gflags & GFLAG_HAVE_STAB) ? gp->stab[state.s] : state.s;
+            pm = &gp->p[x];
 
-	    //fprintf(stderr, "sel %d param %d\n", state.s, x);
+            //fprintf(stderr, "sel %d param %d\n", state.s, x);
 
-	    int len = s->len[rec];
-	    if (!pm->fixed_len || state.first_len) {
-		SIMPLE_MODEL(256,_encodeSymbol)(&model.len[0], &rc, (len>> 0) & 0xff);
-		SIMPLE_MODEL(256,_encodeSymbol)(&model.len[1], &rc, (len>> 8) & 0xff);
-		SIMPLE_MODEL(256,_encodeSymbol)(&model.len[2], &rc, (len>>16) & 0xff);
-		SIMPLE_MODEL(256,_encodeSymbol)(&model.len[3], &rc, (len>>24) & 0xff);
-		//fprintf(stderr, "Len %d\n", len);
-		state.first_len = 0;
-	    }
+            int len = s->len[rec];
+            if (!pm->fixed_len || state.first_len) {
+                SIMPLE_MODEL(256,_encodeSymbol)(&model.len[0], &rc, (len>> 0) & 0xff);
+                SIMPLE_MODEL(256,_encodeSymbol)(&model.len[1], &rc, (len>> 8) & 0xff);
+                SIMPLE_MODEL(256,_encodeSymbol)(&model.len[2], &rc, (len>>16) & 0xff);
+                SIMPLE_MODEL(256,_encodeSymbol)(&model.len[3], &rc, (len>>24) & 0xff);
+                //fprintf(stderr, "Len %d\n", len);
+                state.first_len = 0;
+            }
 
-	    if (gp->gflags & GFLAG_DO_REV) {
-		// no need to reverse complement for V4.0 as the core format
-		// already has this feature.
-		if (s->flags[rec] & FQZ_FREVERSE)
-		    SIMPLE_MODEL(2,_encodeSymbol)(&model.revcomp, &rc, 1);
-		else
-		    SIMPLE_MODEL(2,_encodeSymbol)(&model.revcomp, &rc, 0);
-		//fprintf(stderr, "Rev %d\n", (s->flags[rec] & FQZ_FREVERSE) ? 1 : 0);
-	    }
+            if (gp->gflags & GFLAG_DO_REV) {
+                // no need to reverse complement for V4.0 as the core format
+                // already has this feature.
+                if (s->flags[rec] & FQZ_FREVERSE)
+                    SIMPLE_MODEL(2,_encodeSymbol)(&model.revcomp, &rc, 1);
+                else
+                    SIMPLE_MODEL(2,_encodeSymbol)(&model.revcomp, &rc, 0);
+                //fprintf(stderr, "Rev %d\n", (s->flags[rec] & FQZ_FREVERSE) ? 1 : 0);
+            }
 
-	    rec++;
+            rec++;
 
-	    state.qtot = 0;
-	    state.qlen = 0;
+            state.qtot = 0;
+            state.qlen = 0;
 
-	    state.p = len;
-	    state.add_d = 0;
-	    state.delta = 0;
-	    state.qctx = 0;
-	    state.prevq = 0;
+            state.p = len;
+            state.add_d = 0;
+            state.delta = 0;
+            state.qctx = 0;
+            state.prevq = 0;
 
-	    last = pm->context;
+            last = pm->context;
 
-	    if (pm->do_dedup) {
-		// Possible dup of previous read?
-		if (i && len == last_len && !memcmp(in+i-last_len, in+i, len)) {
-		    SIMPLE_MODEL(2,_encodeSymbol)(&model.dup, &rc, 1);
-		    i += len-1;
-		    state.p = 0;
-		    //fprintf(stderr, "Dup 1\n");
-		    continue;
-		} else {
-		    SIMPLE_MODEL(2,_encodeSymbol)(&model.dup, &rc, 0);
-		    //fprintf(stderr, "Dup 0\n");
-		}
+            if (pm->do_dedup) {
+                // Possible dup of previous read?
+                if (i && len == last_len && !memcmp(in+i-last_len, in+i, len)) {
+                    SIMPLE_MODEL(2,_encodeSymbol)(&model.dup, &rc, 1);
+                    i += len-1;
+                    state.p = 0;
+                    //fprintf(stderr, "Dup 1\n");
+                    continue;
+                } else {
+                    SIMPLE_MODEL(2,_encodeSymbol)(&model.dup, &rc, 0);
+                    //fprintf(stderr, "Dup 0\n");
+                }
 
-		last_len = len;
-	    }
-	}
+                last_len = len;
+            }
+        }
 
-	unsigned char q = in[i];
-	unsigned char qm = pm->qmap[q];
+        unsigned char q = in[i];
+        unsigned char qm = pm->qmap[q];
 
-	SIMPLE_MODEL(QMAX,_encodeSymbol)(&model.qual[last], &rc, qm);
-	//fprintf(stderr, "Sym %d with ctx %04x delta %d prevq %d q %d\n", qm, last, state.delta, state.prevq, qm);
-	//fprintf(stderr, "pos=%d, delta=%d\n", state.p, state.delta);
-	last = fqz_update_ctx(pm, &state, qm);
+        SIMPLE_MODEL(QMAX,_encodeSymbol)(&model.qual[last], &rc, qm);
+        //fprintf(stderr, "Sym %d with ctx %04x delta %d prevq %d q %d\n", qm, last, state.delta, state.prevq, qm);
+        //fprintf(stderr, "pos=%d, delta=%d\n", state.p, state.delta);
+        last = fqz_update_ctx(pm, &state, qm);
     }
 
     RC_FinishEncode(&rc);
 
     // For CRAM3.1, undo our earlier reversal step
     if (gp->gflags & GFLAG_DO_REV) {
-	i = rec = j = 0;
-	while (i < in_size) {
-	    int len = rec < s->num_records-1
-		? s->len[rec]
-		: in_size - i;
+        i = rec = j = 0;
+        while (i < in_size) {
+            int len = rec < s->num_records-1
+                ? s->len[rec]
+                : in_size - i;
 
-	    if (s->flags[rec] & FQZ_FREVERSE) {
-		// Reverse complement sequence - note: modifies buffer
-		int I,J;
-		unsigned char *cp = in+i;
-		for (I = 0, J = len-1; I < J; I++, J--) {
-		    unsigned char c;
-		    c = cp[I];
-		    cp[I] = cp[J];
-		    cp[J] = c;
-		}
-	    }
+            if (s->flags[rec] & FQZ_FREVERSE) {
+                // Reverse complement sequence - note: modifies buffer
+                int I,J;
+                unsigned char *cp = in+i;
+                for (I = 0, J = len-1; I < J; I++, J--) {
+                    unsigned char c;
+                    c = cp[I];
+                    cp[I] = cp[J];
+                    cp[J] = c;
+                }
+            }
 
-	    i += len;
-	    rec++;
-	}
+            i += len;
+            rec++;
+        }
     }
 
     // Clear selector abuse of flags
     for (rec = 0; rec < s->num_records; rec++)
-	s->flags[rec] &= 0xffff;
+        s->flags[rec] &= 0xffff;
 
     *out_size = comp_idx + RC_OutSize(&rc);
     //fprintf(stderr, "%d -> %d\n", (int)in_size, (int)*out_size);
 
     fqz_destroy_models(&model);
     if (free_params)
-	fqz_free_parameters(gp);
+        fqz_free_parameters(gp);
 
     return comp;
 }
@@ -1135,7 +1135,7 @@ int fqz_read_parameters1(fqz_param *pm, unsigned char *in, size_t in_size) {
     size_t i;
 
     if (in_size < 7)
-	return -1;
+        return -1;
 
     // Starting context
     pm->context = in[in_idx] + (in[in_idx+1]<<8);
@@ -1163,46 +1163,46 @@ int fqz_read_parameters1(fqz_param *pm, unsigned char *in, size_t in_size) {
 
     // Maps and tables
     if (pm->store_qmap) {
-	for (i = 0; i < 256; i++) pm->qmap[i] = INT_MAX; // so dump_map works
-	if (in_idx + pm->max_sym > in_size)
-	    return -1;
-	for (i = 0; i < pm->max_sym; i++)
-	    pm->qmap[i] = in[in_idx++];
+        for (i = 0; i < 256; i++) pm->qmap[i] = INT_MAX; // so dump_map works
+        if (in_idx + pm->max_sym > in_size)
+            return -1;
+        for (i = 0; i < pm->max_sym; i++)
+            pm->qmap[i] = in[in_idx++];
     } else {
-	for (i = 0; i < 256; i++)
-	    pm->qmap[i] = i;
+        for (i = 0; i < 256; i++)
+            pm->qmap[i] = i;
     }
 
     if (pm->qbits) {
-	if (pm->use_qtab) {
-	    int used = read_array(in+in_idx, in_size-in_idx, pm->qtab, 256);
-	    if (used < 0)
-		return -1;
-	    in_idx += used;
-	} else {
-	    for (i = 0; i < 256; i++)
-		pm->qtab[i] = i;
-	}
+        if (pm->use_qtab) {
+            int used = read_array(in+in_idx, in_size-in_idx, pm->qtab, 256);
+            if (used < 0)
+                return -1;
+            in_idx += used;
+        } else {
+            for (i = 0; i < 256; i++)
+                pm->qtab[i] = i;
+        }
     }
 
     if (pm->use_ptab) {
-	int used = read_array(in+in_idx, in_size-in_idx, pm->ptab, 1024);
-	if (used < 0)
-	    return -1;
-	in_idx += used;
+        int used = read_array(in+in_idx, in_size-in_idx, pm->ptab, 1024);
+        if (used < 0)
+            return -1;
+        in_idx += used;
     } else {
-	for (i = 0; i < 1024; i++)
-	    pm->ptab[i] = 0;
+        for (i = 0; i < 1024; i++)
+            pm->ptab[i] = 0;
     }
 
     if (pm->use_dtab) {
         int used = read_array(in+in_idx, in_size-in_idx, pm->dtab, 256);
-	if (used < 0)
-	    return -1;
-	in_idx += used;
+        if (used < 0)
+            return -1;
+        in_idx += used;
     } else {
-	for (i = 0; i < 256; i++)
-	    pm->dtab[i] = 0;
+        for (i = 0; i < 256; i++)
+            pm->dtab[i] = 0;
     }
 
     return in_idx;
@@ -1214,12 +1214,12 @@ int fqz_read_parameters(fqz_gparams *gp, unsigned char *in, size_t in_size) {
     int i;
 
     if (in_size < 10)
-	return -1;
+        return -1;
 
     // Format version
     gp->vers = in[in_idx++];
     if (gp->vers != FQZ_VERS)
-	return -1;
+        return -1;
 
     // Global glags
     gp->gflags = in[in_idx++];
@@ -1227,37 +1227,37 @@ int fqz_read_parameters(fqz_gparams *gp, unsigned char *in, size_t in_size) {
     // Number of param blocks and param selector details
     gp->nparam = (gp->gflags & GFLAG_MULTI_PARAM) ? in[in_idx++] : 1;
     if (gp->nparam <= 0)
-	return -1;
+        return -1;
     gp->max_sel = gp->nparam > 1 ? gp->nparam : 0;
 
     if (gp->gflags & GFLAG_HAVE_STAB) {
-	gp->max_sel = in[in_idx++];
-	int used = read_array(in+in_idx, in_size-in_idx, gp->stab, 256);
+        gp->max_sel = in[in_idx++];
+        int used = read_array(in+in_idx, in_size-in_idx, gp->stab, 256);
         if (used < 0)
             goto err;
-	in_idx += used;
+        in_idx += used;
     } else {
-	for (i = 0; i < gp->nparam; i++)
-	    gp->stab[i] = i;
-	for (; i < 256; i++)
-	    gp->stab[i] = gp->nparam-1;
+        for (i = 0; i < gp->nparam; i++)
+            gp->stab[i] = i;
+        for (; i < 256; i++)
+            gp->stab[i] = gp->nparam-1;
     }
 
     // Load the individual parameter locks
     if (!(gp->p = malloc(gp->nparam * sizeof(*gp->p))))
-	return -1;
+        return -1;
 
     gp->max_sym = 0;
     for (i = 0; i < gp->nparam; i++) {
-	int e = fqz_read_parameters1(&gp->p[i], in + in_idx, in_size-in_idx);
-	if (e < 0)
-	    goto err;
+        int e = fqz_read_parameters1(&gp->p[i], in + in_idx, in_size-in_idx);
+        if (e < 0)
+            goto err;
         if (gp->p[i].do_sel && gp->max_sel == 0)
             goto err; // Inconsistent
-	in_idx += e;
+        in_idx += e;
 
-	if (gp->max_sym < gp->p[i].max_sym)
-	    gp->max_sym = gp->p[i].max_sym;
+        if (gp->max_sym < gp->p[i].max_sym)
+            gp->max_sym = gp->p[i].max_sym;
     }
 
     //fprintf(stderr, "Decoded %d bytes of param\n", in_idx);
@@ -1271,11 +1271,11 @@ int fqz_read_parameters(fqz_gparams *gp, unsigned char *in, size_t in_size) {
 
 static
 unsigned char *uncompress_block_fqz2f(fqz_slice *s,
-				      unsigned char *in,
-				      size_t in_size,
-				      size_t *out_size,
-				      int *lengths,
-				      int nlengths) {
+                                      unsigned char *in,
+                                      size_t in_size,
+                                      size_t *out_size,
+                                      int *lengths,
+                                      int nlengths) {
     fqz_gparams gp;
     fqz_param *pm;
     char *rev_a = NULL;
@@ -1289,7 +1289,7 @@ unsigned char *uncompress_block_fqz2f(fqz_slice *s,
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (len > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     unsigned char *uncomp = NULL;
@@ -1298,24 +1298,24 @@ unsigned char *uncompress_block_fqz2f(fqz_slice *s,
 
     // Decode parameter blocks
     if ((i = fqz_read_parameters(&gp, in+in_idx, in_size-in_idx)) < 0)
-	return NULL;
+        return NULL;
     //dump_params(&gp);
     in_idx += i;
 
     // Optimisations to remove shifts from main loop
     for (i = 0; i < gp.nparam; i++) {
-	int j;
-	pm = &gp.p[i];
-	for (j = 0; j < 1024; j++)
-	    pm->ptab[j] <<= pm->ploc;
-	for (j = 0; j < 256; j++)
-	    pm->dtab[j] <<= pm->dloc;
+        int j;
+        pm = &gp.p[i];
+        for (j = 0; j < 1024; j++)
+            pm->ptab[j] <<= pm->ploc;
+        for (j = 0; j < 256; j++)
+            pm->dtab[j] <<= pm->dloc;
     }
 
     // Initialise models and entropy coder
     fqz_model model;
     if (fqz_create_models(&model, &gp) < 0)
-	return NULL;
+        return NULL;
 
     RC_SetInput(&rc, (char *)in+in_idx, (char *)in+in_size);
     RC_StartDecode(&rc);
@@ -1324,13 +1324,13 @@ unsigned char *uncompress_block_fqz2f(fqz_slice *s,
     // Allocate buffers
     uncomp = (unsigned char *)malloc(*out_size);
     if (!uncomp)
-	goto err;
+        goto err;
 
     int nrec = 1000;
     rev_a = malloc(nrec);
     len_a = malloc(nrec * sizeof(int));
     if (!rev_a || !len_a)
-	goto err;
+        goto err;
 
     // Main decode loop
     fqz_state state;
@@ -1346,111 +1346,111 @@ unsigned char *uncompress_block_fqz2f(fqz_slice *s,
     int x = 0;
     pm = &gp.p[x];
     for (rec = i = 0; i < len; i++) {
-	if (rec >= nrec) {
-	    nrec *= 2;
-	    rev_a = realloc(rev_a, nrec);
-	    len_a = realloc(len_a, nrec*sizeof(int));
-	    if (!rev_a || !len_a)
-		goto err;
-	}
+        if (rec >= nrec) {
+            nrec *= 2;
+            rev_a = realloc(rev_a, nrec);
+            len_a = realloc(len_a, nrec*sizeof(int));
+            if (!rev_a || !len_a)
+                goto err;
+        }
 
-	if (state.p == 0) {
-	    // New record
-	    if (pm->do_sel) {
-		state.s = SIMPLE_MODEL(256,_decodeSymbol)(&model.sel, &rc);
-		//fprintf(stderr, "State %d\n", state.s);
-	    } else {
-		state.s = 0;
-	    }
-	    x = (gp.gflags & GFLAG_HAVE_STAB) ? gp.stab[MIN(255, state.s)] : state.s;
-	    if (x >= gp.nparam)
-		goto err;
-	    pm = &gp.p[x];
+        if (state.p == 0) {
+            // New record
+            if (pm->do_sel) {
+                state.s = SIMPLE_MODEL(256,_decodeSymbol)(&model.sel, &rc);
+                //fprintf(stderr, "State %d\n", state.s);
+            } else {
+                state.s = 0;
+            }
+            x = (gp.gflags & GFLAG_HAVE_STAB) ? gp.stab[MIN(255, state.s)] : state.s;
+            if (x >= gp.nparam)
+                goto err;
+            pm = &gp.p[x];
 
-	    unsigned int len = last_len;
-	    if (!pm->fixed_len || state.first_len) {
-		len  = SIMPLE_MODEL(256,_decodeSymbol)(&model.len[0], &rc);
-		len |= SIMPLE_MODEL(256,_decodeSymbol)(&model.len[1], &rc)<<8;
-		len |= SIMPLE_MODEL(256,_decodeSymbol)(&model.len[2], &rc)<<16;
-		len |= ((unsigned)SIMPLE_MODEL(256,_decodeSymbol)(&model.len[3], &rc))<<24;
-		//fprintf(stderr, "Len %d\n", len);
-		state.first_len = 0;
-		last_len = len;
-	    }
-	    if (len > *out_size-i || len <= 0)
-		goto err;
+            unsigned int len = last_len;
+            if (!pm->fixed_len || state.first_len) {
+                len  = SIMPLE_MODEL(256,_decodeSymbol)(&model.len[0], &rc);
+                len |= SIMPLE_MODEL(256,_decodeSymbol)(&model.len[1], &rc)<<8;
+                len |= SIMPLE_MODEL(256,_decodeSymbol)(&model.len[2], &rc)<<16;
+                len |= ((unsigned)SIMPLE_MODEL(256,_decodeSymbol)(&model.len[3], &rc))<<24;
+                //fprintf(stderr, "Len %d\n", len);
+                state.first_len = 0;
+                last_len = len;
+            }
+            if (len > *out_size-i || len <= 0)
+                goto err;
 
-	    if (lengths && rec < nlengths)
-		lengths[rec] = len;
+            if (lengths && rec < nlengths)
+                lengths[rec] = len;
 
-	    if (gp.gflags & GFLAG_DO_REV) {
-		rev = SIMPLE_MODEL(2,_decodeSymbol)(&model.revcomp, &rc);
-		//fprintf(stderr, "rev %d\n", rev);
-		rev_a[rec] = rev;
-		len_a[rec] = len;
-	    }
+            if (gp.gflags & GFLAG_DO_REV) {
+                rev = SIMPLE_MODEL(2,_decodeSymbol)(&model.revcomp, &rc);
+                //fprintf(stderr, "rev %d\n", rev);
+                rev_a[rec] = rev;
+                len_a[rec] = len;
+            }
 
-	    if (pm->do_dedup) {
-		if (SIMPLE_MODEL(2,_decodeSymbol)(&model.dup, &rc)) {
-		    //fprintf(stderr, "Dup 1\n");
-		    // Dup of last line
-		    if (len > i)
-			goto err;
-		    memcpy(uncomp+i, uncomp+i-len, len);
-		    i += len-1;
-		    state.p = 0;
-		    rec++;
-		    continue;
-		} else {
-		    //fprintf(stderr, "Dup 0\n");
-		}
-	    }
+            if (pm->do_dedup) {
+                if (SIMPLE_MODEL(2,_decodeSymbol)(&model.dup, &rc)) {
+                    //fprintf(stderr, "Dup 1\n");
+                    // Dup of last line
+                    if (len > i)
+                        goto err;
+                    memcpy(uncomp+i, uncomp+i-len, len);
+                    i += len-1;
+                    state.p = 0;
+                    rec++;
+                    continue;
+                } else {
+                    //fprintf(stderr, "Dup 0\n");
+                }
+            }
 
-	    rec++;
+            rec++;
 
-	    state.p = len;
-	    state.add_d = 0;
-	    state.delta = 0;
-	    state.prevq = 0;
-	    state.qctx = 0;
+            state.p = len;
+            state.add_d = 0;
+            state.delta = 0;
+            state.prevq = 0;
+            state.qctx = 0;
 
-	    last = pm->context;
-	}
+            last = pm->context;
+        }
 
-	// Decode and output quality
-	unsigned char Q = SIMPLE_MODEL(QMAX,_decodeSymbol)(&model.qual[last], &rc);
-	unsigned char q = pm->qmap[Q];
-	//fprintf(stderr, "Sym %d with ctx %04x delta %d prevq %d q %d\n", Q, last, state.delta, state.prevq, Q);
+        // Decode and output quality
+        unsigned char Q = SIMPLE_MODEL(QMAX,_decodeSymbol)(&model.qual[last], &rc);
+        unsigned char q = pm->qmap[Q];
+        //fprintf(stderr, "Sym %d with ctx %04x delta %d prevq %d q %d\n", Q, last, state.delta, state.prevq, Q);
         uncomp[i] = q;
 
-	// Compute new quality context
-	last = fqz_update_ctx(pm, &state, Q);
+        // Compute new quality context
+        last = fqz_update_ctx(pm, &state, Q);
     }
 
     if (rec >= nrec) {
-	nrec *= 2;
-	rev_a = realloc(rev_a, nrec);
-	len_a = realloc(len_a, nrec*sizeof(int));
-	if (!rev_a || !len_a)
-	    goto err;
+        nrec *= 2;
+        rev_a = realloc(rev_a, nrec);
+        len_a = realloc(len_a, nrec*sizeof(int));
+        if (!rev_a || !len_a)
+            goto err;
     }
     rev_a[rec] = rev;
     len_a[rec] = len;
 
     if (gp.gflags & GFLAG_DO_REV) {
-	for (i = rec = 0; i < len && rec < nrec; i += len_a[rec++]) {
-	    if (!rev_a[rec])
-		continue;
+        for (i = rec = 0; i < len && rec < nrec; i += len_a[rec++]) {
+            if (!rev_a[rec])
+                continue;
 
-	    int I, J;
-	    unsigned char *cp = uncomp+i;
-	    for (I = 0, J = len_a[rec]-1; I < J; I++, J--) {
-		unsigned char c;
-		c = cp[I];
-		cp[I] = cp[J];
-		cp[J] = c;
-	    }
-	}
+            int I, J;
+            unsigned char *cp = uncomp+i;
+            for (I = 0, J = len_a[rec]-1; I < J; I++, J--) {
+                unsigned char c;
+                c = cp[I];
+                cp[I] = cp[J];
+                cp[J] = c;
+            }
+        }
     }
 
     RC_FinishDecode(&rc);
@@ -1477,13 +1477,13 @@ unsigned char *uncompress_block_fqz2f(fqz_slice *s,
 }
 
 char *fqz_compress(int vers, fqz_slice *s, char *in, size_t uncomp_size,
-		   size_t *comp_size, int strat, fqz_gparams *gp) {
+                   size_t *comp_size, int strat, fqz_gparams *gp) {
     return (char *)compress_block_fqz2f(vers, strat, s, (unsigned char *)in,
-					uncomp_size, comp_size, gp);
+                                        uncomp_size, comp_size, gp);
 }
 
 char *fqz_decompress(char *in, size_t comp_size, size_t *uncomp_size,
-		     int *lengths, int nlengths) {
+                     int *lengths, int nlengths) {
     return (char *)uncompress_block_fqz2f(NULL, (unsigned char *)in,
-					  comp_size, uncomp_size, lengths, nlengths);
+                                          comp_size, uncomp_size, lengths, nlengths);
 }

--- a/htscodecs/fqzcomp_qual.h
+++ b/htscodecs/fqzcomp_qual.h
@@ -172,10 +172,10 @@ char *fqz_decompress(char *in, size_t in_size, size_t *out_size,
  *  fqz_compress.
  */
 void fqz_qual_stats(fqz_slice *s,
-		    unsigned char *in, size_t in_size,
-		    fqz_param *pm,
-		    uint32_t qhist[256],
-		    int one_param);
+                    unsigned char *in, size_t in_size,
+                    fqz_param *pm,
+                    uint32_t qhist[256],
+                    int one_param);
 
 #ifdef __cplusplus
 }

--- a/htscodecs/pack.c
+++ b/htscodecs/pack.c
@@ -54,97 +54,97 @@
  *         NULL of failure
  */
 uint8_t *hts_pack(uint8_t *data, int64_t len,
-		  uint8_t *out_meta, int *out_meta_len, uint64_t *out_len) {
+                  uint8_t *out_meta, int *out_meta_len, uint64_t *out_len) {
     int p[256] = {0}, n;
     uint64_t i, j;
     uint8_t *out = malloc(len+1);
     if (!out)
-	return NULL;
+        return NULL;
 
     // count syms
     for (i = 0; i < len; i++)
-	p[data[i]]=1;
+        p[data[i]]=1;
     
     for (i = n = 0; i < 256; i++) {
-	if (p[i]) {
-	    p[i] = n++; // p[i] is now the code number
-	    out_meta[n] = i;
-	}
+        if (p[i]) {
+            p[i] = n++; // p[i] is now the code number
+            out_meta[n] = i;
+        }
     }
     out_meta[0] = n; // 256 wraps to 0
     j = n+1;
 
     // 1 value per byte
     if (n > 16) {
-	*out_meta_len = 1;
-	// FIXME shortcut this by returning data and checking later.
-	memcpy(out, data, len);
-	*out_len = len;
-	return out;
+        *out_meta_len = 1;
+        // FIXME shortcut this by returning data and checking later.
+        memcpy(out, data, len);
+        *out_len = len;
+        return out;
     }
 
     // Work out how many values per byte to encode.
     int val_per_byte;
     if (n > 4)
-	val_per_byte = 2;
+        val_per_byte = 2;
     else if (n > 2)
-	val_per_byte = 4;
+        val_per_byte = 4;
     else if (n > 1)
-	val_per_byte = 8;
+        val_per_byte = 8;
     else
-	val_per_byte = 0; // infinite
+        val_per_byte = 0; // infinite
 
     *out_meta_len = j;
     j = 0;
 
     switch (val_per_byte) {
     case 2:
-	for (i = 0; i < (len & ~1); i+=2)
-	    out[j++] = (p[data[i]]<<0) | (p[data[i+1]]<<4);
-	switch (len-i) {
-	case 1: out[j++] = p[data[i]];
-	}
-	*out_len = j;
-	return out;
+        for (i = 0; i < (len & ~1); i+=2)
+            out[j++] = (p[data[i]]<<0) | (p[data[i+1]]<<4);
+        switch (len-i) {
+        case 1: out[j++] = p[data[i]];
+        }
+        *out_len = j;
+        return out;
 
     case 4: {
-	for (i = 0; i < (len & ~3); i+=4)
-	    out[j++] = (p[data[i]]<<0) | (p[data[i+1]]<<2) | (p[data[i+2]]<<4) | (p[data[i+3]]<<6);
-	out[j] = 0;
-	int s = len-i, x = 0;
-	switch (s) {
-	case 3: out[j] |= p[data[i++]] << x; x+=2;
-	case 2: out[j] |= p[data[i++]] << x; x+=2;
-	case 1: out[j] |= p[data[i++]] << x; x+=2;
-	    j++;
-	}
-	*out_len = j;
-	return out;
+        for (i = 0; i < (len & ~3); i+=4)
+            out[j++] = (p[data[i]]<<0) | (p[data[i+1]]<<2) | (p[data[i+2]]<<4) | (p[data[i+3]]<<6);
+        out[j] = 0;
+        int s = len-i, x = 0;
+        switch (s) {
+        case 3: out[j] |= p[data[i++]] << x; x+=2;
+        case 2: out[j] |= p[data[i++]] << x; x+=2;
+        case 1: out[j] |= p[data[i++]] << x; x+=2;
+            j++;
+        }
+        *out_len = j;
+        return out;
     }
 
     case 8: {
-	for (i = 0; i < (len & ~7); i+=8)
-	    out[j++] = (p[data[i+0]]<<0) | (p[data[i+1]]<<1) | (p[data[i+2]]<<2) | (p[data[i+3]]<<3)
-		     | (p[data[i+4]]<<4) | (p[data[i+5]]<<5) | (p[data[i+6]]<<6) | (p[data[i+7]]<<7);
-	out[j] = 0;
-	int s = len-i, x = 0;
-	switch (s) {
-	case 7: out[j] |= p[data[i++]] << x++;
-	case 6: out[j] |= p[data[i++]] << x++;
-	case 5: out[j] |= p[data[i++]] << x++;
-	case 4: out[j] |= p[data[i++]] << x++;
-	case 3: out[j] |= p[data[i++]] << x++;
-	case 2: out[j] |= p[data[i++]] << x++;
-	case 1: out[j] |= p[data[i++]] << x++;
-	    j++;
-	}
-	*out_len = j;
-	return out;
+        for (i = 0; i < (len & ~7); i+=8)
+            out[j++] = (p[data[i+0]]<<0) | (p[data[i+1]]<<1) | (p[data[i+2]]<<2) | (p[data[i+3]]<<3)
+                     | (p[data[i+4]]<<4) | (p[data[i+5]]<<5) | (p[data[i+6]]<<6) | (p[data[i+7]]<<7);
+        out[j] = 0;
+        int s = len-i, x = 0;
+        switch (s) {
+        case 7: out[j] |= p[data[i++]] << x++;
+        case 6: out[j] |= p[data[i++]] << x++;
+        case 5: out[j] |= p[data[i++]] << x++;
+        case 4: out[j] |= p[data[i++]] << x++;
+        case 3: out[j] |= p[data[i++]] << x++;
+        case 2: out[j] |= p[data[i++]] << x++;
+        case 1: out[j] |= p[data[i++]] << x++;
+            j++;
+        }
+        *out_len = j;
+        return out;
     }
 
     case 0:
-	*out_len = j;
-	return out;
+        *out_len = j;
+        return out;
     }
 
     return NULL;
@@ -163,35 +163,35 @@ uint8_t *hts_pack(uint8_t *data, int64_t len,
  *         zero on failure.
  */
 uint8_t hts_unpack_meta(uint8_t *data, uint32_t data_len,
-			uint64_t udata_len, uint8_t *map, int *nsym) {
+                        uint64_t udata_len, uint8_t *map, int *nsym) {
     if (data_len == 0)
-	return 0;
+        return 0;
 
     // Number of symbols used
     unsigned int n = data[0];
     if (n == 0)
-	n = 256;
+        n = 256;
 
     // Symbols per byte
     if (n <= 1)
-	*nsym = 0;
+        *nsym = 0;
     else if (n <= 2)
-	*nsym = 8;
+        *nsym = 8;
     else if (n <= 4)
-	*nsym = 4;
+        *nsym = 4;
     else if (n <= 16)
-	*nsym = 2;
+        *nsym = 2;
     else {
-	*nsym = 1; // no packing
-	return 1;
+        *nsym = 1; // no packing
+        return 1;
     }
 
     if (data_len <= 1)
-	return 0;
+        return 0;
 
     int j = 1, c = 0;
     do {
-	map[c++] = data[j++];
+        map[c++] = data[j++];
     } while (c < n && j < data_len);
 
     return c < n ? 0 : j;
@@ -214,134 +214,134 @@ uint8_t *hts_unpack(uint8_t *data, int64_t len, uint8_t *out, uint64_t out_len, 
     int64_t i, j = 0, olen;
 
     if (nsym == 1) {
-	// raw data; FIXME: shortcut the need for malloc & memcpy here
-	memcpy(out, data, len);
-	return out;
+        // raw data; FIXME: shortcut the need for malloc & memcpy here
+        memcpy(out, data, len);
+        return out;
     }
 
     switch(nsym) {
     case 8: {
-	union {
-	    uint64_t w;
-	    uint8_t c[8];
-	} map[256];
-	int x;
-	for (x = 0; x < 256; x++) {
-	    map[x].c[0] = p[x>>0&1];
-	    map[x].c[1] = p[x>>1&1];
-	    map[x].c[2] = p[x>>2&1];
-	    map[x].c[3] = p[x>>3&1];
-	    map[x].c[4] = p[x>>4&1];
-	    map[x].c[5] = p[x>>5&1];
-	    map[x].c[6] = p[x>>6&1];
-	    map[x].c[7] = p[x>>7&1];
-	}
-	if ((out_len+7)/8 > len)
-	    return NULL;
-	olen = out_len & ~7;
+        union {
+            uint64_t w;
+            uint8_t c[8];
+        } map[256];
+        int x;
+        for (x = 0; x < 256; x++) {
+            map[x].c[0] = p[x>>0&1];
+            map[x].c[1] = p[x>>1&1];
+            map[x].c[2] = p[x>>2&1];
+            map[x].c[3] = p[x>>3&1];
+            map[x].c[4] = p[x>>4&1];
+            map[x].c[5] = p[x>>5&1];
+            map[x].c[6] = p[x>>6&1];
+            map[x].c[7] = p[x>>7&1];
+        }
+        if ((out_len+7)/8 > len)
+            return NULL;
+        olen = out_len & ~7;
 
-	for (i = 0; i < olen; i+=8)
-	    memcpy(&out[i], &map[data[j++]].w, 8);
+        for (i = 0; i < olen; i+=8)
+            memcpy(&out[i], &map[data[j++]].w, 8);
 
-	if (out_len != olen) {
-	    c = data[j++];
-	    while (i < out_len) {
-		out[i++] = p[c & 1];
-		c >>= 1;
-	    }
-	}
-	break;
+        if (out_len != olen) {
+            c = data[j++];
+            while (i < out_len) {
+                out[i++] = p[c & 1];
+                c >>= 1;
+            }
+        }
+        break;
     }
 
     case 4: {
-	union {
-	    uint32_t w;
-	    uint8_t c[4];
-	} map[256];
+        union {
+            uint32_t w;
+            uint8_t c[4];
+        } map[256];
 
-	int x, y, z, _, P=0;
-	for (x = 0; x < 4; x++)
-	    for (y = 0; y < 4; y++)
-		for (z = 0; z < 4; z++)
-		    for (_ = 0; _ < 4; _++, P++) {
-			map[P].c[0] = p[_];
-			map[P].c[1] = p[z];
-			map[P].c[2] = p[y];
-			map[P].c[3] = p[x];
-		    }
+        int x, y, z, _, P=0;
+        for (x = 0; x < 4; x++)
+            for (y = 0; y < 4; y++)
+                for (z = 0; z < 4; z++)
+                    for (_ = 0; _ < 4; _++, P++) {
+                        map[P].c[0] = p[_];
+                        map[P].c[1] = p[z];
+                        map[P].c[2] = p[y];
+                        map[P].c[3] = p[x];
+                    }
 
-	if ((out_len+3)/4 > len)
-	    return NULL;
-	olen = out_len & ~3;
+        if ((out_len+3)/4 > len)
+            return NULL;
+        olen = out_len & ~3;
 
-	for (i = 0; i < olen-12; i+=16) {
-	    uint32_t w[] = {
-		map[data[j+0]].w,
-		map[data[j+1]].w,
-		map[data[j+2]].w,
-		map[data[j+3]].w
-	    };
-	    j += 4;
-	    memcpy(&out[i], &w, 16);
-	}
+        for (i = 0; i < olen-12; i+=16) {
+            uint32_t w[] = {
+                map[data[j+0]].w,
+                map[data[j+1]].w,
+                map[data[j+2]].w,
+                map[data[j+3]].w
+            };
+            j += 4;
+            memcpy(&out[i], &w, 16);
+        }
 
-	for (; i < olen; i+=4)
-	    memcpy(&out[i], &map[data[j++]].w, 4);
+        for (; i < olen; i+=4)
+            memcpy(&out[i], &map[data[j++]].w, 4);
 
-	if (out_len != olen) {
-	    c = data[j++];
-	    while (i < out_len) {
-		out[i++] = p[c & 3];
-		c >>= 2;
-	    }
-	}
-	break;
+        if (out_len != olen) {
+            c = data[j++];
+            while (i < out_len) {
+                out[i++] = p[c & 3];
+                c >>= 2;
+            }
+        }
+        break;
     }
 
     case 2: {
-	union {
-	    uint16_t w;
-	    uint8_t c[2];
-	} map[256];
+        union {
+            uint16_t w;
+            uint8_t c[2];
+        } map[256];
 
-	int x, y;
-	for (x = 0; x < 16; x++) {
-	    for (y = 0; y < 16; y++) {
-		map[x*16+y].c[0] = p[y];
-		map[x*16+y].c[1] = p[x];
-	    }
-	}
+        int x, y;
+        for (x = 0; x < 16; x++) {
+            for (y = 0; y < 16; y++) {
+                map[x*16+y].c[0] = p[y];
+                map[x*16+y].c[1] = p[x];
+            }
+        }
 
-	if ((out_len+1)/2 > len)
-	    return NULL;
-	olen = out_len & ~1;
+        if ((out_len+1)/2 > len)
+            return NULL;
+        olen = out_len & ~1;
 
-	for (i = j = 0; i+2 < olen; i+=4) {
-	    uint16_t w[] = {
-	    	map[data[j+0]].w,
-	    	map[data[j+1]].w
-	    };
-	    memcpy(&out[i], &w, 4);
+        for (i = j = 0; i+2 < olen; i+=4) {
+            uint16_t w[] = {
+                map[data[j+0]].w,
+                map[data[j+1]].w
+            };
+            memcpy(&out[i], &w, 4);
 
-	    j += 2;
-	}
+            j += 2;
+        }
 
-	for (; i < olen; i+=2)
-	    memcpy(&out[i], &map[data[j++]].w, 2);
+        for (; i < olen; i+=2)
+            memcpy(&out[i], &map[data[j++]].w, 2);
 
-	if (out_len != olen) {
-	    c = data[j++];
-	    out[i+0] = p[c&15];
-	}
-	break;
+        if (out_len != olen) {
+            c = data[j++];
+            out[i+0] = p[c&15];
+        }
+        break;
     }
 
     case 0:
-	memset(out, p[0], out_len);
-	break;
+        memset(out, p[0], out_len);
+        break;
 
     default:
-	return NULL;
+        return NULL;
     }
 
     return out;
@@ -354,44 +354,44 @@ uint8_t *hts_unpack_(uint8_t *data, int64_t len, uint8_t *out, uint64_t out_len,
     int64_t i, j = 0, olen;
 
     if (nsym == 1) {
-	// raw data; FIXME: shortcut the need for malloc & memcpy here
-	memcpy(out, data, len);
-	return out;
+        // raw data; FIXME: shortcut the need for malloc & memcpy here
+        memcpy(out, data, len);
+        return out;
     }
 
     switch(nsym) {
     case 2: {
-	uint16_t map[256], x, y;
-	for (x = 0; x < 16; x++)
-	    for (y = 0; y < 16; y++)
-		map[x*16+y] = p[x]*256+p[y];
+        uint16_t map[256], x, y;
+        for (x = 0; x < 16; x++)
+            for (y = 0; y < 16; y++)
+                map[x*16+y] = p[x]*256+p[y];
 
-	if ((out_len+1)/2 > len)
-	    return NULL;
-	olen = out_len & ~1;
+        if ((out_len+1)/2 > len)
+            return NULL;
+        olen = out_len & ~1;
 
-	uint16_t *o16 = (uint16_t *)out;
-	for (i = 0; i+4 < olen/2; i+=4) {
-	    int k;
-	    for (k = 0; k < 4; k++)
-		o16[i+k] = map[data[i+k]];
-	}
-	j = i; i *= 2;
+        uint16_t *o16 = (uint16_t *)out;
+        for (i = 0; i+4 < olen/2; i+=4) {
+            int k;
+            for (k = 0; k < 4; k++)
+                o16[i+k] = map[data[i+k]];
+        }
+        j = i; i *= 2;
 
-	for (; i < olen; i+=2) {
-	    uint16_t w1 = map[data[j++]];
-	    *(uint16_t *)&out[i] = w1;
-	}
+        for (; i < olen; i+=2) {
+            uint16_t w1 = map[data[j++]];
+            *(uint16_t *)&out[i] = w1;
+        }
 
-	if (out_len != olen) {
-	    c = data[j++];
-	    out[i+0] = p[c&15];
-	}
-	break;
+        if (out_len != olen) {
+            c = data[j++];
+            out[i+0] = p[c&15];
+        }
+        break;
     }
 
     default:
-	return NULL;
+        return NULL;
     }
 
     return out;

--- a/htscodecs/pack.h
+++ b/htscodecs/pack.h
@@ -50,7 +50,7 @@ extern "C" {
  *         NULL of failure
  */
 uint8_t *hts_pack(uint8_t *data, int64_t len,
-		  uint8_t *out_meta, int *out_meta_len, uint64_t *out_len);
+                  uint8_t *out_meta, int *out_meta_len, uint64_t *out_len);
 
 /*
  * Unpacks the meta-data portions of the hts_pack algorithm.
@@ -64,7 +64,7 @@ uint8_t *hts_pack(uint8_t *data, int64_t len,
  *         zero on failure.
  */
 uint8_t hts_unpack_meta(uint8_t *data, uint32_t data_len,
-			uint64_t udata_len, uint8_t *map, int *nsym);
+                        uint64_t udata_len, uint8_t *map, int *nsym);
 
 /*
  * Unpacks a packed data steam (given the unpacked meta-data).

--- a/htscodecs/permute.h
+++ b/htscodecs/permute.h
@@ -13,7 +13,7 @@ int main(void) {
     FILE *fp = fopen(__FILE__, "r");
     char line[8192];
     while(fgets(line, 8192, fp)) {
-	printf("%s", line);
+        printf("%s", line);
     }
     close(fp);
     printf("\n");
@@ -22,42 +22,42 @@ int main(void) {
     printf("#define _ 9\n");
     printf("static uint32_t permute[256][8] = { // reverse binary bit order\n");
     for (i = 0; i < 256; i++) {
-	int b = 0;
-	int v[8] = {0};
-	for (j = 0; j < 8; j++) {
-	    if (i & (1<<j)) {
-		v[j] = ++b;
-	    }
-	}
-	printf("  { ");
-	for (j = 0; j < 8; j++) {
-	    if (v[j])
-		printf("%d,", v[j]-1);
-	    else
-		printf("_,");
-	}
-	printf("},\n");
+        int b = 0;
+        int v[8] = {0};
+        for (j = 0; j < 8; j++) {
+            if (i & (1<<j)) {
+                v[j] = ++b;
+            }
+        }
+        printf("  { ");
+        for (j = 0; j < 8; j++) {
+            if (v[j])
+                printf("%d,", v[j]-1);
+            else
+                printf("_,");
+        }
+        printf("},\n");
     }
     printf("};\n\n");
 
     // Encode table; collapses N values spread across lanes
     printf("static uint32_t permutec[256][8] = { // reverse binary bit order\n"); 
     for (i = 0; i < 256; i++) {
-	int b = 0;
-	int v[9] = {0};
-	for (j = 0; j < 8; j++) {
-	    if (i & (1<<j)) {
-		v[b++] = j+1;
-	    }
-	}
-	printf("  { ");
-	for (j = b-8; j < b; j++) {
-	    if (j >= 0 && v[j])
-		printf("%d,", v[j]-1);
-	    else
-		printf("_,");
-	}
-	printf("},\n");
+        int b = 0;
+        int v[9] = {0};
+        for (j = 0; j < 8; j++) {
+            if (i & (1<<j)) {
+                v[b++] = j+1;
+            }
+        }
+        printf("  { ");
+        for (j = b-8; j < b; j++) {
+            if (j >= 0 && v[j])
+                printf("%d,", v[j]-1);
+            else
+                printf("_,");
+        }
+        printf("},\n");
     }
     printf("};\n");
 

--- a/htscodecs/pooled_alloc.h
+++ b/htscodecs/pooled_alloc.h
@@ -64,12 +64,12 @@ static pool_alloc_t *pool_create(size_t dsize) {
     pool_alloc_t *p;
 
     if (NULL == (p = (pool_alloc_t *)malloc(sizeof(*p))))
-	return NULL;
+        return NULL;
 
     /* Minimum size is a pointer, for free list */
     dsize = (dsize + sizeof(void *) - 1) & ~(sizeof(void *)-1);
     if (dsize < sizeof(void *))
-	dsize = sizeof(void *);
+        dsize = sizeof(void *);
     p->dsize = dsize;
 
     p->npools = 0;
@@ -115,18 +115,18 @@ static void *pool_alloc(pool_alloc_t *p) {
     /* Look on free list */
     if (NULL != p->free) {
         ret = p->free;
-	p->free = *((void **)p->free);
-	return ret;
+        p->free = *((void **)p->free);
+        return ret;
     }
 
     /* Look for space in the last pool */
     if (p->npools) {
         pool = &p->pools[p->npools - 1];
         if (pool->used + p->dsize < PSIZE) {
-	    ret = ((char *) pool->pool) + pool->used;
-	    pool->used += p->dsize;
-	    return ret;
-	}
+            ret = ((char *) pool->pool) + pool->used;
+            pool->used += p->dsize;
+            return ret;
+        }
     }
 
     /* Need a new pool */

--- a/htscodecs/rANS_byte.h
+++ b/htscodecs/rANS_byte.h
@@ -441,8 +441,8 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr) {
     uint8_t  *ptr = *pptr;
 
     __asm__ ("movzbl (%0), %%eax\n\t"
-	     "mov    %1, %%edx\n\t"
-	     "shl    $0x8,%%edx\n\t"
+             "mov    %1, %%edx\n\t"
+             "shl    $0x8,%%edx\n\t"
              "or     %%eax,%%edx\n\t"
              "cmp    $0x800000,%1\n\t"
              "cmovb  %%edx,%1\n\t"
@@ -545,7 +545,7 @@ static inline void RansDecRenormSafe(RansState* r, uint8_t** pptr, uint8_t *ptr_
     if (x >= RANS_BYTE_L || ptr >= ptr_end) return;
     x = (x << 8) | *ptr++;
     if (x < RANS_BYTE_L && ptr < ptr_end)
-	x = (x << 8) | *ptr++;
+        x = (x << 8) | *ptr++;
     *pptr = ptr;
     *r = x;
 }

--- a/htscodecs/rANS_static.c
+++ b/htscodecs/rANS_static.c
@@ -73,7 +73,7 @@
 
 static
 unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
-				unsigned int *out_size) {
+                                unsigned int *out_size) {
     unsigned char *out_buf = malloc(1.05*in_size + 257*257*3 + 9);
     unsigned char *cp, *out_end;
     RansEncSymbol syms[256];
@@ -87,7 +87,7 @@ unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
     uint64_t tr;
 
     if (!out_buf)
-	return NULL;
+        return NULL;
 
     ptr = out_end = out_buf + (int)(1.05*in_size) + 257*257*3 + 9;
 
@@ -98,25 +98,25 @@ unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
  normalise_harder:
     // Normalise so T[i] == TOTFREQ
     for (fsum = m = M = j = 0; j < 256; j++) {
-	if (!F[j])
-	    continue;
+        if (!F[j])
+            continue;
 
-	if (m < F[j])
-	    m = F[j], M = j;
+        if (m < F[j])
+            m = F[j], M = j;
 
-	if ((F[j] = (F[j]*tr)>>31) == 0)
-	    F[j] = 1;
-	fsum += F[j];
+        if ((F[j] = (F[j]*tr)>>31) == 0)
+            F[j] = 1;
+        fsum += F[j];
     }
 
     fsum++;
     if (fsum < TOTFREQ) {
-	F[M] += TOTFREQ-fsum;
+        F[M] += TOTFREQ-fsum;
     } else if (fsum-TOTFREQ > F[M]/2) {
-	// Corner case to avoid excessive frequency reduction
-	tr = 2104533975; goto normalise_harder; // equiv to *0.98.
+        // Corner case to avoid excessive frequency reduction
+        tr = 2104533975; goto normalise_harder; // equiv to *0.98.
     } else {
-	F[M] -= fsum-TOTFREQ;
+        F[M] -= fsum-TOTFREQ;
     }
 
     //printf("F[%d]=%d\n", M, F[M]);
@@ -126,31 +126,31 @@ unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
     cp = out_buf+9;
 
     for (x = rle = j = 0; j < 256; j++) {
-	if (F[j]) {
-	    // j
-	    if (rle) {
-		rle--;
-	    } else {
-		*cp++ = j;
-		if (!rle && j && F[j-1])  {
-		    for(rle=j+1; rle<256 && F[rle]; rle++)
-			;
-		    rle -= j+1;
-		    *cp++ = rle;
-		}
-		//fprintf(stderr, "%d: %d %d\n", j, rle, N[j]);
-	    }
-	    
-	    // F[j]
-	    if (F[j]<128) {
-		*cp++ = F[j];
-	    } else {
-		*cp++ = 128 | (F[j]>>8);
-		*cp++ = F[j]&0xff;
-	    }
-	    RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
-	    x += F[j];
-	}
+        if (F[j]) {
+            // j
+            if (rle) {
+                rle--;
+            } else {
+                *cp++ = j;
+                if (!rle && j && F[j-1])  {
+                    for(rle=j+1; rle<256 && F[rle]; rle++)
+                        ;
+                    rle -= j+1;
+                    *cp++ = rle;
+                }
+                //fprintf(stderr, "%d: %d %d\n", j, rle, N[j]);
+            }
+            
+            // F[j]
+            if (F[j]<128) {
+                *cp++ = F[j];
+            } else {
+                *cp++ = 128 | (F[j]>>8);
+                *cp++ = F[j]&0xff;
+            }
+            RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
+            x += F[j];
+        }
     }
     *cp++ = 0;
 
@@ -167,18 +167,18 @@ unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
     case 2: RansEncPutSymbol(&rans1, &ptr, &syms[in[in_size-(i-1)]]);
     case 1: RansEncPutSymbol(&rans0, &ptr, &syms[in[in_size-(i-0)]]);
     case 0:
-	break;
+        break;
     }
     for (i=(in_size &~3); i>0; i-=4) {
-	RansEncSymbol *s3 = &syms[in[i-1]];
-	RansEncSymbol *s2 = &syms[in[i-2]];
-	RansEncSymbol *s1 = &syms[in[i-3]];
-	RansEncSymbol *s0 = &syms[in[i-4]];
+        RansEncSymbol *s3 = &syms[in[i-1]];
+        RansEncSymbol *s2 = &syms[in[i-2]];
+        RansEncSymbol *s1 = &syms[in[i-3]];
+        RansEncSymbol *s0 = &syms[in[i-4]];
 
-	RansEncPutSymbol(&rans3, &ptr, s3);
-	RansEncPutSymbol(&rans2, &ptr, s2);
-	RansEncPutSymbol(&rans1, &ptr, s1);
-	RansEncPutSymbol(&rans0, &ptr, s0);
+        RansEncPutSymbol(&rans3, &ptr, s3);
+        RansEncPutSymbol(&rans2, &ptr, s2);
+        RansEncPutSymbol(&rans1, &ptr, s1);
+        RansEncPutSymbol(&rans0, &ptr, s0);
     }
 
     RansEncFlush(&rans3, &ptr);
@@ -213,7 +213,7 @@ typedef struct {
 
 static
 unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
-				  unsigned int *out_size) {
+                                  unsigned int *out_size) {
     /* Load in the static tables */
     unsigned char *cp = in + 9;
     unsigned char *cp_end = in + in_size;
@@ -232,15 +232,15 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
         return NULL;
 
     if (*in++ != 0) // Order-0 check
-	return NULL;
+        return NULL;
     
     in_sz  = ((in[0])<<0) | ((in[1])<<8) | ((in[2])<<16) | (((uint32_t)in[3])<<24);
     out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | (((uint32_t)in[7])<<24);
     if (in_sz != in_size-9)
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
     // For speeding up the fuzzer only.
     // Small input can lead to large uncompressed data.
@@ -248,12 +248,12 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
     // paths (once we've verified a few times for large data).
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     out_buf = malloc(out_sz);
     if (!out_buf)
-	return NULL;
+        return NULL;
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
@@ -261,45 +261,45 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
     rle = x = y = 0;
     j = *cp++;
     do {
-	int F, C;
+        int F, C;
         if (cp > cp_end - 16) goto cleanup; // Not enough input bytes left
-	if ((F = *cp++) >= 128) {
-	    F &= ~128;
-	    F = ((F & 127) << 8) | *cp++;
-	}
-	C = x;
+        if ((F = *cp++) >= 128) {
+            F &= ~128;
+            F = ((F & 127) << 8) | *cp++;
+        }
+        C = x;
 
-	if (x + F > TOTFREQ)
-	    goto cleanup;
+        if (x + F > TOTFREQ)
+            goto cleanup;
 
         for (y = 0; y < F; y++) {
             ssym [y + C] = j;
             sfreq[y + C] = F;
             sbase[y + C] = y;
         }
-	x += F;
+        x += F;
 
-	if (!rle && j+1 == *cp) {
-	    j = *cp++;
-	    rle = *cp++;
-	} else if (rle) {
-	    rle--;
-	    j++;
-	    if (j > 255)
-		goto cleanup;
-	} else {
-	    j = *cp++;
-	}
+        if (!rle && j+1 == *cp) {
+            j = *cp++;
+            rle = *cp++;
+        } else if (rle) {
+            rle--;
+            j++;
+            if (j > 255)
+                goto cleanup;
+        } else {
+            j = *cp++;
+        }
     } while(j);
 
     if (x < TOTFREQ-1 || x > TOTFREQ)
-	goto cleanup;
+        goto cleanup;
     if (x != TOTFREQ) {
-	// Protection against accessing uninitialised memory in the case
-	// where SUM(freqs) == 4095 and not 4096.
-	ssym [x] = ssym [x-1];
-	sfreq[x] = sfreq[x-1];
-	sbase[x] = sbase[x-1]+1;
+        // Protection against accessing uninitialised memory in the case
+        // where SUM(freqs) == 4095 and not 4096.
+        ssym [x] = ssym [x-1];
+        sfreq[x] = sfreq[x-1];
+        sbase[x] = sbase[x-1]+1;
     }
 
     // 16 bytes of cp here. Also why cp - 16 in above loop.
@@ -313,31 +313,31 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
     int out_end = (out_sz&~3);
     cp_end -= 8; // within 8 for simplicity of loop below
     for (i=0; i < out_end; i+=4) {
-	m[0] = R[0] & mask;
+        m[0] = R[0] & mask;
         out_buf[i+0] = ssym[m[0]];
         R[0] = sfreq[m[0]] * (R[0] >> TF_SHIFT) + sbase[m[0]];
 
         m[1] = R[1] & mask;
-	out_buf[i+1] = ssym[m[1]];
+        out_buf[i+1] = ssym[m[1]];
         R[1] = sfreq[m[1]] * (R[1] >> TF_SHIFT) + sbase[m[1]];
 
         m[2] = R[2] & mask;
-	out_buf[i+2] = ssym[m[2]];
+        out_buf[i+2] = ssym[m[2]];
         R[2] = sfreq[m[2]] * (R[2] >> TF_SHIFT) + sbase[m[2]];
 
         m[3] = R[3] & mask;
-	out_buf[i+3] = ssym[m[3]];
+        out_buf[i+3] = ssym[m[3]];
         R[3] = sfreq[m[3]] * (R[3] >> TF_SHIFT) + sbase[m[3]];
 
-	if (cp < cp_end) {
-	    RansDecRenorm2(&R[0], &R[1], &cp);
-	    RansDecRenorm2(&R[2], &R[3], &cp);
-	} else {
-	    RansDecRenormSafe(&R[0], &cp, cp_end+8);
-	    RansDecRenormSafe(&R[1], &cp, cp_end+8);
-	    RansDecRenormSafe(&R[2], &cp, cp_end+8);
-	    RansDecRenormSafe(&R[3], &cp, cp_end+8);
-	}
+        if (cp < cp_end) {
+            RansDecRenorm2(&R[0], &R[1], &cp);
+            RansDecRenorm2(&R[2], &R[3], &cp);
+        } else {
+            RansDecRenormSafe(&R[0], &cp, cp_end+8);
+            RansDecRenormSafe(&R[1], &cp, cp_end+8);
+            RansDecRenormSafe(&R[2], &cp, cp_end+8);
+            RansDecRenormSafe(&R[3], &cp, cp_end+8);
+        }
     }
 
     switch(out_sz&3) {
@@ -361,20 +361,20 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
-				unsigned int *out_size) {
+                                unsigned int *out_size) {
     unsigned char *out_buf = NULL, *out_end, *cp;
     unsigned int tab_size, rle_i, rle_j;
 
 
     if (in_size < 4)
-	return rans_compress_O0(in, in_size, out_size);
+        return rans_compress_O0(in, in_size, out_size);
 
     int (*F)[256];
     RansEncSymbol (*syms)[256];
 
     uint8_t *mem = htscodecs_tls_alloc(256 * (sizeof(*syms) + sizeof(*F)));
     if (!mem)
-	return NULL;
+        return NULL;
     syms = (RansEncSymbol (*)[256])mem;
     F = (int (*)[256])(mem + 256*sizeof(*syms));
     memset(F, 0, 256*sizeof(*F));
@@ -399,87 +399,87 @@ unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
     
     // Normalise so T[i] == TOTFREQ
     for (rle_i = i = 0; i < 256; i++) {
-	int t2, m, M;
-	unsigned int x;
+        int t2, m, M;
+        unsigned int x;
 
-	if (T[i] == 0)
-	    continue;
+        if (T[i] == 0)
+            continue;
 
-	//uint64_t p = (TOTFREQ * TOTFREQ) / t;
-	double p = ((double)TOTFREQ)/T[i];
+        //uint64_t p = (TOTFREQ * TOTFREQ) / t;
+        double p = ((double)TOTFREQ)/T[i];
     normalise_harder:
-	for (t2 = m = M = j = 0; j < 256; j++) {
-	    if (!F[i][j])
-		continue;
+        for (t2 = m = M = j = 0; j < 256; j++) {
+            if (!F[i][j])
+                continue;
 
-	    if (m < F[i][j])
-		m = F[i][j], M = j;
+            if (m < F[i][j])
+                m = F[i][j], M = j;
 
-	    //if ((F[i][j] = (F[i][j] * p) / TOTFREQ) == 0)
-	    if ((F[i][j] *= p) == 0)
-		F[i][j] = 1;
-	    t2 += F[i][j];
-	}
+            //if ((F[i][j] = (F[i][j] * p) / TOTFREQ) == 0)
+            if ((F[i][j] *= p) == 0)
+                F[i][j] = 1;
+            t2 += F[i][j];
+        }
 
-	t2++;
-	if (t2 < TOTFREQ) {
-	    F[i][M] += TOTFREQ-t2;
-	} else if (t2-TOTFREQ >= F[i][M]/2) {
-	    // Corner case to avoid excessive frequency reduction
-	    p = .98; goto normalise_harder;
-	} else {
-	    F[i][M] -= t2-TOTFREQ;
-	}
+        t2++;
+        if (t2 < TOTFREQ) {
+            F[i][M] += TOTFREQ-t2;
+        } else if (t2-TOTFREQ >= F[i][M]/2) {
+            // Corner case to avoid excessive frequency reduction
+            p = .98; goto normalise_harder;
+        } else {
+            F[i][M] -= t2-TOTFREQ;
+        }
 
-	// Store frequency table
-	// i
-	if (rle_i) {
-	    rle_i--;
-	} else {
-	    *cp++ = i;
-	    // FIXME: could use order-0 statistics to observe which alphabet
-	    // symbols are present and base RLE on that ordering instead.
-	    if (i && T[i-1]) {
-		for(rle_i=i+1; rle_i<256 && T[rle_i]; rle_i++)
-		    ;
-		rle_i -= i+1;
-		*cp++ = rle_i;
-	    }
-	}
+        // Store frequency table
+        // i
+        if (rle_i) {
+            rle_i--;
+        } else {
+            *cp++ = i;
+            // FIXME: could use order-0 statistics to observe which alphabet
+            // symbols are present and base RLE on that ordering instead.
+            if (i && T[i-1]) {
+                for(rle_i=i+1; rle_i<256 && T[rle_i]; rle_i++)
+                    ;
+                rle_i -= i+1;
+                *cp++ = rle_i;
+            }
+        }
 
-	int *F_i_ = F[i];
-	x = 0;
-	rle_j = 0;
-	for (j = 0; j < 256; j++) {
-	    if (F_i_[j]) {
-		//fprintf(stderr, "F[%d][%d]=%d, x=%d\n", i, j, F_i_[j], x);
+        int *F_i_ = F[i];
+        x = 0;
+        rle_j = 0;
+        for (j = 0; j < 256; j++) {
+            if (F_i_[j]) {
+                //fprintf(stderr, "F[%d][%d]=%d, x=%d\n", i, j, F_i_[j], x);
 
-		// j
-		if (rle_j) {
-		    rle_j--;
-		} else {
-		    *cp++ = j;
-		    if (!rle_j && j && F_i_[j-1]) {
-			for(rle_j=j+1; rle_j<256 && F_i_[rle_j]; rle_j++)
-			    ;
-			rle_j -= j+1;
-			*cp++ = rle_j;
-		    }
-		}
+                // j
+                if (rle_j) {
+                    rle_j--;
+                } else {
+                    *cp++ = j;
+                    if (!rle_j && j && F_i_[j-1]) {
+                        for(rle_j=j+1; rle_j<256 && F_i_[rle_j]; rle_j++)
+                            ;
+                        rle_j -= j+1;
+                        *cp++ = rle_j;
+                    }
+                }
 
-		// F_i_[j]
-		if (F_i_[j]<128) {
- 		    *cp++ = F_i_[j];
-		} else {
-		    *cp++ = 128 | (F_i_[j]>>8);
-		    *cp++ = F_i_[j]&0xff;
-		}
+                // F_i_[j]
+                if (F_i_[j]<128) {
+                    *cp++ = F_i_[j];
+                } else {
+                    *cp++ = 128 | (F_i_[j]>>8);
+                    *cp++ = F_i_[j]&0xff;
+                }
 
-		RansEncSymbolInit(&syms[i][j], x, F_i_[j], TF_SHIFT);
-		x += F_i_[j];
-	    }
-	}
-	*cp++ = 0;
+                RansEncSymbolInit(&syms[i][j], x, F_i_[j], TF_SHIFT);
+                x += F_i_[j];
+            }
+        }
+        *cp++ = 0;
     }
     *cp++ = 0;
 
@@ -509,29 +509,29 @@ unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
     // Deal with the remainder
     l3 = in[in_size-1];
     for (i3 = in_size-2; i3 > 4*isz4-2; i3--) {
-	unsigned char c3 = in[i3];
-	RansEncPutSymbol(&rans3, &ptr, &syms[c3][l3]);
-	l3 = c3;
+        unsigned char c3 = in[i3];
+        RansEncPutSymbol(&rans3, &ptr, &syms[c3][l3]);
+        l3 = c3;
     }
 
     for (; i0 >= 0; i0--, i1--, i2--, i3--) {
-	unsigned char c3 = in[i3];
-	unsigned char c2 = in[i2];
-	unsigned char c1 = in[i1];
-	unsigned char c0 = in[i0];
+        unsigned char c3 = in[i3];
+        unsigned char c2 = in[i2];
+        unsigned char c1 = in[i1];
+        unsigned char c0 = in[i0];
 
-	RansEncSymbol *s3 = &syms[c3][l3];
-	RansEncSymbol *s2 = &syms[c2][l2];
-	RansEncSymbol *s1 = &syms[c1][l1];
-	RansEncSymbol *s0 = &syms[c0][l0];
+        RansEncSymbol *s3 = &syms[c3][l3];
+        RansEncSymbol *s2 = &syms[c2][l2];
+        RansEncSymbol *s1 = &syms[c1][l1];
+        RansEncSymbol *s0 = &syms[c0][l0];
 
-	RansEncPutSymbol4(&rans3, &rans2, &rans1, &rans0, &ptr,
-			  s3, s2, s1, s0);
+        RansEncPutSymbol4(&rans3, &rans2, &rans1, &rans0, &ptr,
+                          s3, s2, s1, s0);
 
-	l3 = c3;
-	l2 = c2;
-	l1 = c1;
-	l0 = c0;
+        l3 = c3;
+        l2 = c2;
+        l1 = c1;
+        l0 = c0;
     }
 
     RansEncPutSymbol(&rans3, &ptr, &syms[0][l3]);
@@ -569,7 +569,7 @@ unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
-				  unsigned int *out_size) {
+                                  unsigned int *out_size) {
     /* Load in the static tables */
     unsigned char *cp = in + 9;
     unsigned char *ptr_end = in + in_size;
@@ -583,15 +583,15 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
         return NULL;
 
     if (*in++ != 1) // Order-1 check
-	return NULL;
+        return NULL;
 
     in_sz  = ((in[0])<<0) | ((in[1])<<8) | ((in[2])<<16) | (((uint32_t)in[3])<<24);
     out_sz = ((in[4])<<0) | ((in[5])<<8) | ((in[6])<<16) | (((uint32_t)in[7])<<24);
     if (in_sz != in_size-9)
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
     // For speeding up the fuzzer only.
     // Small input can lead to large uncompressed data.
@@ -599,15 +599,15 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
     // paths (once we've verified a few times for large data).
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     // Allocate decoding lookup tables
     RansDecSymbol32 (*syms)[256];
     uint8_t *mem = htscodecs_tls_calloc(256, sizeof(ari_decoder)
-					+ sizeof(*syms));
+                                        + sizeof(*syms));
     if (!mem)
-	return NULL;
+        return NULL;
     ari_decoder *const D = (ari_decoder *)mem;
     syms = (RansDecSymbol32 (*)[256])(mem + 256*sizeof(ari_decoder));
     int16_t map[256], map_i = 0;
@@ -620,7 +620,7 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
        will end up in either row or column 0 of syms. */
     memset(&syms[0], 0, sizeof(syms[0]));
     for (i = 0; i < 256; i++)
-	memset(&syms[i][0], 0, sizeof(syms[0][0]));
+        memset(&syms[i][0], 0, sizeof(syms[0][0]));
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
@@ -628,73 +628,73 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
     rle_i = 0;
     i = *cp++;
     do {
-	// Map arbitrary a,b,c to 0,1,2 to improve cache locality.
-	if (map[i] == -1)
-	    map[i] = map_i++;
-	int m_i = map[i];
+        // Map arbitrary a,b,c to 0,1,2 to improve cache locality.
+        if (map[i] == -1)
+            map[i] = map_i++;
+        int m_i = map[i];
 
-	rle_j = x = 0;
-	j = *cp++;
-	do {
-	    if (map[j] == -1)
-		map[j] = map_i++;
+        rle_j = x = 0;
+        j = *cp++;
+        do {
+            if (map[j] == -1)
+                map[j] = map_i++;
 
-	    int F, C;
+            int F, C;
             if (cp > ptr_end - 16) goto cleanup; // Not enough input bytes left
-	    if ((F = *cp++) >= 128) {
-		F &= ~128;
-		F = ((F & 127) << 8) | *cp++;
-	    }
-	    C = x;
+            if ((F = *cp++) >= 128) {
+                F &= ~128;
+                F = ((F & 127) << 8) | *cp++;
+            }
+            C = x;
 
-	    //fprintf(stderr, "i=%d j=%d F=%d C=%d\n", i, j, F, C);
+            //fprintf(stderr, "i=%d j=%d F=%d C=%d\n", i, j, F, C);
 
-	    if (!F)
-		F = TOTFREQ;
+            if (!F)
+                F = TOTFREQ;
 
-	    RansDecSymbolInit32(&syms[m_i][j], C, F);
+            RansDecSymbolInit32(&syms[m_i][j], C, F);
 
-	    /* Build reverse lookup table */
-	    //if (!D[i].R) D[i].R = (unsigned char *)malloc(TOTFREQ);
-	    if (x + F > TOTFREQ)
-		goto cleanup;
+            /* Build reverse lookup table */
+            //if (!D[i].R) D[i].R = (unsigned char *)malloc(TOTFREQ);
+            if (x + F > TOTFREQ)
+                goto cleanup;
 
-	    memset(&D[m_i].R[x], j, F);
-	    x += F;
+            memset(&D[m_i].R[x], j, F);
+            x += F;
 
-	    if (!rle_j && j+1 == *cp) {
-		j = *cp++;
-		rle_j = *cp++;
-	    } else if (rle_j) {
-		rle_j--;
-		j++;
-		if (j > 255)
-		    goto cleanup;
-	    } else {
-		j = *cp++;
-	    }
-	} while(j);
+            if (!rle_j && j+1 == *cp) {
+                j = *cp++;
+                rle_j = *cp++;
+            } else if (rle_j) {
+                rle_j--;
+                j++;
+                if (j > 255)
+                    goto cleanup;
+            } else {
+                j = *cp++;
+            }
+        } while(j);
 
         if (x < TOTFREQ-1 || x > TOTFREQ)
             goto cleanup;
         if (x < TOTFREQ) // historically we fill 4095, not 4096
             D[i].R[x] = D[i].R[x-1];
 
-	if (!rle_i && i+1 == *cp) {
-	    i = *cp++;
-	    rle_i = *cp++;
-	} else if (rle_i) {
-	    rle_i--;
-	    i++;
-	    if (i > 255)
-		goto cleanup;
-	} else {
-	    i = *cp++;
-	}
+        if (!rle_i && i+1 == *cp) {
+            i = *cp++;
+            rle_i = *cp++;
+        } else if (rle_i) {
+            rle_i--;
+            i++;
+            if (i > 255)
+                goto cleanup;
+        } else {
+            i = *cp++;
+        }
     } while (i);
     for (i = 0; i < 256; i++)
-	if (map[i] == -1)
-	    map[i] = 0;
+        if (map[i] == -1)
+            map[i] = 0;
 
     RansState rans0, rans1, rans2, rans3;
     uint8_t *ptr = cp;
@@ -729,64 +729,64 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
 
     ptr_end -= 8;
     for (; i4[0] < isz4; i4[0]++, i4[1]++, i4[2]++, i4[3]++) {
-	out_buf[i4[0]] = cc0;
-	out_buf[i4[1]] = cc1;
-	out_buf[i4[2]] = cc2;
-	out_buf[i4[3]] = cc3;
+        out_buf[i4[0]] = cc0;
+        out_buf[i4[1]] = cc1;
+        out_buf[i4[2]] = cc2;
+        out_buf[i4[3]] = cc3;
 
-	//RansDecAdvanceStep(&R[0], syms[l0][cc0].start, syms[l0][cc0].freq, TF_SHIFT);
-	//RansDecAdvanceStep(&R[1], syms[l1][cc1].start, syms[l1][cc1].freq, TF_SHIFT);
-	//RansDecAdvanceStep(&R[2], syms[l2][cc2].start, syms[l2][cc2].freq, TF_vSHIFT);
-	//RansDecAdvanceStep(&R[3], syms[l3][cc3].start, syms[l3][cc3].freq, TF_SHIFT);
+        //RansDecAdvanceStep(&R[0], syms[l0][cc0].start, syms[l0][cc0].freq, TF_SHIFT);
+        //RansDecAdvanceStep(&R[1], syms[l1][cc1].start, syms[l1][cc1].freq, TF_SHIFT);
+        //RansDecAdvanceStep(&R[2], syms[l2][cc2].start, syms[l2][cc2].freq, TF_vSHIFT);
+        //RansDecAdvanceStep(&R[3], syms[l3][cc3].start, syms[l3][cc3].freq, TF_SHIFT);
 
-	{
-	    uint32_t m[4];
+        {
+            uint32_t m[4];
 
-	    // Ordering to try and improve OoO cpu instructions
-	    m[0] = R[0] & ((1u << TF_SHIFT)-1);
-	    R[0] = syms[l0][cc0].freq * (R[0]>>TF_SHIFT);
-	    m[1] = R[1] & ((1u << TF_SHIFT)-1);
-	    R[0] += m[0] - syms[l0][cc0].start;
-	    R[1] = syms[l1][cc1].freq * (R[1]>>TF_SHIFT);
-	    m[2] = R[2] & ((1u << TF_SHIFT)-1);
-	    R[1] += m[1] - syms[l1][cc1].start;
-	    R[2] = syms[l2][cc2].freq * (R[2]>>TF_SHIFT);
-	    m[3] = R[3] & ((1u << TF_SHIFT)-1);
-	    R[3] = syms[l3][cc3].freq * (R[3]>>TF_SHIFT);
-	    R[2] += m[2] - syms[l2][cc2].start;
-	    R[3] += m[3] - syms[l3][cc3].start;
-	}
+            // Ordering to try and improve OoO cpu instructions
+            m[0] = R[0] & ((1u << TF_SHIFT)-1);
+            R[0] = syms[l0][cc0].freq * (R[0]>>TF_SHIFT);
+            m[1] = R[1] & ((1u << TF_SHIFT)-1);
+            R[0] += m[0] - syms[l0][cc0].start;
+            R[1] = syms[l1][cc1].freq * (R[1]>>TF_SHIFT);
+            m[2] = R[2] & ((1u << TF_SHIFT)-1);
+            R[1] += m[1] - syms[l1][cc1].start;
+            R[2] = syms[l2][cc2].freq * (R[2]>>TF_SHIFT);
+            m[3] = R[3] & ((1u << TF_SHIFT)-1);
+            R[3] = syms[l3][cc3].freq * (R[3]>>TF_SHIFT);
+            R[2] += m[2] - syms[l2][cc2].start;
+            R[3] += m[3] - syms[l3][cc3].start;
+        }
 
-	l0 = map[cc0];
-	l1 = map[cc1];
-	l2 = map[cc2];
-	l3 = map[cc3];
+        l0 = map[cc0];
+        l1 = map[cc1];
+        l2 = map[cc2];
+        l3 = map[cc3];
 
-	if (ptr < ptr_end) {
-	    RansDecRenorm2(&R[0], &R[1], &ptr);
-	    RansDecRenorm2(&R[2], &R[3], &ptr);
-	} else {
-	    RansDecRenormSafe(&R[0], &ptr, ptr_end+8);
-	    RansDecRenormSafe(&R[1], &ptr, ptr_end+8);
-	    RansDecRenormSafe(&R[2], &ptr, ptr_end+8);
-	    RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
-	}
+        if (ptr < ptr_end) {
+            RansDecRenorm2(&R[0], &R[1], &ptr);
+            RansDecRenorm2(&R[2], &R[3], &ptr);
+        } else {
+            RansDecRenormSafe(&R[0], &ptr, ptr_end+8);
+            RansDecRenormSafe(&R[1], &ptr, ptr_end+8);
+            RansDecRenormSafe(&R[2], &ptr, ptr_end+8);
+            RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
+        }
 
-	cc0 = D[l0].R[R[0] & ((1u << TF_SHIFT)-1)];
-	cc1 = D[l1].R[R[1] & ((1u << TF_SHIFT)-1)];
-	cc2 = D[l2].R[R[2] & ((1u << TF_SHIFT)-1)];
-	cc3 = D[l3].R[R[3] & ((1u << TF_SHIFT)-1)];
+        cc0 = D[l0].R[R[0] & ((1u << TF_SHIFT)-1)];
+        cc1 = D[l1].R[R[1] & ((1u << TF_SHIFT)-1)];
+        cc2 = D[l2].R[R[2] & ((1u << TF_SHIFT)-1)];
+        cc3 = D[l3].R[R[3] & ((1u << TF_SHIFT)-1)];
     }
 
     // Remainder
     for (; i4[3] < out_sz; i4[3]++) {
-	unsigned char c3 = D[l3].R[RansDecGet(&R[3], TF_SHIFT)];
-	out_buf[i4[3]] = c3;
+        unsigned char c3 = D[l3].R[RansDecGet(&R[3], TF_SHIFT)];
+        out_buf[i4[3]] = c3;
 
-	uint32_t m = R[3] & ((1u << TF_SHIFT)-1);
-	R[3] = syms[l3][c3].freq * (R[3]>>TF_SHIFT) + m - syms[l3][c3].start;
-	RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
-	l3 = map[c3];
+        uint32_t m = R[3] & ((1u << TF_SHIFT)-1);
+        R[3] = syms[l3][c3].freq * (R[3]>>TF_SHIFT) + m - syms[l3][c3].start;
+        RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
+        l3 = map[c3];
     }
     
     *out_size = out_sz;
@@ -801,19 +801,19 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
  * Simple interface to the order-0 vs order-1 encoders and decoders.
  */
 unsigned char *rans_compress(unsigned char *in, unsigned int in_size,
-			     unsigned int *out_size, int order) {
+                             unsigned int *out_size, int order) {
     return order
-	? rans_compress_O1(in, in_size, out_size)
-	: rans_compress_O0(in, in_size, out_size);
+        ? rans_compress_O1(in, in_size, out_size)
+        : rans_compress_O0(in, in_size, out_size);
 }
 
 unsigned char *rans_uncompress(unsigned char *in, unsigned int in_size,
-			       unsigned int *out_size) {
+                               unsigned int *out_size) {
     /* Both rans_uncompress functions need to be able to read at least 9
        bytes. */
     if (in_size < 9)
         return NULL;
     return in[0]
-	? rans_uncompress_O1(in, in_size, out_size)
-	: rans_uncompress_O0(in, in_size, out_size);
+        ? rans_uncompress_O1(in, in_size, out_size)
+        : rans_uncompress_O0(in, in_size, out_size);
 }

--- a/htscodecs/rANS_static.h
+++ b/htscodecs/rANS_static.h
@@ -39,9 +39,9 @@ extern "C" {
 #endif
 
 unsigned char *rans_compress(unsigned char *in, unsigned int in_size,
-			     unsigned int *out_size, int order);
+                             unsigned int *out_size, int order);
 unsigned char *rans_uncompress(unsigned char *in, unsigned int in_size,
-			       unsigned int *out_size);
+                               unsigned int *out_size);
 
 #ifdef __cplusplus
 }

--- a/htscodecs/rANS_static16_int.h
+++ b/htscodecs/rANS_static16_int.h
@@ -74,9 +74,9 @@
 #define TOTFREQ_O1_FAST (1<<TF_SHIFT_O1_FAST)
 
 unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
-				     unsigned char *out, unsigned int *out_size);
+                                     unsigned char *out, unsigned int *out_size);
 unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
-				       unsigned char *out, unsigned int out_sz);
+                                       unsigned char *out, unsigned int out_sz);
 
 int rans_compute_shift(uint32_t *F0, uint32_t (*F)[256], uint32_t *T, int *S);
 
@@ -97,47 +97,47 @@ static inline int normalise_freq(uint32_t *F, int size, uint32_t tot) {
     int m, M, j, loop = 0;
     uint64_t tr;
     if (!size)
-	return 0;
+        return 0;
 
  again:
     tr = ((uint64_t)tot<<31)/size + (1<<30)/size;
 
     for (size = m = M = j = 0; j < 256; j++) {
-	if (!F[j])
-	    continue;
+        if (!F[j])
+            continue;
 
-	if (m < F[j])
-	    m = F[j], M = j;
+        if (m < F[j])
+            m = F[j], M = j;
 
-	if ((F[j] = (F[j]*tr)>>31) == 0)
-	    F[j] = 1;
-	size += F[j];
-//	if (F[j] == tot)
-//	    F[j]--;
+        if ((F[j] = (F[j]*tr)>>31) == 0)
+            F[j] = 1;
+        size += F[j];
+//      if (F[j] == tot)
+//          F[j]--;
     }
 
     int adjust = tot - size;
     if (adjust > 0) {
-	F[M] += adjust;
+        F[M] += adjust;
     } else if (adjust < 0) {
-	if (F[M] > -adjust && (loop == 1 || F[M]/2 >= -adjust)) {
-	    F[M] += adjust;
-	} else {
-	    if (loop < 1) {
-		loop++;
-		goto again;
-	    }
-	    adjust += F[M]-1;
-	    F[M] = 1;
-	    for (j = 0; adjust && j < 256; j++) {
-		if (F[j] < 2) continue;
+        if (F[M] > -adjust && (loop == 1 || F[M]/2 >= -adjust)) {
+            F[M] += adjust;
+        } else {
+            if (loop < 1) {
+                loop++;
+                goto again;
+            }
+            adjust += F[M]-1;
+            F[M] = 1;
+            for (j = 0; adjust && j < 256; j++) {
+                if (F[j] < 2) continue;
 
-		int d = F[j] > -adjust;
-		int m = d ? adjust : 1-F[j];
-		F[j]   += m;
-		adjust -= m;
-	    }
-	}
+                int d = F[j] > -adjust;
+                int m = d ? adjust : 1-F[j];
+                F[j]   += m;
+                adjust -= m;
+            }
+        }
     }
 
     //printf("F[%d]=%d\n", M, F[M]);
@@ -148,16 +148,16 @@ static inline int normalise_freq(uint32_t *F, int size, uint32_t tot) {
 // is already normalised to a power of 2, meaning we can just perform
 // shifts instead of hard to define multiplications and adjustments.
 static inline void normalise_freq_shift(uint32_t *F, uint32_t size,
-					uint32_t max_tot) {
+                                        uint32_t max_tot) {
     if (size == 0 || size == max_tot)
-	return;
+        return;
 
     int shift = 0, i;
     while (size < max_tot)
-	size*=2, shift++;
+        size*=2, shift++;
 
     for (i = 0; i < 256; i++)
-	F[i] <<= shift;
+        F[i] <<= shift;
 }
 
 // symbols only
@@ -166,21 +166,21 @@ static inline int encode_alphabet(uint8_t *cp, uint32_t *F) {
     int rle, j;
 
     for (rle = j = 0; j < 256; j++) {
-	if (F[j]) {
-	    // j
-	    if (rle) {
-		rle--;
-	    } else {
-		*cp++ = j;
-		if (!rle && j && F[j-1])  {
-		    for(rle=j+1; rle<256 && F[rle]; rle++)
-			;
-		    rle -= j+1;
-		    *cp++ = rle;
-		}
-		//fprintf(stderr, "%d: %d %d\n", j, rle, N[j]);
-	    }
-	}
+        if (F[j]) {
+            // j
+            if (rle) {
+                rle--;
+            } else {
+                *cp++ = j;
+                if (!rle && j && F[j-1])  {
+                    for(rle=j+1; rle<256 && F[rle]; rle++)
+                        ;
+                    rle -= j+1;
+                    *cp++ = rle;
+                }
+                //fprintf(stderr, "%d: %d %d\n", j, rle, N[j]);
+            }
+        }
     }
     *cp++ = 0;
     
@@ -189,48 +189,48 @@ static inline int encode_alphabet(uint8_t *cp, uint32_t *F) {
 
 static inline int decode_alphabet(uint8_t *cp, uint8_t *cp_end, uint32_t *F) {
     if (cp == cp_end)
-	return 0;
+        return 0;
 
     uint8_t *op = cp;
     int rle = 0;
     int j = *cp++;
     if (cp+2 >= cp_end)
-	goto carefully;
+        goto carefully;
 
     do {
-	F[j] = 1;
-	if (!rle && j+1 == *cp) {
-	    j = *cp++;
-	    rle = *cp++;
-	} else if (rle) {
-	    rle--;
-	    j++;
-	    if (j > 255)
-		return 0;
-	} else {
-	    j = *cp++;
-	}
+        F[j] = 1;
+        if (!rle && j+1 == *cp) {
+            j = *cp++;
+            rle = *cp++;
+        } else if (rle) {
+            rle--;
+            j++;
+            if (j > 255)
+                return 0;
+        } else {
+            j = *cp++;
+        }
     } while(j && cp+2 < cp_end);
 
  carefully:
     if (j) {
-	do {
-	    F[j] = 1;
-	    if(cp >= cp_end) return 0;
-	    if (!rle && j+1 == *cp) {
-		if (cp+1 >= cp_end) return 0;
-		j = *cp++;
-		rle = *cp++;
-	    } else if (rle) {
-		rle--;
-		j++;
-		if (j > 255)
-		    return 0;
-	    } else {
-		if (cp >= cp_end) return 0;
-		j = *cp++;
-	    }
-	} while(j && cp < cp_end);
+        do {
+            F[j] = 1;
+            if(cp >= cp_end) return 0;
+            if (!rle && j+1 == *cp) {
+                if (cp+1 >= cp_end) return 0;
+                j = *cp++;
+                rle = *cp++;
+            } else if (rle) {
+                rle--;
+                j++;
+                if (j > 255)
+                    return 0;
+            } else {
+                if (cp >= cp_end) return 0;
+                j = *cp++;
+            }
+        } while(j && cp < cp_end);
     }
 
     return cp - op;
@@ -243,27 +243,27 @@ static inline int encode_freq(uint8_t *cp, uint32_t *F) {
     cp += encode_alphabet(cp, F);
 
     for (j = 0; j < 256; j++) {
-	if (F[j])
-	    cp += var_put_u32(cp, NULL, F[j]);
+        if (F[j])
+            cp += var_put_u32(cp, NULL, F[j]);
     }
 
     return cp - op;
 }
 
 static inline int decode_freq(uint8_t *cp, uint8_t *cp_end, uint32_t *F,
-			      uint32_t *fsum) {
+                              uint32_t *fsum) {
     if (cp == cp_end)
-	return 0;
+        return 0;
 
     uint8_t *op = cp;
     cp += decode_alphabet(cp, cp_end, F);
 
     int j, tot = 0;
     for (j = 0; j < 256; j++) {
-	if (F[j]) {
-	    cp += var_get_u32(cp, cp_end, (unsigned int *)&F[j]);
-	    tot += F[j];
-	}
+        if (F[j]) {
+            cp += var_get_u32(cp, cp_end, (unsigned int *)&F[j]);
+            tot += F[j];
+        }
     }
 
     *fsum = tot;
@@ -279,28 +279,28 @@ static inline int encode_freq_d(uint8_t *cp, uint32_t *F0, uint32_t *F) {
     int j, dz;
 
     for (dz = j = 0; j < 256; j++) {
-	if (F0[j]) {
-	    if (F[j] != 0) {
-		if (dz) {
-		    // Replace dz zeros with zero + dz-1 run length
-		    cp -= dz-1;
-		    *cp++ = dz-1;
-		}
-		dz = 0;
-		cp += var_put_u32(cp, NULL, F[j]);
-	    } else {
-		//fprintf(stderr, "2: j=%d F0[j]=%d, F[j]=%d, dz=%d\n", j, F0[j], F[j], dz);
-		dz++;
-		*cp++ = 0;
-	    }
-	} else {
-	    assert(F[j] == 0);
-	}
+        if (F0[j]) {
+            if (F[j] != 0) {
+                if (dz) {
+                    // Replace dz zeros with zero + dz-1 run length
+                    cp -= dz-1;
+                    *cp++ = dz-1;
+                }
+                dz = 0;
+                cp += var_put_u32(cp, NULL, F[j]);
+            } else {
+                //fprintf(stderr, "2: j=%d F0[j]=%d, F[j]=%d, dz=%d\n", j, F0[j], F[j], dz);
+                dz++;
+                *cp++ = 0;
+            }
+        } else {
+            assert(F[j] == 0);
+        }
     }
     
     if (dz) {
-	cp -= dz-1;
-	*cp++ = dz-1;
+        cp -= dz-1;
+        *cp++ = dz-1;
     }
 
     return cp - op;
@@ -311,19 +311,19 @@ static inline int encode_freq_d(uint8_t *cp, uint32_t *F0, uint32_t *F) {
 //
 // Returns the desired TF_SHIFT; 10 or 12 bit, or -1 on error.
 static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
-			       RansEncSymbol syms[256][256], uint8_t **cp_p) {
+                               RansEncSymbol syms[256][256], uint8_t **cp_p) {
     int tab_size = 0, i, j, z;
     uint8_t *out = *cp_p, *cp = out;
 
     // Compute O1 frequency statistics
     uint32_t (*F)[256] = htscodecs_tls_calloc(256, (sizeof(*F)));
     if (!F)
-	return -1;
+        return -1;
     uint32_t T[256+MAGIC] = {0};
     int isz4 = in_size/Nway;
     hist1_4(in, in_size, F, T);
     for (z = 1; z < Nway; z++)
-	F[0][in[z*isz4]]++;
+        F[0][in[z*isz4]]++;
     T[0]+=Nway-1;
 
     // Potential fix for the wrap-around bug in AVX2 O1 encoder with shift=12.
@@ -332,25 +332,25 @@ static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
     // See "if (1)" statements in the AVX2 code, which is an alternative
     // to the "if (0)" here.
 //    if (0) {
-//	int x = -1, y = -1;
-//	int n1, n2;
-//	for (x = 0; x < 256; x++) {
-//	    n1 = n2 = -1;
-//	    for (y = 0; y < 256; y++) {
-//		if (F[x][y])
-//		    n2 = n1, n1 = y;
-//	    }
-//	    if (n2!=-1 || n1 == -1)
-//		continue;
+//      int x = -1, y = -1;
+//      int n1, n2;
+//      for (x = 0; x < 256; x++) {
+//          n1 = n2 = -1;
+//          for (y = 0; y < 256; y++) {
+//              if (F[x][y])
+//                  n2 = n1, n1 = y;
+//          }
+//          if (n2!=-1 || n1 == -1)
+//              continue;
 //
-//	    for (y = 0; y < 256; y++)
-//		if (!F[x][y])
-//		    break;
-//	    assert(y<256);
-//	    F[x][y]++;
-//	    F[0][y]++; T[y]++; F0[y]=1;
-//	    F[0][x]++; T[x]++; F0[x]=1;
-//	}
+//          for (y = 0; y < 256; y++)
+//              if (!F[x][y])
+//                  break;
+//          assert(y<256);
+//          F[x][y]++;
+//          F[0][y]++; T[y]++; F0[y]=1;
+//          F[0][x]++; T[x]++; F0[x]=1;
+//      }
 //    }
 
     // Encode the order-0 stats
@@ -367,48 +367,48 @@ static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
 
     // Normalise so T[i] == TOTFREQ_O1
     for (i = 0; i < 256; i++) {
-	unsigned int x;
+        unsigned int x;
 
-	if (T[i] == 0)
-	    continue;
+        if (T[i] == 0)
+            continue;
 
-	int max_val = S[i];
-	if (shift == TF_SHIFT_O1_FAST && max_val > TOTFREQ_O1_FAST)
-	    max_val = TOTFREQ_O1_FAST;
+        int max_val = S[i];
+        if (shift == TF_SHIFT_O1_FAST && max_val > TOTFREQ_O1_FAST)
+            max_val = TOTFREQ_O1_FAST;
 
-	if (normalise_freq(F[i], T[i], max_val) < 0)
-	    goto err;
-	T[i]=max_val;
+        if (normalise_freq(F[i], T[i], max_val) < 0)
+            goto err;
+        T[i]=max_val;
 
-	// Encode our frequency array
-	cp += encode_freq_d(cp, T, F[i]);
+        // Encode our frequency array
+        cp += encode_freq_d(cp, T, F[i]);
 
-	normalise_freq_shift(F[i], T[i], 1<<shift); T[i]=1<<shift;
+        normalise_freq_shift(F[i], T[i], 1<<shift); T[i]=1<<shift;
 
-	// Initialise Rans Symbol struct too.
-	uint32_t *F_i_ = F[i];
-	for (x = j = 0; j < 256; j++) {
-	    RansEncSymbolInit(&syms[i][j], x, F_i_[j], shift);
-	    x += F_i_[j];
-	}
+        // Initialise Rans Symbol struct too.
+        uint32_t *F_i_ = F[i];
+        for (x = j = 0; j < 256; j++) {
+            RansEncSymbolInit(&syms[i][j], x, F_i_[j], shift);
+            x += F_i_[j];
+        }
     }
 
     *out = shift<<4;
     if (cp - out > 1000) {
-	uint8_t *op = out;
-	// try rans0 compression of header
-	unsigned int u_freq_sz = cp-(op+1);
-	unsigned int c_freq_sz;
-	unsigned char *c_freq = rans_compress_O0_4x16(op+1, u_freq_sz, NULL,
-						      &c_freq_sz);
-	if (c_freq && c_freq_sz + 6 < cp-op) {
-	    *op++ |= 1; // compressed
-	    op += var_put_u32(op, NULL, u_freq_sz);
-	    op += var_put_u32(op, NULL, c_freq_sz);
-	    memcpy(op, c_freq, c_freq_sz);
-	    cp = op+c_freq_sz;
-	}
-	free(c_freq);
+        uint8_t *op = out;
+        // try rans0 compression of header
+        unsigned int u_freq_sz = cp-(op+1);
+        unsigned int c_freq_sz;
+        unsigned char *c_freq = rans_compress_O0_4x16(op+1, u_freq_sz, NULL,
+                                                      &c_freq_sz);
+        if (c_freq && c_freq_sz + 6 < cp-op) {
+            *op++ |= 1; // compressed
+            op += var_put_u32(op, NULL, u_freq_sz);
+            op += var_put_u32(op, NULL, c_freq_sz);
+            memcpy(op, c_freq, c_freq_sz);
+            cp = op+c_freq_sz;
+        }
+        free(c_freq);
     }
 
     tab_size = cp - out;
@@ -426,32 +426,32 @@ static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
 // Part of decode_freq1 below.  This decodes an order-1 frequency table
 // using an order-0 table to determine which stats may be stored.
 static inline int decode_freq_d(uint8_t *cp, uint8_t *cp_end, uint32_t *F0,
-				uint32_t *F, uint32_t *total) {
+                                uint32_t *F, uint32_t *total) {
     if (cp == cp_end)
-	return 0;
+        return 0;
 
     uint8_t *op = cp;
     int j, dz, T = 0;
 
     for (j = dz = 0; j < 256 && cp < cp_end; j++) {
-	//if (F0[j]) fprintf(stderr, "F0[%d]=%d\n", j, F0[j]);
-	if (!F0[j])
-	    continue;
+        //if (F0[j]) fprintf(stderr, "F0[%d]=%d\n", j, F0[j]);
+        if (!F0[j])
+            continue;
 
-	uint32_t f;
-	if (dz) {
-	    f = 0;
-	    dz--;
-	} else {
-	    if (cp >= cp_end) return 0;
-	    cp += var_get_u32(cp, cp_end, &f);
-	    if (f == 0) {
-		if (cp >= cp_end) return 0;
-		dz = *cp++;
-	    }
-	}
-	F[j] = f;
-	T += f;
+        uint32_t f;
+        if (dz) {
+            f = 0;
+            dz--;
+        } else {
+            if (cp >= cp_end) return 0;
+            cp += var_get_u32(cp, cp_end, &f);
+            if (f == 0) {
+                if (cp >= cp_end) return 0;
+                dz = *cp++;
+            }
+        }
+        F[j] = f;
+        T += f;
     }
 
     if (total) *total = T;
@@ -469,19 +469,19 @@ typedef struct {
 //
 // Returns the number of bytes decoded.
 static inline int decode_freq1(uint8_t *cp, uint8_t *cp_end, int shift,
-			       uint32_t s3 [256][TOTFREQ_O1],
-			       uint32_t s3F[256][TOTFREQ_O1_FAST],
-			       uint8_t *sfb[256], fb_t fb[256][256]) {
+                               uint32_t s3 [256][TOTFREQ_O1],
+                               uint32_t s3F[256][TOTFREQ_O1_FAST],
+                               uint8_t *sfb[256], fb_t fb[256][256]) {
     uint8_t *cp_start = cp;
     int i, j, x;
     uint32_t F0[256] = {0};
     int fsz = decode_alphabet(cp, cp_end, F0);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     if (cp >= cp_end)
-	goto err;
+        goto err;
 
     // silence false gcc warnings
     if (fb) {fb [0][0].b= 0;}
@@ -489,47 +489,47 @@ static inline int decode_freq1(uint8_t *cp, uint8_t *cp_end, int shift,
     if (s3F){s3F[0][0]  = 0;}
 
     for (i = 0; i < 256; i++) {
-	if (F0[i] == 0)
-	    continue;
+        if (F0[i] == 0)
+            continue;
 
-	uint32_t F[256] = {0}, T = 0;
-	fsz = decode_freq_d(cp, cp_end, F0, F, &T);
-	if (!fsz)
-	    goto err;
-	cp += fsz;
+        uint32_t F[256] = {0}, T = 0;
+        fsz = decode_freq_d(cp, cp_end, F0, F, &T);
+        if (!fsz)
+            goto err;
+        cp += fsz;
 
-	if (!T) {
-	    //fprintf(stderr, "No freq for F_%d\n", i);
-	    continue;
-	}
+        if (!T) {
+            //fprintf(stderr, "No freq for F_%d\n", i);
+            continue;
+        }
 
-	normalise_freq_shift(F, T, 1<<shift);
+        normalise_freq_shift(F, T, 1<<shift);
 
-	// Build symbols; fixme, do as part of decode, see the _d variant
-	for (j = x = 0; j < 256; j++) {
-	    if (F[j]) {
-		if (F[j] > (1<<shift) - x)
-		    goto err;
+        // Build symbols; fixme, do as part of decode, see the _d variant
+        for (j = x = 0; j < 256; j++) {
+            if (F[j]) {
+                if (F[j] > (1<<shift) - x)
+                    goto err;
 
-		if (sfb && shift == TF_SHIFT_O1) {
-		    memset(&sfb[i][x], j, F[j]);
-		    fb[i][j].f = F[j];
-		    fb[i][j].b = x;
-		} else if (s3 && shift == TF_SHIFT_O1) {
-		    int y;
-		    for (y = 0; y < F[j]; y++)
-			s3[i][y+x] = (((uint32_t)F[j])<<(shift+8)) |(y<<8) |j;
-		} else if (s3F && shift == TF_SHIFT_O1_FAST) {
-		    int y;
-		    for (y = 0; y < F[j]; y++)
-			s3F[i][y+x] = (((uint32_t)F[j])<<(shift+8)) |(y<<8) |j;
-		}
+                if (sfb && shift == TF_SHIFT_O1) {
+                    memset(&sfb[i][x], j, F[j]);
+                    fb[i][j].f = F[j];
+                    fb[i][j].b = x;
+                } else if (s3 && shift == TF_SHIFT_O1) {
+                    int y;
+                    for (y = 0; y < F[j]; y++)
+                        s3[i][y+x] = (((uint32_t)F[j])<<(shift+8)) |(y<<8) |j;
+                } else if (s3F && shift == TF_SHIFT_O1_FAST) {
+                    int y;
+                    for (y = 0; y < F[j]; y++)
+                        s3F[i][y+x] = (((uint32_t)F[j])<<(shift+8)) |(y<<8) |j;
+                }
 
-		x += F[j];
-	    }
-	}
-	if (x != (1<<shift))
-	    goto err;
+                x += F[j];
+            }
+        }
+        if (x != (1<<shift))
+            goto err;
     }
 
     return cp - cp_start;
@@ -543,13 +543,13 @@ static inline int decode_freq1(uint8_t *cp, uint8_t *cp_end, int shift,
 static inline int rans_F_to_s3(uint32_t *F, int shift, uint32_t *s3) {
     int j, x, y;
     for (j = x = 0; j < 256; j++) {
-	if (F[j]) {
-	    if (F[j] > (1<<shift) - x)
-		return 1;
-	    for (y = 0; y < F[j]; y++)
-		s3[y+x] = (((uint32_t)F[j])<<(shift+8))|(y<<8)|j;
-	    x += F[j];
-	}
+        if (F[j]) {
+            if (F[j] > (1<<shift) - x)
+                return 1;
+            for (y = 0; y < F[j]; y++)
+                s3[y+x] = (((uint32_t)F[j])<<(shift+8))|(y<<8)|j;
+            x += F[j];
+        }
     }
 
     return x == (1<<shift) ? 0 : 1;
@@ -569,72 +569,72 @@ static inline void rot32_simd(uint8_t t[32][32], uint8_t *out, int iN[32]) {
 
     __m256i lh8[32];
     for (z = 0; z < 32/2; z+=2) {
-	__m256i a, b, c, d;
-	a = _mm256_loadu_si256((__m256i *)&t[z*2+0]);
-	b = _mm256_loadu_si256((__m256i *)&t[z*2+1]);
-	c = _mm256_loadu_si256((__m256i *)&t[z*2+2]);
-	d = _mm256_loadu_si256((__m256i *)&t[z*2+3]);
+        __m256i a, b, c, d;
+        a = _mm256_loadu_si256((__m256i *)&t[z*2+0]);
+        b = _mm256_loadu_si256((__m256i *)&t[z*2+1]);
+        c = _mm256_loadu_si256((__m256i *)&t[z*2+2]);
+        d = _mm256_loadu_si256((__m256i *)&t[z*2+3]);
 
-	lh8[z+0]  = _mm256_unpacklo_epi8(a, b);
-	lh8[z+16] = _mm256_unpackhi_epi8(a, b);
-	lh8[z+1]  = _mm256_unpacklo_epi8(c, d);
-	lh8[z+17] = _mm256_unpackhi_epi8(c, d);
+        lh8[z+0]  = _mm256_unpacklo_epi8(a, b);
+        lh8[z+16] = _mm256_unpackhi_epi8(a, b);
+        lh8[z+1]  = _mm256_unpacklo_epi8(c, d);
+        lh8[z+17] = _mm256_unpackhi_epi8(c, d);
     }
 
     __m256i lh32[32];
     for (z = 0; z < 32/4; z+=2) {
-	__m256i a, b, c, d;
-	a = _mm256_unpacklo_epi16(lh8[z*4+0], lh8[z*4+1]);
-	b = _mm256_unpacklo_epi16(lh8[z*4+2], lh8[z*4+3]);
-	c = _mm256_unpackhi_epi16(lh8[z*4+0], lh8[z*4+1]);
-	d = _mm256_unpackhi_epi16(lh8[z*4+2], lh8[z*4+3]);
+        __m256i a, b, c, d;
+        a = _mm256_unpacklo_epi16(lh8[z*4+0], lh8[z*4+1]);
+        b = _mm256_unpacklo_epi16(lh8[z*4+2], lh8[z*4+3]);
+        c = _mm256_unpackhi_epi16(lh8[z*4+0], lh8[z*4+1]);
+        d = _mm256_unpackhi_epi16(lh8[z*4+2], lh8[z*4+3]);
 
-	__m256i e, f, g, h;
-	e = _mm256_unpacklo_epi16(lh8[(z+1)*4+0], lh8[(z+1)*4+1]);
-	f = _mm256_unpacklo_epi16(lh8[(z+1)*4+2], lh8[(z+1)*4+3]);
-	g = _mm256_unpackhi_epi16(lh8[(z+1)*4+0], lh8[(z+1)*4+1]);
-	h = _mm256_unpackhi_epi16(lh8[(z+1)*4+2], lh8[(z+1)*4+3]);
+        __m256i e, f, g, h;
+        e = _mm256_unpacklo_epi16(lh8[(z+1)*4+0], lh8[(z+1)*4+1]);
+        f = _mm256_unpacklo_epi16(lh8[(z+1)*4+2], lh8[(z+1)*4+3]);
+        g = _mm256_unpackhi_epi16(lh8[(z+1)*4+0], lh8[(z+1)*4+1]);
+        h = _mm256_unpackhi_epi16(lh8[(z+1)*4+2], lh8[(z+1)*4+3]);
 
-	lh32[z+0]  = _mm256_unpacklo_epi32(a,b);
-	lh32[z+8]  = _mm256_unpacklo_epi32(c,d);
-	lh32[z+16] = _mm256_unpackhi_epi32(a,b);
-	lh32[z+24] = _mm256_unpackhi_epi32(c,d);
+        lh32[z+0]  = _mm256_unpacklo_epi32(a,b);
+        lh32[z+8]  = _mm256_unpacklo_epi32(c,d);
+        lh32[z+16] = _mm256_unpackhi_epi32(a,b);
+        lh32[z+24] = _mm256_unpackhi_epi32(c,d);
 
-	lh32[z+1+0]  = _mm256_unpacklo_epi32(e,f);
-	lh32[z+1+8]  = _mm256_unpacklo_epi32(g,h);
-	lh32[z+1+16] = _mm256_unpackhi_epi32(e,f);
-	lh32[z+1+24] = _mm256_unpackhi_epi32(g,h);
+        lh32[z+1+0]  = _mm256_unpacklo_epi32(e,f);
+        lh32[z+1+8]  = _mm256_unpacklo_epi32(g,h);
+        lh32[z+1+16] = _mm256_unpackhi_epi32(e,f);
+        lh32[z+1+24] = _mm256_unpackhi_epi32(g,h);
     }
 
     // Final unpack 64 and store
     int idx[] = {0, 8, 4, 12, 2, 10, 6, 14};
     for (z = 0; z < 8; z++) {
-	int i = idx[z];
+        int i = idx[z];
 
-	// Putting this here doesn't soeed things up
-	__m256i a = _mm256_unpacklo_epi64(lh32[i*2+0], lh32[i*2+1]);
-	__m256i b = _mm256_unpacklo_epi64(lh32[i*2+2], lh32[i*2+3]);
-	__m256i c = _mm256_unpackhi_epi64(lh32[i*2+0], lh32[i*2+1]);
-	__m256i d = _mm256_unpackhi_epi64(lh32[i*2+2], lh32[i*2+3]);
+        // Putting this here doesn't soeed things up
+        __m256i a = _mm256_unpacklo_epi64(lh32[i*2+0], lh32[i*2+1]);
+        __m256i b = _mm256_unpacklo_epi64(lh32[i*2+2], lh32[i*2+3]);
+        __m256i c = _mm256_unpackhi_epi64(lh32[i*2+0], lh32[i*2+1]);
+        __m256i d = _mm256_unpackhi_epi64(lh32[i*2+2], lh32[i*2+3]);
 
-	__m256i p = _mm256_set_m128ix(_mm256_extracti128_si256(b,0),
-				      _mm256_extracti128_si256(a,0));
-	__m256i q = _mm256_set_m128ix(_mm256_extracti128_si256(d,0),
-				      _mm256_extracti128_si256(c,0));
-	__m256i r = _mm256_set_m128ix(_mm256_extracti128_si256(b,1),
-				      _mm256_extracti128_si256(a,1));
-	__m256i s = _mm256_set_m128ix(_mm256_extracti128_si256(d,1),
-				      _mm256_extracti128_si256(c,1));
+        __m256i p = _mm256_set_m128ix(_mm256_extracti128_si256(b,0),
+                                      _mm256_extracti128_si256(a,0));
+        __m256i q = _mm256_set_m128ix(_mm256_extracti128_si256(d,0),
+                                      _mm256_extracti128_si256(c,0));
+        __m256i r = _mm256_set_m128ix(_mm256_extracti128_si256(b,1),
+                                      _mm256_extracti128_si256(a,1));
+        __m256i s = _mm256_set_m128ix(_mm256_extracti128_si256(d,1),
+                                      _mm256_extracti128_si256(c,1));
 
-	_mm256_storeu_si256((__m256i *)(&out[iN[z*2+0]]),  p);
-	_mm256_storeu_si256((__m256i *)(&out[iN[z*2+1]]),  q);
-	_mm256_storeu_si256((__m256i *)(&out[iN[z*2+16]]), r);
-	_mm256_storeu_si256((__m256i *)(&out[iN[z*2+17]]), s);
+        _mm256_storeu_si256((__m256i *)(&out[iN[z*2+0]]),  p);
+        _mm256_storeu_si256((__m256i *)(&out[iN[z*2+1]]),  q);
+        _mm256_storeu_si256((__m256i *)(&out[iN[z*2+16]]), r);
+        _mm256_storeu_si256((__m256i *)(&out[iN[z*2+17]]), s);
     }
 
     // Store
     for (z = 0; z < 32; z++)
-	iN[z] += 32;
+        iN[z] += 32;
 }
 #endif
 

--- a/htscodecs/rANS_static32x16pr.c
+++ b/htscodecs/rANS_static32x16pr.c
@@ -69,9 +69,9 @@
 #define NX 32
 
 unsigned char *rans_compress_O0_32x16(unsigned char *in,
-				      unsigned int in_size,
-				      unsigned char *out,
-				      unsigned int *out_size) {
+                                      unsigned int in_size,
+                                      unsigned char *out,
+                                      unsigned int *out_size) {
     unsigned char *cp, *out_end, *out_free = NULL;
     RansEncSymbol syms[256];
     RansState ransN[NX];
@@ -82,20 +82,20 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
     unsigned int bound = rans_compress_bound_4x16(in_size,0)-20;
 
     if (!out) {
-	*out_size = bound;
-	out = out_free = malloc(*out_size);
+        *out_size = bound;
+        out = out_free = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     // If "out" isn't word aligned, tweak out_end/ptr to ensure it is.
     // We already added more round in bound to allow for this.
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     ptr = out_end = out + bound;
 
     if (in_size == 0)
-	goto empty;
+        goto empty;
 
     // Compute statistics
     double e = hist8e(in, in_size, F);
@@ -106,11 +106,11 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
     uint32_t fsum = in_size;
     uint32_t max_val = round2(fsum);
     if (max_val > TOTFREQ)
-	max_val = TOTFREQ;
+        max_val = TOTFREQ;
 
     if (normalise_freq(F, fsum, max_val) < 0) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
     fsum=max_val;
 
@@ -120,16 +120,16 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
     //write(2, out+4, cp-(out+4));
 
     if (normalise_freq(F, fsum, TOTFREQ) < 0) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     // Encode statistics.
     for (x = rle = j = 0; j < 256; j++) {
-	if (F[j]) {
-	    RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
-	    x += F[j];
-	}
+        if (F[j]) {
+            RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
+            x += F[j];
+        }
     }
 
     for (z = 0; z < NX; z++)
@@ -140,114 +140,114 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
       RansEncPutSymbol(&ransN[z], &ptr, &syms[in[in_size-(i-z)]]);
 
     if (low_ent) {
-	// orig
-	// gcc   446
-	// clang 427
-	for (i=(in_size &~(NX-1)); i>0; i-=NX) {
-	    for (z = NX-1; z >= 0; z-=4) {
-		RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
-		RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
-		RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
-		RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
-		RansEncPutSymbol_branched(&ransN[z-0], &ptr, s0);
-		RansEncPutSymbol_branched(&ransN[z-1], &ptr, s1);
-		RansEncPutSymbol_branched(&ransN[z-2], &ptr, s2);
-		RansEncPutSymbol_branched(&ransN[z-3], &ptr, s3);
-		if (NX%8 == 0) {
-		    z -= 4;
-		    RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
-		    RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
-		    RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
-		    RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
-		    RansEncPutSymbol_branched(&ransN[z-0], &ptr, s0);
-		    RansEncPutSymbol_branched(&ransN[z-1], &ptr, s1);
-		    RansEncPutSymbol_branched(&ransN[z-2], &ptr, s2);
-		    RansEncPutSymbol_branched(&ransN[z-3], &ptr, s3);
-		}
-	    }
-	    if (z < -1) abort();
-	}
+        // orig
+        // gcc   446
+        // clang 427
+        for (i=(in_size &~(NX-1)); i>0; i-=NX) {
+            for (z = NX-1; z >= 0; z-=4) {
+                RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
+                RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
+                RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
+                RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
+                RansEncPutSymbol_branched(&ransN[z-0], &ptr, s0);
+                RansEncPutSymbol_branched(&ransN[z-1], &ptr, s1);
+                RansEncPutSymbol_branched(&ransN[z-2], &ptr, s2);
+                RansEncPutSymbol_branched(&ransN[z-3], &ptr, s3);
+                if (NX%8 == 0) {
+                    z -= 4;
+                    RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
+                    RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
+                    RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
+                    RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
+                    RansEncPutSymbol_branched(&ransN[z-0], &ptr, s0);
+                    RansEncPutSymbol_branched(&ransN[z-1], &ptr, s1);
+                    RansEncPutSymbol_branched(&ransN[z-2], &ptr, s2);
+                    RansEncPutSymbol_branched(&ransN[z-3], &ptr, s3);
+                }
+            }
+            if (z < -1) abort();
+        }
     } else {
-	// Branchless version optimises poorly with gcc unless we have
- 	// AVX2 capability, so have a custom rewrite of it.
-	uint16_t* ptr16 = (uint16_t *)ptr;
-	for (i=(in_size &~(NX-1)); i>0; i-=NX) {
-	    // Unrolled copy of below, because gcc doesn't optimise this
-	    // well in the original form.
-	    //
-	    // Gcc11:   328 MB/s (this) vs 208 MB/s (orig)
-	    // Clang10: 352 MB/s (this) vs 340 MB/s (orig)
-	    //
-	    // for (z = NX-1; z >= 0; z-=4) {
-	    // 	RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
-	    // 	RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
-	    // 	RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
-	    // 	RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
-	    // 	RansEncPutSymbol(&ransN[z-0], &ptr, s0);
-	    // 	RansEncPutSymbol(&ransN[z-1], &ptr, s1);
-	    // 	RansEncPutSymbol(&ransN[z-2], &ptr, s2);
-	    // 	RansEncPutSymbol(&ransN[z-3], &ptr, s3);
-	    // }
+        // Branchless version optimises poorly with gcc unless we have
+        // AVX2 capability, so have a custom rewrite of it.
+        uint16_t* ptr16 = (uint16_t *)ptr;
+        for (i=(in_size &~(NX-1)); i>0; i-=NX) {
+            // Unrolled copy of below, because gcc doesn't optimise this
+            // well in the original form.
+            //
+            // Gcc11:   328 MB/s (this) vs 208 MB/s (orig)
+            // Clang10: 352 MB/s (this) vs 340 MB/s (orig)
+            //
+            // for (z = NX-1; z >= 0; z-=4) {
+            //  RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
+            //  RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
+            //  RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
+            //  RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
+            //  RansEncPutSymbol(&ransN[z-0], &ptr, s0);
+            //  RansEncPutSymbol(&ransN[z-1], &ptr, s1);
+            //  RansEncPutSymbol(&ransN[z-2], &ptr, s2);
+            //  RansEncPutSymbol(&ransN[z-3], &ptr, s3);
+            // }
 
-	    for (z = NX-1; z >= 0; z-=4) {
-		// RansEncPutSymbol added in-situ
-		RansState *rp = &ransN[z]-3;
-		RansEncSymbol *sy[4];
-		uint8_t *C = &in[i-(NX-z)]-3;
+            for (z = NX-1; z >= 0; z-=4) {
+                // RansEncPutSymbol added in-situ
+                RansState *rp = &ransN[z]-3;
+                RansEncSymbol *sy[4];
+                uint8_t *C = &in[i-(NX-z)]-3;
 
-		sy[0] = &syms[C[3]];
-		sy[1] = &syms[C[2]];
+                sy[0] = &syms[C[3]];
+                sy[1] = &syms[C[2]];
 
-		int c0  = rp[3-0] > sy[0]->x_max;
-		int c1  = rp[3-1] > sy[1]->x_max;
+                int c0  = rp[3-0] > sy[0]->x_max;
+                int c1  = rp[3-1] > sy[1]->x_max;
 
 #ifdef HTSCODECS_LITTLE_ENDIAN
-		ptr16[-1] = rp[3-0]; ptr16 -= c0;
-		ptr16[-1] = rp[3-1]; ptr16 -= c1;
+                ptr16[-1] = rp[3-0]; ptr16 -= c0;
+                ptr16[-1] = rp[3-1]; ptr16 -= c1;
 #else
-		((uint8_t *)&ptr16[-1])[0] = rp[3-0];
-		((uint8_t *)&ptr16[-1])[1] = rp[3-0]>>8;
-		ptr16 -= c0;
-		((uint8_t *)&ptr16[-1])[0] = rp[3-1];
-		((uint8_t *)&ptr16[-1])[1] = rp[3-1]>>8;
-		ptr16 -= c1;
+                ((uint8_t *)&ptr16[-1])[0] = rp[3-0];
+                ((uint8_t *)&ptr16[-1])[1] = rp[3-0]>>8;
+                ptr16 -= c0;
+                ((uint8_t *)&ptr16[-1])[0] = rp[3-1];
+                ((uint8_t *)&ptr16[-1])[1] = rp[3-1]>>8;
+                ptr16 -= c1;
 #endif
 
-		rp[3-0] >>= c0<<4;
-		rp[3-1] >>= c1<<4;
+                rp[3-0] >>= c0<<4;
+                rp[3-1] >>= c1<<4;
 
-		sy[2] = &syms[C[1]];
-		sy[3] = &syms[C[0]];
+                sy[2] = &syms[C[1]];
+                sy[3] = &syms[C[0]];
 
-		int c2  = rp[3-2] > sy[2]->x_max;
-		int c3  = rp[3-3] > sy[3]->x_max;
+                int c2  = rp[3-2] > sy[2]->x_max;
+                int c3  = rp[3-3] > sy[3]->x_max;
 #ifdef HTSCODECS_LITTLE_ENDIAN
-		ptr16[-1] = rp[3-2]; ptr16 -= c2;
-		ptr16[-1] = rp[3-3]; ptr16 -= c3;
+                ptr16[-1] = rp[3-2]; ptr16 -= c2;
+                ptr16[-1] = rp[3-3]; ptr16 -= c3;
 #else
-		((uint8_t *)&ptr16[-1])[0] = rp[3-0];
-		((uint8_t *)&ptr16[-1])[1] = rp[3-0]>>8;
-		ptr16 -= c2;
-		((uint8_t *)&ptr16[-1])[0] = rp[3-1];
-		((uint8_t *)&ptr16[-1])[1] = rp[3-1]>>8;
-		ptr16 -= c3;
+                ((uint8_t *)&ptr16[-1])[0] = rp[3-0];
+                ((uint8_t *)&ptr16[-1])[1] = rp[3-0]>>8;
+                ptr16 -= c2;
+                ((uint8_t *)&ptr16[-1])[0] = rp[3-1];
+                ((uint8_t *)&ptr16[-1])[1] = rp[3-1]>>8;
+                ptr16 -= c3;
 #endif
-		rp[3-2] >>= c2<<4;
-		rp[3-3] >>= c3<<4;
+                rp[3-2] >>= c2<<4;
+                rp[3-3] >>= c3<<4;
 
-		int k;
-		for (k = 0; k < 4; k++) {
-		    uint64_t r64 = (uint64_t)rp[3-k];
-		    uint32_t q = (r64 * sy[k]->rcp_freq) >> sy[k]->rcp_shift;
-		    rp[3-k] += sy[k]->bias + q*sy[k]->cmpl_freq;
-		}
-	    }
-	    if (z < -1) abort();
-	}
-	ptr = (uint8_t *)ptr16;
+                int k;
+                for (k = 0; k < 4; k++) {
+                    uint64_t r64 = (uint64_t)rp[3-k];
+                    uint32_t q = (r64 * sy[k]->rcp_freq) >> sy[k]->rcp_shift;
+                    rp[3-k] += sy[k]->bias + q*sy[k]->cmpl_freq;
+                }
+            }
+            if (z < -1) abort();
+        }
+        ptr = (uint8_t *)ptr16;
     }
     for (z = NX-1; z >= 0; z--)
-	RansEncFlush(&ransN[z], &ptr);
+        RansEncFlush(&ransN[z], &ptr);
 
  empty:
     // Finalise block size and return it
@@ -259,18 +259,18 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
 }
 
 unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
-					unsigned int in_size,
-					unsigned char *out,
-					unsigned int out_sz) {
+                                        unsigned int in_size,
+                                        unsigned char *out,
+                                        unsigned int out_sz) {
     if (in_size < 16) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -280,32 +280,32 @@ unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
     uint32_t s3[TOTFREQ]; // For TF_SHIFT <= 12
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     // Precompute reverse lookup of frequency.
     uint32_t F[256] = {0}, fsum;
     int fsz = decode_freq(cp, cp_end, F, &fsum);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     normalise_freq_shift(F, fsum, TOTFREQ);
 
     // Build symbols; fixme, do as part of decode, see the _d variant
     if (rans_F_to_s3(F, TF_SHIFT, s3))
-	goto err;
+        goto err;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     int z;
     RansState R[NX];
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &cp);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &cp);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     int out_end = (out_sz&~(NX-1));
@@ -315,78 +315,78 @@ unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
     // assume NX is divisible by 4
     assert(NX%4==0);
     for (i=0; i < out_end; i+=NX) {
-	for (z = 0; z < NX; z+=4) {
-	    uint32_t S[4];
-	    S[0] = s3[R[z+0] & mask];
-	    S[1] = s3[R[z+1] & mask];
-	    S[2] = s3[R[z+2] & mask];
-	    S[3] = s3[R[z+3] & mask];
+        for (z = 0; z < NX; z+=4) {
+            uint32_t S[4];
+            S[0] = s3[R[z+0] & mask];
+            S[1] = s3[R[z+1] & mask];
+            S[2] = s3[R[z+2] & mask];
+            S[3] = s3[R[z+3] & mask];
 
-	    R[z+0] = (S[0]>>(TF_SHIFT+8)) * (R[z+0] >> TF_SHIFT)
-		+ ((S[0]>>8) & mask);
-	    R[z+1] = (S[1]>>(TF_SHIFT+8)) * (R[z+1] >> TF_SHIFT)
-		+ ((S[1]>>8) & mask);
-	    R[z+2] = (S[2]>>(TF_SHIFT+8)) * (R[z+2] >> TF_SHIFT)
-		+ ((S[2]>>8) & mask);
-	    R[z+3] = (S[3]>>(TF_SHIFT+8)) * (R[z+3] >> TF_SHIFT)
-		+ ((S[3]>>8) & mask);
+            R[z+0] = (S[0]>>(TF_SHIFT+8)) * (R[z+0] >> TF_SHIFT)
+                + ((S[0]>>8) & mask);
+            R[z+1] = (S[1]>>(TF_SHIFT+8)) * (R[z+1] >> TF_SHIFT)
+                + ((S[1]>>8) & mask);
+            R[z+2] = (S[2]>>(TF_SHIFT+8)) * (R[z+2] >> TF_SHIFT)
+                + ((S[2]>>8) & mask);
+            R[z+3] = (S[3]>>(TF_SHIFT+8)) * (R[z+3] >> TF_SHIFT)
+                + ((S[3]>>8) & mask);
 
-	    out[i+z+0] = S[0];
-	    out[i+z+1] = S[1];
-	    out[i+z+2] = S[2];
-	    out[i+z+3] = S[3];
+            out[i+z+0] = S[0];
+            out[i+z+1] = S[1];
+            out[i+z+2] = S[2];
+            out[i+z+3] = S[3];
 
-	    if (cp < cp_end) {
-		// 6.8% (clang 13) performance hit, but safe.
-		// Plus we don't expect scalar version to be used much.
-		RansDecRenorm(&R[z+0], &cp);
-		RansDecRenorm(&R[z+1], &cp);
-		RansDecRenorm(&R[z+2], &cp);
-		RansDecRenorm(&R[z+3], &cp);
-	    } else {
-		RansDecRenormSafe(&R[z+0], &cp, cp_end+NX*2);
-		RansDecRenormSafe(&R[z+1], &cp, cp_end+NX*2);
-		RansDecRenormSafe(&R[z+2], &cp, cp_end+NX*2);
-		RansDecRenormSafe(&R[z+3], &cp, cp_end+NX*2);
-	    }
-	    if (NX%8==0) {
-		z += 4;
-		S[0] = s3[R[z+0] & mask];
-		S[1] = s3[R[z+1] & mask];
-		S[2] = s3[R[z+2] & mask];
-		S[3] = s3[R[z+3] & mask];
+            if (cp < cp_end) {
+                // 6.8% (clang 13) performance hit, but safe.
+                // Plus we don't expect scalar version to be used much.
+                RansDecRenorm(&R[z+0], &cp);
+                RansDecRenorm(&R[z+1], &cp);
+                RansDecRenorm(&R[z+2], &cp);
+                RansDecRenorm(&R[z+3], &cp);
+            } else {
+                RansDecRenormSafe(&R[z+0], &cp, cp_end+NX*2);
+                RansDecRenormSafe(&R[z+1], &cp, cp_end+NX*2);
+                RansDecRenormSafe(&R[z+2], &cp, cp_end+NX*2);
+                RansDecRenormSafe(&R[z+3], &cp, cp_end+NX*2);
+            }
+            if (NX%8==0) {
+                z += 4;
+                S[0] = s3[R[z+0] & mask];
+                S[1] = s3[R[z+1] & mask];
+                S[2] = s3[R[z+2] & mask];
+                S[3] = s3[R[z+3] & mask];
 
-		R[z+0] = (S[0]>>(TF_SHIFT+8)) * (R[z+0] >> TF_SHIFT)
-		    + ((S[0]>>8) & mask);
-		R[z+1] = (S[1]>>(TF_SHIFT+8)) * (R[z+1] >> TF_SHIFT)
-		    + ((S[1]>>8) & mask);
-		R[z+2] = (S[2]>>(TF_SHIFT+8)) * (R[z+2] >> TF_SHIFT)
-		    + ((S[2]>>8) & mask);
-		R[z+3] = (S[3]>>(TF_SHIFT+8)) * (R[z+3] >> TF_SHIFT)
-		    + ((S[3]>>8) & mask);
+                R[z+0] = (S[0]>>(TF_SHIFT+8)) * (R[z+0] >> TF_SHIFT)
+                    + ((S[0]>>8) & mask);
+                R[z+1] = (S[1]>>(TF_SHIFT+8)) * (R[z+1] >> TF_SHIFT)
+                    + ((S[1]>>8) & mask);
+                R[z+2] = (S[2]>>(TF_SHIFT+8)) * (R[z+2] >> TF_SHIFT)
+                    + ((S[2]>>8) & mask);
+                R[z+3] = (S[3]>>(TF_SHIFT+8)) * (R[z+3] >> TF_SHIFT)
+                    + ((S[3]>>8) & mask);
 
-		out[i+z+0] = S[0];
-		out[i+z+1] = S[1];
-		out[i+z+2] = S[2];
-		out[i+z+3] = S[3];
+                out[i+z+0] = S[0];
+                out[i+z+1] = S[1];
+                out[i+z+2] = S[2];
+                out[i+z+3] = S[3];
 
-		if (cp < cp_end) {
-		    RansDecRenorm(&R[z+0], &cp);
-		    RansDecRenorm(&R[z+1], &cp);
-		    RansDecRenorm(&R[z+2], &cp);
-		    RansDecRenorm(&R[z+3], &cp);
-		} else {
-		    RansDecRenormSafe(&R[z+0], &cp, cp_end+NX*2);
-		    RansDecRenormSafe(&R[z+1], &cp, cp_end+NX*2);
-		    RansDecRenormSafe(&R[z+2], &cp, cp_end+NX*2);
-		    RansDecRenormSafe(&R[z+3], &cp, cp_end+NX*2);
-		}
-	    }
-	}
+                if (cp < cp_end) {
+                    RansDecRenorm(&R[z+0], &cp);
+                    RansDecRenorm(&R[z+1], &cp);
+                    RansDecRenorm(&R[z+2], &cp);
+                    RansDecRenorm(&R[z+3], &cp);
+                } else {
+                    RansDecRenormSafe(&R[z+0], &cp, cp_end+NX*2);
+                    RansDecRenormSafe(&R[z+1], &cp, cp_end+NX*2);
+                    RansDecRenormSafe(&R[z+2], &cp, cp_end+NX*2);
+                    RansDecRenormSafe(&R[z+3], &cp, cp_end+NX*2);
+                }
+            }
+        }
     }
 
     for (z = out_sz & (NX-1); z-- > 0; )
-	out[out_end + z] = s3[R[z] & mask];
+        out[out_end + z] = s3[R[z] & mask];
 
     //fprintf(stderr, "    0 Decoded %d bytes\n", (int)(cp-in)); //c-size
 
@@ -400,40 +400,40 @@ unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
 
 //-----------------------------------------------------------------------------
 unsigned char *rans_compress_O1_32x16(unsigned char *in,
-				      unsigned int in_size,
-				      unsigned char *out,
-				      unsigned int *out_size) {
+                                      unsigned int in_size,
+                                      unsigned char *out,
+                                      unsigned int *out_size) {
     unsigned char *cp, *out_end, *out_free = NULL;
     unsigned int tab_size;
     int bound = rans_compress_bound_4x16(in_size,1)-20, z;
     RansState ransN[NX];
 
     if (in_size < NX) // force O0 instead
-	return NULL;
+        return NULL;
 
     if (!out) {
-	*out_size = bound;
-	out_free = out = malloc(*out_size);
+        *out_size = bound;
+        out_free = out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     out_end = out + bound;
 
     RansEncSymbol (*syms)[256] = htscodecs_tls_alloc(256 * (sizeof(*syms)));
     if (!syms) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     cp = out;
     int shift = encode_freq1(in, in_size, 32, syms, &cp); 
     if (shift < 0) {
-	free(out_free);
-	htscodecs_tls_free(syms);
-	return NULL;
+        free(out_free);
+        htscodecs_tls_free(syms);
+        return NULL;
     }
     tab_size = cp - out;
 
@@ -444,63 +444,63 @@ unsigned char *rans_compress_O1_32x16(unsigned char *in,
 
     int iN[NX], isz4 = in_size/NX, i;
     for (z = 0; z < NX; z++)
-	iN[z] = (z+1)*isz4-2;
+        iN[z] = (z+1)*isz4-2;
 
     unsigned char lN[NX];
     for (z = 0; z < NX; z++)
-	lN[z] = in[iN[z]+1];
+        lN[z] = in[iN[z]+1];
 
     // Deal with the remainder
     z = NX-1;
     lN[z] = in[in_size-1];
     for (iN[z] = in_size-2; iN[z] > NX*isz4-2; iN[z]--) {
-	unsigned char c = in[iN[z]];
-	RansEncPutSymbol(&ransN[z], &ptr, &syms[c][lN[z]]);
-	lN[z] = c;
+        unsigned char c = in[iN[z]];
+        RansEncPutSymbol(&ransN[z], &ptr, &syms[c][lN[z]]);
+        lN[z] = c;
     }
 
     unsigned char *i32[NX];
     for (i = 0; i < NX; i++)
-	i32[i] = &in[iN[i]];
+        i32[i] = &in[iN[i]];
 
     for (; i32[0] >= in; ) {
-	uint16_t *ptr16 = (uint16_t *)ptr;
-	for (z = NX-1; z >= 0; z-=4) {
-	    RansEncSymbol *sy[4];
-	    int k;
+        uint16_t *ptr16 = (uint16_t *)ptr;
+        for (z = NX-1; z >= 0; z-=4) {
+            RansEncSymbol *sy[4];
+            int k;
 
-	    for (k = 0; k < 4; k++) {
-		sy[k] = &syms[*i32[z-k]][lN[z-k]];
-		lN[z-k] = *i32[z-k]--;
-	    }
+            for (k = 0; k < 4; k++) {
+                sy[k] = &syms[*i32[z-k]][lN[z-k]];
+                lN[z-k] = *i32[z-k]--;
+            }
 
-	    // RansEncPutSymbol added in-situ
-	    for (k = 0; k < 4; k++) {
-		int c = ransN[z-k] > sy[k]->x_max;
+            // RansEncPutSymbol added in-situ
+            for (k = 0; k < 4; k++) {
+                int c = ransN[z-k] > sy[k]->x_max;
 #ifdef HTSCODECS_LITTLE_ENDIAN
-		ptr16[-1] = ransN[z-k];
+                ptr16[-1] = ransN[z-k];
 #else
-		((uint8_t *)&ptr16[-1])[0] = ransN[z-k];
-		((uint8_t *)&ptr16[-1])[1] = ransN[z-k]>>8;
+                ((uint8_t *)&ptr16[-1])[0] = ransN[z-k];
+                ((uint8_t *)&ptr16[-1])[1] = ransN[z-k]>>8;
 #endif
-		ptr16 -= c;
-		ransN[z-k] >>= c<<4;
-	    }
+                ptr16 -= c;
+                ransN[z-k] >>= c<<4;
+            }
 
-	    for (k = 0; k < 4; k++) {
-		uint64_t r64 = ransN[z-k];
-		uint32_t q = (r64 * sy[k]->rcp_freq) >> sy[k]->rcp_shift;
-		ransN[z-k] += sy[k]->bias + q*sy[k]->cmpl_freq;
-	    }
-	}
-	ptr = (uint8_t *)ptr16;
+            for (k = 0; k < 4; k++) {
+                uint64_t r64 = ransN[z-k];
+                uint32_t q = (r64 * sy[k]->rcp_freq) >> sy[k]->rcp_shift;
+                ransN[z-k] += sy[k]->bias + q*sy[k]->cmpl_freq;
+            }
+        }
+        ptr = (uint8_t *)ptr16;
     }
 
     for (z = NX-1; z>=0; z--)
-	RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
+        RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
 
     for (z = NX-1; z>=0; z--)
-	RansEncFlush(&ransN[z], &ptr);
+        RansEncFlush(&ransN[z], &ptr);
 
     *out_size = (out_end - ptr) + tab_size;
 
@@ -516,18 +516,18 @@ unsigned char *rans_compress_O1_32x16(unsigned char *in,
 //#define MAGIC2 0
 
 unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
-					unsigned int in_size,
-					unsigned char *out,
-					unsigned int out_sz) {
+                                        unsigned int in_size,
+                                        unsigned char *out,
+                                        unsigned int out_sz) {
     if (in_size < NX*4) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -536,29 +536,29 @@ unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
     int i;
 
     uint8_t *sfb_ = htscodecs_tls_alloc(256*
-					((TOTFREQ_O1+256)*sizeof(*sfb_)
-					 +TOTFREQ_O1_FAST * sizeof(uint32_t)
-					 +256 * sizeof(fb_t)));
+                                        ((TOTFREQ_O1+256)*sizeof(*sfb_)
+                                         +TOTFREQ_O1_FAST * sizeof(uint32_t)
+                                         +256 * sizeof(fb_t)));
     if (!sfb_)
-	return NULL;
+        return NULL;
     uint32_t (*s3)[TOTFREQ_O1_FAST] = (uint32_t (*)[TOTFREQ_O1_FAST])
-	(sfb_+(TOTFREQ_O1+256)*sizeof(*sfb_));
+        (sfb_+(TOTFREQ_O1+256)*sizeof(*sfb_));
     fb_t (*fb)[256] = (fb_t (*)[256])
-	((uint8_t *)s3 + 256*TOTFREQ_O1_FAST*sizeof(uint32_t));
+        ((uint8_t *)s3 + 256*TOTFREQ_O1_FAST*sizeof(uint32_t));
     uint8_t *sfb[256];
     if ((*cp >> 4) == TF_SHIFT_O1) {
-	for (i = 0; i < 256; i++)
-	    sfb[i]=  sfb_ + i*(TOTFREQ_O1+MAGIC2);
+        for (i = 0; i < 256; i++)
+            sfb[i]=  sfb_ + i*(TOTFREQ_O1+MAGIC2);
     } else {
-	for (i = 0; i < 256; i++)
-	    sfb[i]=  sfb_ + i*(TOTFREQ_O1_FAST+MAGIC2);
+        for (i = 0; i < 256; i++)
+            sfb[i]=  sfb_ + i*(TOTFREQ_O1_FAST+MAGIC2);
     }
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
 
     if (!out)
-	goto err;
+        goto err;
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
@@ -567,157 +567,157 @@ unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
     unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
-	uint32_t u_freq_sz, c_freq_sz;
-	cp += var_get_u32(cp, cp_end, &u_freq_sz);
-	cp += var_get_u32(cp, cp_end, &c_freq_sz);
-	if (c_freq_sz >= cp_end - cp - 16)
-	    goto err;
-	tab_end = cp + c_freq_sz;
-	if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL,u_freq_sz)))
-	    goto err;
-	cp = c_freq;
-	c_freq_end = c_freq + u_freq_sz;
+        uint32_t u_freq_sz, c_freq_sz;
+        cp += var_get_u32(cp, cp_end, &u_freq_sz);
+        cp += var_get_u32(cp, cp_end, &c_freq_sz);
+        if (c_freq_sz >= cp_end - cp - 16)
+            goto err;
+        tab_end = cp + c_freq_sz;
+        if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL,u_freq_sz)))
+            goto err;
+        cp = c_freq;
+        c_freq_end = c_freq + u_freq_sz;
     }
 
     // Decode order-0 symbol list; avoids needing in order-1 tables
     cp += decode_freq1(cp, c_freq_end, shift, NULL, s3, sfb, fb);
 
     if (tab_end)
-	cp = tab_end;
+        cp = tab_end;
     free(c_freq);
     c_freq = NULL;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     RansState R[NX];
     uint8_t *ptr = cp, *ptr_end = in + in_size - 2*NX;
     int z;
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &ptr);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &ptr);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     int isz4 = out_sz/NX;
     int i4[NX], l[NX] = {0};
     for (z = 0; z < NX; z++)
-	i4[z] = z*isz4;
+        i4[z] = z*isz4;
 
     // Around 15% faster to specialise for 10/12 than to have one
     // loop with shift as a variable.
     if (shift == TF_SHIFT_O1) {
-	// TF_SHIFT_O1 = 12
-	const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
-	for (; i4[0] < isz4;) {
-	    for (z = 0; z < NX; z+=4) {
-		uint16_t m[4], c[4];
+        // TF_SHIFT_O1 = 12
+        const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
+        for (; i4[0] < isz4;) {
+            for (z = 0; z < NX; z+=4) {
+                uint16_t m[4], c[4];
 
-		c[0] = sfb[l[z+0]][m[0] = R[z+0] & mask];
-		c[1] = sfb[l[z+1]][m[1] = R[z+1] & mask];
-		c[2] = sfb[l[z+2]][m[2] = R[z+2] & mask];
-		c[3] = sfb[l[z+3]][m[3] = R[z+3] & mask];
+                c[0] = sfb[l[z+0]][m[0] = R[z+0] & mask];
+                c[1] = sfb[l[z+1]][m[1] = R[z+1] & mask];
+                c[2] = sfb[l[z+2]][m[2] = R[z+2] & mask];
+                c[3] = sfb[l[z+3]][m[3] = R[z+3] & mask];
 
-		R[z+0] = fb[l[z+0]][c[0]].f * (R[z+0]>>TF_SHIFT_O1);
-		R[z+0] += m[0] - fb[l[z+0]][c[0]].b;
+                R[z+0] = fb[l[z+0]][c[0]].f * (R[z+0]>>TF_SHIFT_O1);
+                R[z+0] += m[0] - fb[l[z+0]][c[0]].b;
 
-		R[z+1] = fb[l[z+1]][c[1]].f * (R[z+1]>>TF_SHIFT_O1);
-		R[z+1] += m[1] - fb[l[z+1]][c[1]].b;
+                R[z+1] = fb[l[z+1]][c[1]].f * (R[z+1]>>TF_SHIFT_O1);
+                R[z+1] += m[1] - fb[l[z+1]][c[1]].b;
 
-		R[z+2] = fb[l[z+2]][c[2]].f * (R[z+2]>>TF_SHIFT_O1);
-		R[z+2] += m[2] - fb[l[z+2]][c[2]].b;
+                R[z+2] = fb[l[z+2]][c[2]].f * (R[z+2]>>TF_SHIFT_O1);
+                R[z+2] += m[2] - fb[l[z+2]][c[2]].b;
 
-		R[z+3] = fb[l[z+3]][c[3]].f * (R[z+3]>>TF_SHIFT_O1);
-		R[z+3] += m[3] - fb[l[z+3]][c[3]].b;
+                R[z+3] = fb[l[z+3]][c[3]].f * (R[z+3]>>TF_SHIFT_O1);
+                R[z+3] += m[3] - fb[l[z+3]][c[3]].b;
 
-		out[i4[z+0]++] = l[z+0] = c[0];
-		out[i4[z+1]++] = l[z+1] = c[1];
-		out[i4[z+2]++] = l[z+2] = c[2];
-		out[i4[z+3]++] = l[z+3] = c[3];
+                out[i4[z+0]++] = l[z+0] = c[0];
+                out[i4[z+1]++] = l[z+1] = c[1];
+                out[i4[z+2]++] = l[z+2] = c[2];
+                out[i4[z+3]++] = l[z+3] = c[3];
 
-		if (ptr < ptr_end) {
-		    RansDecRenorm(&R[z+0], &ptr);
-		    RansDecRenorm(&R[z+1], &ptr);
-		    RansDecRenorm(&R[z+2], &ptr);
-		    RansDecRenorm(&R[z+3], &ptr);
-		} else {
-		    RansDecRenormSafe(&R[z+0], &ptr, ptr_end+2*NX);
-		    RansDecRenormSafe(&R[z+1], &ptr, ptr_end+2*NX);
-		    RansDecRenormSafe(&R[z+2], &ptr, ptr_end+2*NX);
-		    RansDecRenormSafe(&R[z+3], &ptr, ptr_end+2*NX);
-		}
-	    }
-	}
+                if (ptr < ptr_end) {
+                    RansDecRenorm(&R[z+0], &ptr);
+                    RansDecRenorm(&R[z+1], &ptr);
+                    RansDecRenorm(&R[z+2], &ptr);
+                    RansDecRenorm(&R[z+3], &ptr);
+                } else {
+                    RansDecRenormSafe(&R[z+0], &ptr, ptr_end+2*NX);
+                    RansDecRenormSafe(&R[z+1], &ptr, ptr_end+2*NX);
+                    RansDecRenormSafe(&R[z+2], &ptr, ptr_end+2*NX);
+                    RansDecRenormSafe(&R[z+3], &ptr, ptr_end+2*NX);
+                }
+            }
+        }
 
-	// Remainder
-	for (; i4[NX-1] < out_sz; i4[NX-1]++) {
-	    uint32_t m = R[NX-1] & ((1u<<TF_SHIFT_O1)-1);
-	    unsigned char c = sfb[l[NX-1]][m];
-	    out[i4[NX-1]] = c;
-	    R[NX-1] = fb[l[NX-1]][c].f * (R[NX-1]>>TF_SHIFT_O1) +
-		m - fb[l[NX-1]][c].b;
-	    RansDecRenormSafe(&R[NX-1], &ptr, ptr_end + 2*NX);
-	    l[NX-1] = c;
-	}
+        // Remainder
+        for (; i4[NX-1] < out_sz; i4[NX-1]++) {
+            uint32_t m = R[NX-1] & ((1u<<TF_SHIFT_O1)-1);
+            unsigned char c = sfb[l[NX-1]][m];
+            out[i4[NX-1]] = c;
+            R[NX-1] = fb[l[NX-1]][c].f * (R[NX-1]>>TF_SHIFT_O1) +
+                m - fb[l[NX-1]][c].b;
+            RansDecRenormSafe(&R[NX-1], &ptr, ptr_end + 2*NX);
+            l[NX-1] = c;
+        }
     } else {
-	// TF_SHIFT_O1 = 10
-	const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
-	for (; i4[0] < isz4;) {
-	    for (z = 0; z < NX; z+=4) {
-		// Merged sfb and fb into single s3 lookup.
-		// The m[4] array completely vanishes in this method.
-		uint32_t S[4] = {
-		    s3[l[z+0]][R[z+0] & mask],
-		    s3[l[z+1]][R[z+1] & mask],
-		    s3[l[z+2]][R[z+2] & mask],
-		    s3[l[z+3]][R[z+3] & mask],
-		};
+        // TF_SHIFT_O1 = 10
+        const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
+        for (; i4[0] < isz4;) {
+            for (z = 0; z < NX; z+=4) {
+                // Merged sfb and fb into single s3 lookup.
+                // The m[4] array completely vanishes in this method.
+                uint32_t S[4] = {
+                    s3[l[z+0]][R[z+0] & mask],
+                    s3[l[z+1]][R[z+1] & mask],
+                    s3[l[z+2]][R[z+2] & mask],
+                    s3[l[z+3]][R[z+3] & mask],
+                };
 
-		l[z+0] = out[i4[z+0]++] = S[0];
-		l[z+1] = out[i4[z+1]++] = S[1];
-		l[z+2] = out[i4[z+2]++] = S[2];
-		l[z+3] = out[i4[z+3]++] = S[3];
+                l[z+0] = out[i4[z+0]++] = S[0];
+                l[z+1] = out[i4[z+1]++] = S[1];
+                l[z+2] = out[i4[z+2]++] = S[2];
+                l[z+3] = out[i4[z+3]++] = S[3];
 
-		uint32_t F[4] = {
-		    S[0]>>(TF_SHIFT_O1_FAST+8),
-		    S[1]>>(TF_SHIFT_O1_FAST+8),
-		    S[2]>>(TF_SHIFT_O1_FAST+8),
-		    S[3]>>(TF_SHIFT_O1_FAST+8),
-	        };
-		uint32_t B[4] = {
-		    (S[0]>>8) & mask,
-		    (S[1]>>8) & mask,
-		    (S[2]>>8) & mask,
-		    (S[3]>>8) & mask,
-	        };
+                uint32_t F[4] = {
+                    S[0]>>(TF_SHIFT_O1_FAST+8),
+                    S[1]>>(TF_SHIFT_O1_FAST+8),
+                    S[2]>>(TF_SHIFT_O1_FAST+8),
+                    S[3]>>(TF_SHIFT_O1_FAST+8),
+                };
+                uint32_t B[4] = {
+                    (S[0]>>8) & mask,
+                    (S[1]>>8) & mask,
+                    (S[2]>>8) & mask,
+                    (S[3]>>8) & mask,
+                };
 
-		R[z+0] = F[0] * (R[z+0]>>TF_SHIFT_O1_FAST) + B[0];
-		R[z+1] = F[1] * (R[z+1]>>TF_SHIFT_O1_FAST) + B[1];
-		R[z+2] = F[2] * (R[z+2]>>TF_SHIFT_O1_FAST) + B[2];
-		R[z+3] = F[3] * (R[z+3]>>TF_SHIFT_O1_FAST) + B[3];
+                R[z+0] = F[0] * (R[z+0]>>TF_SHIFT_O1_FAST) + B[0];
+                R[z+1] = F[1] * (R[z+1]>>TF_SHIFT_O1_FAST) + B[1];
+                R[z+2] = F[2] * (R[z+2]>>TF_SHIFT_O1_FAST) + B[2];
+                R[z+3] = F[3] * (R[z+3]>>TF_SHIFT_O1_FAST) + B[3];
 
-		if (ptr < ptr_end) {
-		    RansDecRenorm(&R[z+0], &ptr);
-		    RansDecRenorm(&R[z+1], &ptr);
-		    RansDecRenorm(&R[z+2], &ptr);
-		    RansDecRenorm(&R[z+3], &ptr);
-		} else {
-		    RansDecRenormSafe(&R[z+0], &ptr, ptr_end+2*NX);
-		    RansDecRenormSafe(&R[z+1], &ptr, ptr_end+2*NX);
-		    RansDecRenormSafe(&R[z+2], &ptr, ptr_end+2*NX);
-		    RansDecRenormSafe(&R[z+3], &ptr, ptr_end+2*NX);
-		}
-	    }
-	}
+                if (ptr < ptr_end) {
+                    RansDecRenorm(&R[z+0], &ptr);
+                    RansDecRenorm(&R[z+1], &ptr);
+                    RansDecRenorm(&R[z+2], &ptr);
+                    RansDecRenorm(&R[z+3], &ptr);
+                } else {
+                    RansDecRenormSafe(&R[z+0], &ptr, ptr_end+2*NX);
+                    RansDecRenormSafe(&R[z+1], &ptr, ptr_end+2*NX);
+                    RansDecRenormSafe(&R[z+2], &ptr, ptr_end+2*NX);
+                    RansDecRenormSafe(&R[z+3], &ptr, ptr_end+2*NX);
+                }
+            }
+        }
 
-	// Remainder
-	for (; i4[NX-1] < out_sz; i4[NX-1]++) {
-	    uint32_t S = s3[l[NX-1]][R[NX-1] & ((1u<<TF_SHIFT_O1_FAST)-1)];
-	    out[i4[NX-1]] = l[NX-1] = S&0xff;
-	    R[NX-1] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[NX-1]>>TF_SHIFT_O1_FAST)
-		+ ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-	    RansDecRenormSafe(&R[NX-1], &ptr, ptr_end + 2*NX);
-	}
+        // Remainder
+        for (; i4[NX-1] < out_sz; i4[NX-1]++) {
+            uint32_t S = s3[l[NX-1]][R[NX-1] & ((1u<<TF_SHIFT_O1_FAST)-1)];
+            out[i4[NX-1]] = l[NX-1] = S&0xff;
+            R[NX-1] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[NX-1]>>TF_SHIFT_O1_FAST)
+                + ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+            RansDecRenormSafe(&R[NX-1], &ptr, ptr_end + 2*NX);
+        }
     }
     //fprintf(stderr, "    1 Decoded %d bytes\n", (int)(ptr-in)); //c-size
 

--- a/htscodecs/rANS_static32x16pr.h
+++ b/htscodecs/rANS_static32x16pr.h
@@ -58,114 +58,114 @@ extern "C" {
 //----------------------------------------------------------------------
 // Standard scalar versions
 unsigned char *rans_compress_O0_32x16(unsigned char *in,
-				      unsigned int in_size,
-				      unsigned char *out,
-				      unsigned int *out_size);
+                                      unsigned int in_size,
+                                      unsigned char *out,
+                                      unsigned int *out_size);
 
 unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
-					unsigned int in_size,
-					unsigned char *out,
-					unsigned int out_sz);
+                                        unsigned int in_size,
+                                        unsigned char *out,
+                                        unsigned int out_sz);
 
 unsigned char *rans_compress_O1_32x16(unsigned char *in,
-				      unsigned int in_size,
-				      unsigned char *out,
-				      unsigned int *out_size);
+                                      unsigned int in_size,
+                                      unsigned char *out,
+                                      unsigned int *out_size);
 
 unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
-					unsigned int in_size,
-					unsigned char *out,
-					unsigned int out_sz);
+                                        unsigned int in_size,
+                                        unsigned char *out,
+                                        unsigned int out_sz);
 
 //----------------------------------------------------------------------
 // Intel SSE4 implementation.  Only the O0 decoder for now
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
 unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size);
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size);
 
 unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz);
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz);
 
 unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz);
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz);
 #endif
 
 //----------------------------------------------------------------------
 // Intel AVX2 implementation
 #ifdef HAVE_AVX2
 unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size);
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size);
 
 unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz);
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz);
 
 unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size);
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size);
 
 unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz);
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz);
 #endif // HAVE_AVX2
 
 //----------------------------------------------------------------------
 // Intel AVX512 implementation
 #ifdef HAVE_AVX512
 unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int *out_size);
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int *out_size);
 
 unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
-					       unsigned int in_size,
-					       unsigned char *out,
-					       unsigned int out_sz);
+                                               unsigned int in_size,
+                                               unsigned char *out,
+                                               unsigned int out_sz);
 
 unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int *out_size);
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int *out_size);
 
 unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
-					       unsigned int in_size,
-					       unsigned char *out,
-					       unsigned int out_sz);
+                                               unsigned int in_size,
+                                               unsigned char *out,
+                                               unsigned int out_sz);
 #endif // HAVE_AVX512
 
 //----------------------------------------------------------------------
 // Arm Neon implementation
 #ifdef __ARM_NEON
 unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size);
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size);
 
 unsigned char *rans_uncompress_O0_32x16_neon(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz);
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz);
 
 unsigned char *rans_compress_O1_32x16_neon(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size);
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size);
 
 unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz);
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz);
 #endif // ARM_NEON
 
 #ifdef __cplusplus

--- a/htscodecs/rANS_static32x16pr_avx2.c
+++ b/htscodecs/rANS_static32x16pr_avx2.c
@@ -99,7 +99,7 @@ static __m256i _mm256_mulhi_epu32(__m256i a, __m256i b) {
 
     //return _mm256_blend_epi32(ab_lm, ab_hm, 0xaa);
     ab_hm = _mm256_and_si256(ab_hm,
-			 _mm256_set1_epi64x((uint64_t)0xffffffff00000000));
+                         _mm256_set1_epi64x((uint64_t)0xffffffff00000000));
     ab_hm = _mm256_or_si256(ab_hm, ab_lm);
 
     return ab_hm;
@@ -108,14 +108,14 @@ static __m256i _mm256_mulhi_epu32(__m256i a, __m256i b) {
 static inline __m256i _mm256_mulhi_epu32(__m256i a, __m256i b) {
     // Multiply bottom 4 items and top 4 items together.
     __m256i ab_hm = _mm256_mul_epu32(_mm256_srli_epi64(a, 32),
-				     _mm256_srli_epi64(b, 32));
+                                     _mm256_srli_epi64(b, 32));
     __m256i ab_lm = _mm256_srli_epi64(_mm256_mul_epu32(a, b), 32);
 
     return _mm256_blend_epi32(ab_lm, ab_hm, 0xaa);
 //
 //    // Shift to get hi 32-bit of each 64-bit product
 //    ab_hm = _mm256_and_si256(ab_hm,
-//			 _mm256_set1_epi64x((uint64_t)0xffffffff00000000));
+//                       _mm256_set1_epi64x((uint64_t)0xffffffff00000000));
 //
 //    return _mm256_or_si256(ab_lm, ab_hm);
 }
@@ -127,16 +127,16 @@ static inline __m256i _mm256_i32gather_epi32x(int *b, __m256i idx, int size) {
     int c[8] __attribute__((aligned(32)));
     _mm256_store_si256((__m256i *)c, idx);
     return _mm256_set_epi32(b[c[7]], b[c[6]], b[c[5]], b[c[4]],
-			    b[c[3]], b[c[2]], b[c[1]], b[c[0]]);
+                            b[c[3]], b[c[2]], b[c[1]], b[c[0]]);
 }
 #else
 #define _mm256_i32gather_epi32x _mm256_i32gather_epi32
 #endif
 
 unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size) {
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size) {
     unsigned char *cp, *out_end;
     RansEncSymbol syms[256];
     RansState ransN[NX] __attribute__((aligned(32)));
@@ -147,20 +147,20 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
     int bound = rans_compress_bound_4x16(in_size,0)-20;
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     // If "out" isn't word aligned, tweak out_end/ptr to ensure it is.
     // We already added more round in bound to allow for this.
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     ptr = out_end = out + bound;
 
     if (in_size == 0)
-	goto empty;
+        goto empty;
 
     // Compute statistics
     hist8(in, in_size, F);
@@ -169,10 +169,10 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
     uint32_t fsum = in_size;
     uint32_t max_val = round2(fsum);
     if (max_val > TOTFREQ)
-	max_val = TOTFREQ;
+        max_val = TOTFREQ;
 
     if (normalise_freq(F, fsum, max_val) < 0)
-	return NULL;
+        return NULL;
     fsum=max_val;
 
     cp = out;
@@ -181,14 +181,14 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
     //write(2, out+4, cp-(out+4));
 
     if (normalise_freq(F, fsum, TOTFREQ) < 0)
-	return NULL;
+        return NULL;
 
     // Encode statistics.
     for (x = rle = j = 0; j < 256; j++) {
-	if (F[j]) {
-	    RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
-	    x += F[j];
-	}
+        if (F[j]) {
+            RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
+            x += F[j];
+        }
     }
 
     for (z = 0; z < NX; z++)
@@ -203,212 +203,212 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
     LOAD(Rv, ransN);
 
     for (i=(in_size &~(NX-1)); i>0; i-=NX) {
-	// We need to gather sym[curr_char][last_char] structs.
-	// These hold 4 32-bit values, so are 128 bit each, and
-	// are loaded from 32 distinct addresses.
-	//
-	// We load them into 32 128-bit lanes and then combine to get
-	// 16 avx-256 registers.
-	// These are now ABCD ABCD ABCD ABCD... orientation
-	// We can then "gather" from these registers via a combination
-	// of shuffle / permutes / and / or operations.  This is less
-	// IO than repeating 4 sets of gathers/loads 32-times over.
+        // We need to gather sym[curr_char][last_char] structs.
+        // These hold 4 32-bit values, so are 128 bit each, and
+        // are loaded from 32 distinct addresses.
+        //
+        // We load them into 32 128-bit lanes and then combine to get
+        // 16 avx-256 registers.
+        // These are now ABCD ABCD ABCD ABCD... orientation
+        // We can then "gather" from these registers via a combination
+        // of shuffle / permutes / and / or operations.  This is less
+        // IO than repeating 4 sets of gathers/loads 32-times over.
 
-	// DCBA holding 4 elements in a syms[] array
-	// -> 4-way rotate via shuffles
-	// [0] DCBA  11 10 01 00  E4
-	// [1] CBAD  10 01 00 11  93
-	// [2] BADC  01 00 11 10  4E
-	// [3] ADCB  00 11 10 01  39
-	//
-	// Then AND to select relevant lanes and OR
-	// [0] ......A0
-	// [1] ....A1..
-	// [2] ..A2....
-	// [3] A3......  OR to get A3A2A1A0
-	//
-	// or:
-	// [0] ....B0..
-	// [1] ..B1....
-	// [2] B2......
-	// [3] ......B3  OR to get B2B1B0B3 and shuffle to B3B2B1B0
+        // DCBA holding 4 elements in a syms[] array
+        // -> 4-way rotate via shuffles
+        // [0] DCBA  11 10 01 00  E4
+        // [1] CBAD  10 01 00 11  93
+        // [2] BADC  01 00 11 10  4E
+        // [3] ADCB  00 11 10 01  39
+        //
+        // Then AND to select relevant lanes and OR
+        // [0] ......A0
+        // [1] ....A1..
+        // [2] ..A2....
+        // [3] A3......  OR to get A3A2A1A0
+        //
+        // or:
+        // [0] ....B0..
+        // [1] ..B1....
+        // [2] B2......
+        // [3] ......B3  OR to get B2B1B0B3 and shuffle to B3B2B1B0
 
-	__m256i sh[16];
-	for (z = 0; z < 16; z+=4) {
-	    int Z = i - NX + z*2;
+        __m256i sh[16];
+        for (z = 0; z < 16; z+=4) {
+            int Z = i - NX + z*2;
 
 #define m128_to_256 _mm256_castsi128_si256
-	    __m256i t0, t1, t2, t3;
-	    __m128i *s0, *s1, *s2, *s3;
-	    s0 = (__m128i *)((int *)syms + 4*in[Z+0]);
-	    s1 = (__m128i *)((int *)syms + 4*in[Z+4]);
-	    s2 = (__m128i *)((int *)syms + 4*in[Z+1]);
-	    s3 = (__m128i *)((int *)syms + 4*in[Z+5]);
-	    // FIXME: try load instead of loadu, as 128-bit aligned.
-	    t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0xE4);
-	    t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0xE4);
-	    t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x93);
-	    t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x93);
+            __m256i t0, t1, t2, t3;
+            __m128i *s0, *s1, *s2, *s3;
+            s0 = (__m128i *)((int *)syms + 4*in[Z+0]);
+            s1 = (__m128i *)((int *)syms + 4*in[Z+4]);
+            s2 = (__m128i *)((int *)syms + 4*in[Z+1]);
+            s3 = (__m128i *)((int *)syms + 4*in[Z+5]);
+            // FIXME: try load instead of loadu, as 128-bit aligned.
+            t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0xE4);
+            t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0xE4);
+            t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x93);
+            t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x93);
 
-	    sh[z+0] = _mm256_permute2x128_si256(t0, t1, 0x20);
-	    sh[z+1] = _mm256_permute2x128_si256(t2, t3, 0x20);
+            sh[z+0] = _mm256_permute2x128_si256(t0, t1, 0x20);
+            sh[z+1] = _mm256_permute2x128_si256(t2, t3, 0x20);
 
-	    s0 = (__m128i *)((int *)syms + 4*in[Z+2]);
-	    s1 = (__m128i *)((int *)syms + 4*in[Z+6]);
-	    s2 = (__m128i *)((int *)syms + 4*in[Z+3]);
-	    s3 = (__m128i *)((int *)syms + 4*in[Z+7]);
-	    t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0x4E);
-	    t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0x4E);
-	    t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x39);
-	    t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x39);
+            s0 = (__m128i *)((int *)syms + 4*in[Z+2]);
+            s1 = (__m128i *)((int *)syms + 4*in[Z+6]);
+            s2 = (__m128i *)((int *)syms + 4*in[Z+3]);
+            s3 = (__m128i *)((int *)syms + 4*in[Z+7]);
+            t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0x4E);
+            t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0x4E);
+            t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x39);
+            t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x39);
 
-	    sh[z+2] = _mm256_permute2x128_si256(t0, t1, 0x20);
-	    sh[z+3] = _mm256_permute2x128_si256(t2, t3, 0x20);
+            sh[z+2] = _mm256_permute2x128_si256(t0, t1, 0x20);
+            sh[z+3] = _mm256_permute2x128_si256(t2, t3, 0x20);
 
-	    // potential to set xmax, rf, bias, and SD in-situ here, removing
-	    // the need to hold sh[] in regs.  Doing so doesn't seem to speed
-	    // things up though.
-	}
+            // potential to set xmax, rf, bias, and SD in-situ here, removing
+            // the need to hold sh[] in regs.  Doing so doesn't seem to speed
+            // things up though.
+        }
 
-	__m256i xA = _mm256_set_epi32(0,0,0,-1, 0,0,0,-1);
-	__m256i xB = _mm256_set_epi32(0,0,-1,0, 0,0,-1,0);
-	__m256i xC = _mm256_set_epi32(0,-1,0,0, 0,-1,0,0);
-	__m256i xD = _mm256_set_epi32(-1,0,0,0, -1,0,0,0);
+        __m256i xA = _mm256_set_epi32(0,0,0,-1, 0,0,0,-1);
+        __m256i xB = _mm256_set_epi32(0,0,-1,0, 0,0,-1,0);
+        __m256i xC = _mm256_set_epi32(0,-1,0,0, 0,-1,0,0);
+        __m256i xD = _mm256_set_epi32(-1,0,0,0, -1,0,0,0);
 
-#define SYM_LOAD(x, A, B, C, D)						\
-	_mm256_or_si256(_mm256_or_si256(_mm256_and_si256(sh[x+0], A),	\
-					_mm256_and_si256(sh[x+1], B)),	\
-  	                _mm256_or_si256(_mm256_and_si256(sh[x+2], C),	\
-			                _mm256_and_si256(sh[x+3], D)))
+#define SYM_LOAD(x, A, B, C, D)                                         \
+        _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(sh[x+0], A),   \
+                                        _mm256_and_si256(sh[x+1], B)),  \
+                        _mm256_or_si256(_mm256_and_si256(sh[x+2], C),   \
+                                        _mm256_and_si256(sh[x+3], D)))
 
-	// Renorm:
-	// if (x > x_max) {*--ptr16 = x & 0xffff; x >>= 16;}
-	__m256i xmax1 = SYM_LOAD( 0, xA, xB, xC, xD);
-	__m256i xmax2 = SYM_LOAD( 4, xA, xB, xC, xD);
-	__m256i xmax3 = SYM_LOAD( 8, xA, xB, xC, xD);
-	__m256i xmax4 = SYM_LOAD(12, xA, xB, xC, xD);
+        // Renorm:
+        // if (x > x_max) {*--ptr16 = x & 0xffff; x >>= 16;}
+        __m256i xmax1 = SYM_LOAD( 0, xA, xB, xC, xD);
+        __m256i xmax2 = SYM_LOAD( 4, xA, xB, xC, xD);
+        __m256i xmax3 = SYM_LOAD( 8, xA, xB, xC, xD);
+        __m256i xmax4 = SYM_LOAD(12, xA, xB, xC, xD);
 
-	__m256i cv1 = _mm256_cmpgt_epi32(Rv1, xmax1);
-	__m256i cv2 = _mm256_cmpgt_epi32(Rv2, xmax2);
-	__m256i cv3 = _mm256_cmpgt_epi32(Rv3, xmax3);
-	__m256i cv4 = _mm256_cmpgt_epi32(Rv4, xmax4);
+        __m256i cv1 = _mm256_cmpgt_epi32(Rv1, xmax1);
+        __m256i cv2 = _mm256_cmpgt_epi32(Rv2, xmax2);
+        __m256i cv3 = _mm256_cmpgt_epi32(Rv3, xmax3);
+        __m256i cv4 = _mm256_cmpgt_epi32(Rv4, xmax4);
 
-	// Store bottom 16-bits at ptr16
-	unsigned int imask1 = _mm256_movemask_ps((__m256)cv1);
-	unsigned int imask2 = _mm256_movemask_ps((__m256)cv2);
-	unsigned int imask3 = _mm256_movemask_ps((__m256)cv3);
-	unsigned int imask4 = _mm256_movemask_ps((__m256)cv4);
+        // Store bottom 16-bits at ptr16
+        unsigned int imask1 = _mm256_movemask_ps((__m256)cv1);
+        unsigned int imask2 = _mm256_movemask_ps((__m256)cv2);
+        unsigned int imask3 = _mm256_movemask_ps((__m256)cv3);
+        unsigned int imask4 = _mm256_movemask_ps((__m256)cv4);
 
-	__m256i idx1 = _mm256_load_si256((const __m256i*)permutec[imask1]);
-	__m256i idx2 = _mm256_load_si256((const __m256i*)permutec[imask2]);
-	__m256i idx3 = _mm256_load_si256((const __m256i*)permutec[imask3]);
-	__m256i idx4 = _mm256_load_si256((const __m256i*)permutec[imask4]);
+        __m256i idx1 = _mm256_load_si256((const __m256i*)permutec[imask1]);
+        __m256i idx2 = _mm256_load_si256((const __m256i*)permutec[imask2]);
+        __m256i idx3 = _mm256_load_si256((const __m256i*)permutec[imask3]);
+        __m256i idx4 = _mm256_load_si256((const __m256i*)permutec[imask4]);
 
-	// Permute; to gather together the rans states that need flushing
-	__m256i V1, V2, V3, V4;
-	V1 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv1, cv1), idx1);
-	V2 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv2, cv2), idx2);
-	V3 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv3, cv3), idx3);
-	V4 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv4, cv4), idx4);
-	
-	// We only flush bottom 16 bits, to squash 32-bit states into 16 bit.
-	V1 = _mm256_and_si256(V1, _mm256_set1_epi32(0xffff));
-	V2 = _mm256_and_si256(V2, _mm256_set1_epi32(0xffff));
-	V3 = _mm256_and_si256(V3, _mm256_set1_epi32(0xffff));
-	V4 = _mm256_and_si256(V4, _mm256_set1_epi32(0xffff));
-	__m256i V12 = _mm256_packus_epi32(V1, V2);
-	__m256i V34 = _mm256_packus_epi32(V3, V4);
+        // Permute; to gather together the rans states that need flushing
+        __m256i V1, V2, V3, V4;
+        V1 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv1, cv1), idx1);
+        V2 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv2, cv2), idx2);
+        V3 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv3, cv3), idx3);
+        V4 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv4, cv4), idx4);
+        
+        // We only flush bottom 16 bits, to squash 32-bit states into 16 bit.
+        V1 = _mm256_and_si256(V1, _mm256_set1_epi32(0xffff));
+        V2 = _mm256_and_si256(V2, _mm256_set1_epi32(0xffff));
+        V3 = _mm256_and_si256(V3, _mm256_set1_epi32(0xffff));
+        V4 = _mm256_and_si256(V4, _mm256_set1_epi32(0xffff));
+        __m256i V12 = _mm256_packus_epi32(V1, V2);
+        __m256i V34 = _mm256_packus_epi32(V3, V4);
 
-	// It's BAba order, want BbAa so shuffle.
-	V12 = _mm256_permute4x64_epi64(V12, 0xd8);
-	V34 = _mm256_permute4x64_epi64(V34, 0xd8);
+        // It's BAba order, want BbAa so shuffle.
+        V12 = _mm256_permute4x64_epi64(V12, 0xd8);
+        V34 = _mm256_permute4x64_epi64(V34, 0xd8);
 
-	// Now we have bottom N 16-bit values in each V12/V34 to flush
-	__m128i f =  _mm256_extractf128_si256(V34, 1);
-	_mm_storeu_si128((__m128i *)(ptr16-8), f);
-	ptr16 -= _mm_popcnt_u32(imask4);
+        // Now we have bottom N 16-bit values in each V12/V34 to flush
+        __m128i f =  _mm256_extractf128_si256(V34, 1);
+        _mm_storeu_si128((__m128i *)(ptr16-8), f);
+        ptr16 -= _mm_popcnt_u32(imask4);
 
-	f =  _mm256_extractf128_si256(V34, 0);
-	_mm_storeu_si128((__m128i *)(ptr16-8), f);
-	ptr16 -= _mm_popcnt_u32(imask3);
+        f =  _mm256_extractf128_si256(V34, 0);
+        _mm_storeu_si128((__m128i *)(ptr16-8), f);
+        ptr16 -= _mm_popcnt_u32(imask3);
 
-	f =  _mm256_extractf128_si256(V12, 1);
-	_mm_storeu_si128((__m128i *)(ptr16-8), f);
-	ptr16 -= _mm_popcnt_u32(imask2);
+        f =  _mm256_extractf128_si256(V12, 1);
+        _mm_storeu_si128((__m128i *)(ptr16-8), f);
+        ptr16 -= _mm_popcnt_u32(imask2);
 
-	f =  _mm256_extractf128_si256(V12, 0);
-	_mm_storeu_si128((__m128i *)(ptr16-8), f);
-	ptr16 -= _mm_popcnt_u32(imask1);
+        f =  _mm256_extractf128_si256(V12, 0);
+        _mm_storeu_si128((__m128i *)(ptr16-8), f);
+        ptr16 -= _mm_popcnt_u32(imask1);
 
-	__m256i Rs;
-	Rs = _mm256_srli_epi32(Rv1,16); Rv1 = _mm256_blendv_epi8(Rv1, Rs, cv1);
-	Rs = _mm256_srli_epi32(Rv2,16); Rv2 = _mm256_blendv_epi8(Rv2, Rs, cv2);
-	Rs = _mm256_srli_epi32(Rv3,16); Rv3 = _mm256_blendv_epi8(Rv3, Rs, cv3);
-	Rs = _mm256_srli_epi32(Rv4,16); Rv4 = _mm256_blendv_epi8(Rv4, Rs, cv4);
+        __m256i Rs;
+        Rs = _mm256_srli_epi32(Rv1,16); Rv1 = _mm256_blendv_epi8(Rv1, Rs, cv1);
+        Rs = _mm256_srli_epi32(Rv2,16); Rv2 = _mm256_blendv_epi8(Rv2, Rs, cv2);
+        Rs = _mm256_srli_epi32(Rv3,16); Rv3 = _mm256_blendv_epi8(Rv3, Rs, cv3);
+        Rs = _mm256_srli_epi32(Rv4,16); Rv4 = _mm256_blendv_epi8(Rv4, Rs, cv4);
 
-	// Cannot trivially replace the multiply as mulhi_epu32 doesn't
-	// exist (only mullo).
-	// However we can use _mm256_mul_epu32 twice to get 64bit results
-	// (half our lanes) and shift/or to get the answer.
-	//
-	// (AVX512 allows us to hold it all in 64-bit lanes and use mullo_epi64
-	// plus a shift.  KNC has mulhi_epi32, but not sure if this is
-	// available.)
-	__m256i rfv1 = _mm256_shuffle_epi32(SYM_LOAD( 0, xB, xC, xD, xA),0x39);
-	__m256i rfv2 = _mm256_shuffle_epi32(SYM_LOAD( 4, xB, xC, xD, xA),0x39);
-	__m256i rfv3 = _mm256_shuffle_epi32(SYM_LOAD( 8, xB, xC, xD, xA),0x39);
-	__m256i rfv4 = _mm256_shuffle_epi32(SYM_LOAD(12, xB, xC, xD, xA),0x39);
+        // Cannot trivially replace the multiply as mulhi_epu32 doesn't
+        // exist (only mullo).
+        // However we can use _mm256_mul_epu32 twice to get 64bit results
+        // (half our lanes) and shift/or to get the answer.
+        //
+        // (AVX512 allows us to hold it all in 64-bit lanes and use mullo_epi64
+        // plus a shift.  KNC has mulhi_epi32, but not sure if this is
+        // available.)
+        __m256i rfv1 = _mm256_shuffle_epi32(SYM_LOAD( 0, xB, xC, xD, xA),0x39);
+        __m256i rfv2 = _mm256_shuffle_epi32(SYM_LOAD( 4, xB, xC, xD, xA),0x39);
+        __m256i rfv3 = _mm256_shuffle_epi32(SYM_LOAD( 8, xB, xC, xD, xA),0x39);
+        __m256i rfv4 = _mm256_shuffle_epi32(SYM_LOAD(12, xB, xC, xD, xA),0x39);
 
-	rfv1 = _mm256_mulhi_epu32(Rv1, rfv1);
-	rfv2 = _mm256_mulhi_epu32(Rv2, rfv2);
-	rfv3 = _mm256_mulhi_epu32(Rv3, rfv3);
-	rfv4 = _mm256_mulhi_epu32(Rv4, rfv4);
+        rfv1 = _mm256_mulhi_epu32(Rv1, rfv1);
+        rfv2 = _mm256_mulhi_epu32(Rv2, rfv2);
+        rfv3 = _mm256_mulhi_epu32(Rv3, rfv3);
+        rfv4 = _mm256_mulhi_epu32(Rv4, rfv4);
 
-	__m256i SDv1 = _mm256_shuffle_epi32(SYM_LOAD( 0, xD, xA, xB, xC),0x93);
-	__m256i SDv2 = _mm256_shuffle_epi32(SYM_LOAD( 4, xD, xA, xB, xC),0x93);
-	__m256i SDv3 = _mm256_shuffle_epi32(SYM_LOAD( 8, xD, xA, xB, xC),0x93);
-	__m256i SDv4 = _mm256_shuffle_epi32(SYM_LOAD(12, xD, xA, xB, xC),0x93);
+        __m256i SDv1 = _mm256_shuffle_epi32(SYM_LOAD( 0, xD, xA, xB, xC),0x93);
+        __m256i SDv2 = _mm256_shuffle_epi32(SYM_LOAD( 4, xD, xA, xB, xC),0x93);
+        __m256i SDv3 = _mm256_shuffle_epi32(SYM_LOAD( 8, xD, xA, xB, xC),0x93);
+        __m256i SDv4 = _mm256_shuffle_epi32(SYM_LOAD(12, xD, xA, xB, xC),0x93);
 
-	__m256i shiftv1 = _mm256_srli_epi32(SDv1, 16);
-	__m256i shiftv2 = _mm256_srli_epi32(SDv2, 16);
-	__m256i shiftv3 = _mm256_srli_epi32(SDv3, 16);
-	__m256i shiftv4 = _mm256_srli_epi32(SDv4, 16);
+        __m256i shiftv1 = _mm256_srli_epi32(SDv1, 16);
+        __m256i shiftv2 = _mm256_srli_epi32(SDv2, 16);
+        __m256i shiftv3 = _mm256_srli_epi32(SDv3, 16);
+        __m256i shiftv4 = _mm256_srli_epi32(SDv4, 16);
 
-	shiftv1 = _mm256_sub_epi32(shiftv1, _mm256_set1_epi32(32));
-	shiftv2 = _mm256_sub_epi32(shiftv2, _mm256_set1_epi32(32));
-	shiftv3 = _mm256_sub_epi32(shiftv3, _mm256_set1_epi32(32));
-	shiftv4 = _mm256_sub_epi32(shiftv4, _mm256_set1_epi32(32));
+        shiftv1 = _mm256_sub_epi32(shiftv1, _mm256_set1_epi32(32));
+        shiftv2 = _mm256_sub_epi32(shiftv2, _mm256_set1_epi32(32));
+        shiftv3 = _mm256_sub_epi32(shiftv3, _mm256_set1_epi32(32));
+        shiftv4 = _mm256_sub_epi32(shiftv4, _mm256_set1_epi32(32));
 
-	__m256i qv1 = _mm256_srlv_epi32(rfv1, shiftv1);
-	__m256i qv2 = _mm256_srlv_epi32(rfv2, shiftv2);
+        __m256i qv1 = _mm256_srlv_epi32(rfv1, shiftv1);
+        __m256i qv2 = _mm256_srlv_epi32(rfv2, shiftv2);
 
-	__m256i freqv1 = _mm256_and_si256(SDv1, _mm256_set1_epi32(0xffff));
-	__m256i freqv2 = _mm256_and_si256(SDv2, _mm256_set1_epi32(0xffff));
-	qv1 = _mm256_mullo_epi32(qv1, freqv1);
-	qv2 = _mm256_mullo_epi32(qv2, freqv2);
+        __m256i freqv1 = _mm256_and_si256(SDv1, _mm256_set1_epi32(0xffff));
+        __m256i freqv2 = _mm256_and_si256(SDv2, _mm256_set1_epi32(0xffff));
+        qv1 = _mm256_mullo_epi32(qv1, freqv1);
+        qv2 = _mm256_mullo_epi32(qv2, freqv2);
 
-	__m256i qv3 = _mm256_srlv_epi32(rfv3, shiftv3);
-	__m256i qv4 = _mm256_srlv_epi32(rfv4, shiftv4);
+        __m256i qv3 = _mm256_srlv_epi32(rfv3, shiftv3);
+        __m256i qv4 = _mm256_srlv_epi32(rfv4, shiftv4);
 
-	__m256i freqv3 = _mm256_and_si256(SDv3, _mm256_set1_epi32(0xffff));
-	__m256i freqv4 = _mm256_and_si256(SDv4, _mm256_set1_epi32(0xffff));
-	qv3 = _mm256_mullo_epi32(qv3, freqv3);
-	qv4 = _mm256_mullo_epi32(qv4, freqv4);
+        __m256i freqv3 = _mm256_and_si256(SDv3, _mm256_set1_epi32(0xffff));
+        __m256i freqv4 = _mm256_and_si256(SDv4, _mm256_set1_epi32(0xffff));
+        qv3 = _mm256_mullo_epi32(qv3, freqv3);
+        qv4 = _mm256_mullo_epi32(qv4, freqv4);
 
-	__m256i biasv1=_mm256_shuffle_epi32(SYM_LOAD( 0, xC, xD, xA, xB),0x4E);
-	__m256i biasv2=_mm256_shuffle_epi32(SYM_LOAD( 4, xC, xD, xA, xB),0x4E);
-	__m256i biasv3=_mm256_shuffle_epi32(SYM_LOAD( 8, xC, xD, xA, xB),0x4E);
-	__m256i biasv4=_mm256_shuffle_epi32(SYM_LOAD(12, xC, xD, xA, xB),0x4E);
+        __m256i biasv1=_mm256_shuffle_epi32(SYM_LOAD( 0, xC, xD, xA, xB),0x4E);
+        __m256i biasv2=_mm256_shuffle_epi32(SYM_LOAD( 4, xC, xD, xA, xB),0x4E);
+        __m256i biasv3=_mm256_shuffle_epi32(SYM_LOAD( 8, xC, xD, xA, xB),0x4E);
+        __m256i biasv4=_mm256_shuffle_epi32(SYM_LOAD(12, xC, xD, xA, xB),0x4E);
 
-	qv1 = _mm256_add_epi32(qv1, biasv1);
-	qv2 = _mm256_add_epi32(qv2, biasv2);
-	qv3 = _mm256_add_epi32(qv3, biasv3);
-	qv4 = _mm256_add_epi32(qv4, biasv4);
+        qv1 = _mm256_add_epi32(qv1, biasv1);
+        qv2 = _mm256_add_epi32(qv2, biasv2);
+        qv3 = _mm256_add_epi32(qv3, biasv3);
+        qv4 = _mm256_add_epi32(qv4, biasv4);
 
-	Rv1 = _mm256_add_epi32(Rv1, qv1);
-	Rv2 = _mm256_add_epi32(Rv2, qv2);
-	Rv3 = _mm256_add_epi32(Rv3, qv3);
-	Rv4 = _mm256_add_epi32(Rv4, qv4);
+        Rv1 = _mm256_add_epi32(Rv1, qv1);
+        Rv2 = _mm256_add_epi32(Rv2, qv2);
+        Rv3 = _mm256_add_epi32(Rv3, qv3);
+        Rv4 = _mm256_add_epi32(Rv4, qv4);
     }
 
     STORE(Rv, ransN);
@@ -433,18 +433,18 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
 }
 
 unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz) {
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz) {
     if (in_size < 16) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -454,32 +454,32 @@ unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
     uint32_t s3[TOTFREQ] __attribute__((aligned(32))); // For TF_SHIFT <= 12
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     // Precompute reverse lookup of frequency.
     uint32_t F[256] = {0}, fsum;
     int fsz = decode_freq(cp, cp_end, F, &fsum);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     normalise_freq_shift(F, fsum, TOTFREQ);
 
     // Build symbols; fixme, do as part of decode, see the _d variant
     if (rans_F_to_s3(F, TF_SHIFT, s3))
-	goto err;
+        goto err;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     int z;
     RansState R[NX] __attribute__((aligned(32)));
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &cp);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &cp);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     uint16_t *sp = (uint16_t *)cp;
@@ -489,9 +489,9 @@ unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
     // Protect against running off the end of in buffer.
     // We copy it to a worst-case local buffer when near the end.
     if ((uint8_t *)sp > cp_end) {
-	memmove(overflow, sp, cp_end+64 - (uint8_t *)sp);
-	sp = (uint16_t *)overflow;
-	cp_end = overflow + sizeof(overflow) - 64;
+        memmove(overflow, sp, cp_end+64 - (uint8_t *)sp);
+        sp = (uint16_t *)overflow;
+        cp_end = overflow + sizeof(overflow) - 64;
     }
 
     int out_end = (out_sz&~(NX-1));
@@ -501,56 +501,56 @@ unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
     LOAD(Rv, R);
 
     for (i=0; i < out_end; i+=NX) {
-	//for (z = 0; z < NX; z++)
-	//  m[z] = R[z] & mask;
-	__m256i masked1 = _mm256_and_si256(Rv1, maskv);
-	__m256i masked2 = _mm256_and_si256(Rv2, maskv);
+        //for (z = 0; z < NX; z++)
+        //  m[z] = R[z] & mask;
+        __m256i masked1 = _mm256_and_si256(Rv1, maskv);
+        __m256i masked2 = _mm256_and_si256(Rv2, maskv);
 
-	//  S[z] = s3[m[z]];
-	__m256i Sv1 = _mm256_i32gather_epi32x((int *)s3, masked1, sizeof(*s3));
-	__m256i Sv2 = _mm256_i32gather_epi32x((int *)s3, masked2, sizeof(*s3));
+        //  S[z] = s3[m[z]];
+        __m256i Sv1 = _mm256_i32gather_epi32x((int *)s3, masked1, sizeof(*s3));
+        __m256i Sv2 = _mm256_i32gather_epi32x((int *)s3, masked2, sizeof(*s3));
 
-	//  f[z] = S[z]>>(TF_SHIFT+8);
-	__m256i fv1 = _mm256_srli_epi32(Sv1, TF_SHIFT+8);
-	__m256i fv2 = _mm256_srli_epi32(Sv2, TF_SHIFT+8);
+        //  f[z] = S[z]>>(TF_SHIFT+8);
+        __m256i fv1 = _mm256_srli_epi32(Sv1, TF_SHIFT+8);
+        __m256i fv2 = _mm256_srli_epi32(Sv2, TF_SHIFT+8);
 
-	//  b[z] = (S[z]>>8) & mask;
-	__m256i bv1 = _mm256_and_si256(_mm256_srli_epi32(Sv1, 8), maskv);
-	__m256i bv2 = _mm256_and_si256(_mm256_srli_epi32(Sv2, 8), maskv);
+        //  b[z] = (S[z]>>8) & mask;
+        __m256i bv1 = _mm256_and_si256(_mm256_srli_epi32(Sv1, 8), maskv);
+        __m256i bv2 = _mm256_and_si256(_mm256_srli_epi32(Sv2, 8), maskv);
 
-	//  s[z] = S[z] & 0xff;
-	__m256i sv1 = _mm256_and_si256(Sv1, _mm256_set1_epi32(0xff));
-	__m256i sv2 = _mm256_and_si256(Sv2, _mm256_set1_epi32(0xff));
+        //  s[z] = S[z] & 0xff;
+        __m256i sv1 = _mm256_and_si256(Sv1, _mm256_set1_epi32(0xff));
+        __m256i sv2 = _mm256_and_si256(Sv2, _mm256_set1_epi32(0xff));
 
-	//  R[z] = f[z] * (R[z] >> TF_SHIFT) + b[z];
-	Rv1 = _mm256_add_epi32(
-	          _mm256_mullo_epi32(
-		      _mm256_srli_epi32(Rv1,TF_SHIFT), fv1), bv1);
-	Rv2 = _mm256_add_epi32(
-		  _mm256_mullo_epi32(
-		      _mm256_srli_epi32(Rv2,TF_SHIFT), fv2), bv2);
+        //  R[z] = f[z] * (R[z] >> TF_SHIFT) + b[z];
+        Rv1 = _mm256_add_epi32(
+                  _mm256_mullo_epi32(
+                      _mm256_srli_epi32(Rv1,TF_SHIFT), fv1), bv1);
+        Rv2 = _mm256_add_epi32(
+                  _mm256_mullo_epi32(
+                      _mm256_srli_epi32(Rv2,TF_SHIFT), fv2), bv2);
 
 #ifdef __clang__
-	// Protect against running off the end of in buffer.
-	// We copy it to a worst-case local buffer when near the end.
-	if ((uint8_t *)sp > cp_end) {
-	    memmove(overflow, sp, cp_end+64 - (uint8_t *)sp);
-	    sp = (uint16_t *)overflow;
-	    cp_end = overflow + sizeof(overflow) - 64;
-	}
+        // Protect against running off the end of in buffer.
+        // We copy it to a worst-case local buffer when near the end.
+        if ((uint8_t *)sp > cp_end) {
+            memmove(overflow, sp, cp_end+64 - (uint8_t *)sp);
+            sp = (uint16_t *)overflow;
+            cp_end = overflow + sizeof(overflow) - 64;
+        }
 #endif
-	// Tricky one:  out[i+z] = s[z];
-	//             ---h---g ---f---e  ---d---c ---b---a
-	//             ---p---o ---n---m  ---l---k ---j---i
-	// packs_epi32 -p-o-n-m -h-g-f-e  -l-k-j-i -d-c-b-a
-	// permute4x64 -p-o-n-m -l-k-j-i  -h-g-f-e -d-c-b-a
-	// packs_epi16 ponmlkji ponmlkji  hgfedcba hgfedcba
-	sv1 = _mm256_packus_epi32(sv1, sv2);
-	sv1 = _mm256_permute4x64_epi64(sv1, 0xd8);
-	__m256i Vv1 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	sv1 = _mm256_packus_epi16(sv1, sv1);
+        // Tricky one:  out[i+z] = s[z];
+        //             ---h---g ---f---e  ---d---c ---b---a
+        //             ---p---o ---n---m  ---l---k ---j---i
+        // packs_epi32 -p-o-n-m -h-g-f-e  -l-k-j-i -d-c-b-a
+        // permute4x64 -p-o-n-m -l-k-j-i  -h-g-f-e -d-c-b-a
+        // packs_epi16 ponmlkji ponmlkji  hgfedcba hgfedcba
+        sv1 = _mm256_packus_epi32(sv1, sv2);
+        sv1 = _mm256_permute4x64_epi64(sv1, 0xd8);
+        __m256i Vv1 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        sv1 = _mm256_packus_epi16(sv1, sv1);
 
-	// c =  R[z] < RANS_BYTE_L;
+        // c =  R[z] < RANS_BYTE_L;
 
 // The lack of unsigned comparisons means we have to jump through hoops.
 // in AVX2 land the second version comes out best (and first in SSE land).
@@ -559,118 +559,118 @@ unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
 
 #define _mm256_cmplt_epu32_imm(a,b) _mm256_cmpgt_epi32(_mm256_set1_epi32((b)-0x80000000), _mm256_xor_si256((a), _mm256_set1_epi32(0x80000000)))
 
-	__m256i renorm_mask1, renorm_mask2;
+        __m256i renorm_mask1, renorm_mask2;
         renorm_mask1 = _mm256_cmplt_epu32_imm(Rv1, RANS_BYTE_L);
         renorm_mask2 = _mm256_cmplt_epu32_imm(Rv2, RANS_BYTE_L);
 
-	// y = (R[z] << 16) | V[z];
-	unsigned int imask1 = _mm256_movemask_ps((__m256)renorm_mask1);
-	__m256i idx1 = _mm256_load_si256((const __m256i*)permute[imask1]);
-	__m256i Yv1 = _mm256_slli_epi32(Rv1, 16);
-	Vv1 = _mm256_permutevar8x32_epi32(Vv1, idx1);
-	__m256i Yv2 = _mm256_slli_epi32(Rv2, 16);
+        // y = (R[z] << 16) | V[z];
+        unsigned int imask1 = _mm256_movemask_ps((__m256)renorm_mask1);
+        __m256i idx1 = _mm256_load_si256((const __m256i*)permute[imask1]);
+        __m256i Yv1 = _mm256_slli_epi32(Rv1, 16);
+        Vv1 = _mm256_permutevar8x32_epi32(Vv1, idx1);
+        __m256i Yv2 = _mm256_slli_epi32(Rv2, 16);
 
-	// Shuffle the renorm values to correct lanes and incr sp pointer
-	unsigned int imask2 = _mm256_movemask_ps((__m256)renorm_mask2);
-	sp += _mm_popcnt_u32(imask1);
+        // Shuffle the renorm values to correct lanes and incr sp pointer
+        unsigned int imask2 = _mm256_movemask_ps((__m256)renorm_mask2);
+        sp += _mm_popcnt_u32(imask1);
 
-	__m256i idx2 = _mm256_load_si256((const __m256i*)permute[imask2]);
-	__m256i Vv2 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	sp += _mm_popcnt_u32(imask2);
+        __m256i idx2 = _mm256_load_si256((const __m256i*)permute[imask2]);
+        __m256i Vv2 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        sp += _mm_popcnt_u32(imask2);
 
-	Yv1 = _mm256_or_si256(Yv1, Vv1);
-	Vv2 = _mm256_permutevar8x32_epi32(Vv2, idx2);
-	Yv2 = _mm256_or_si256(Yv2, Vv2);
+        Yv1 = _mm256_or_si256(Yv1, Vv1);
+        Vv2 = _mm256_permutevar8x32_epi32(Vv2, idx2);
+        Yv2 = _mm256_or_si256(Yv2, Vv2);
 
-	// R[z] = c ? Y[z] : R[z];
-	Rv1 = _mm256_blendv_epi8(Rv1, Yv1, renorm_mask1);
-	Rv2 = _mm256_blendv_epi8(Rv2, Yv2, renorm_mask2);
+        // R[z] = c ? Y[z] : R[z];
+        Rv1 = _mm256_blendv_epi8(Rv1, Yv1, renorm_mask1);
+        Rv2 = _mm256_blendv_epi8(Rv2, Yv2, renorm_mask2);
 
-	// ------------------------------------------------------------
+        // ------------------------------------------------------------
 
-	//  m[z] = R[z] & mask;
-	//  S[z] = s3[m[z]];
-	__m256i masked3 = _mm256_and_si256(Rv3, maskv);
-	__m256i Sv3 = _mm256_i32gather_epi32x((int *)s3, masked3, sizeof(*s3));
+        //  m[z] = R[z] & mask;
+        //  S[z] = s3[m[z]];
+        __m256i masked3 = _mm256_and_si256(Rv3, maskv);
+        __m256i Sv3 = _mm256_i32gather_epi32x((int *)s3, masked3, sizeof(*s3));
 
-	*(uint64_t *)&out[i+0] = _mm256_extract_epi64(sv1, 0);
-	*(uint64_t *)&out[i+8] = _mm256_extract_epi64(sv1, 2);
+        *(uint64_t *)&out[i+0] = _mm256_extract_epi64(sv1, 0);
+        *(uint64_t *)&out[i+8] = _mm256_extract_epi64(sv1, 2);
 
-	__m256i masked4 = _mm256_and_si256(Rv4, maskv);
-	__m256i Sv4 = _mm256_i32gather_epi32x((int *)s3, masked4, sizeof(*s3));
+        __m256i masked4 = _mm256_and_si256(Rv4, maskv);
+        __m256i Sv4 = _mm256_i32gather_epi32x((int *)s3, masked4, sizeof(*s3));
 
-	//  f[z] = S[z]>>(TF_SHIFT+8);
-	__m256i fv3 = _mm256_srli_epi32(Sv3, TF_SHIFT+8);
-	__m256i fv4 = _mm256_srli_epi32(Sv4, TF_SHIFT+8);
+        //  f[z] = S[z]>>(TF_SHIFT+8);
+        __m256i fv3 = _mm256_srli_epi32(Sv3, TF_SHIFT+8);
+        __m256i fv4 = _mm256_srli_epi32(Sv4, TF_SHIFT+8);
 
-	//  b[z] = (S[z]>>8) & mask;
-	__m256i bv3 = _mm256_and_si256(_mm256_srli_epi32(Sv3, 8), maskv);
-	__m256i bv4 = _mm256_and_si256(_mm256_srli_epi32(Sv4, 8), maskv);
+        //  b[z] = (S[z]>>8) & mask;
+        __m256i bv3 = _mm256_and_si256(_mm256_srli_epi32(Sv3, 8), maskv);
+        __m256i bv4 = _mm256_and_si256(_mm256_srli_epi32(Sv4, 8), maskv);
 
-	//  s[z] = S[z] & 0xff;
-	__m256i sv3 = _mm256_and_si256(Sv3, _mm256_set1_epi32(0xff));
-	__m256i sv4 = _mm256_and_si256(Sv4, _mm256_set1_epi32(0xff));
+        //  s[z] = S[z] & 0xff;
+        __m256i sv3 = _mm256_and_si256(Sv3, _mm256_set1_epi32(0xff));
+        __m256i sv4 = _mm256_and_si256(Sv4, _mm256_set1_epi32(0xff));
 
-	//  R[z] = f[z] * (R[z] >> TF_SHIFT) + b[z];
-	Rv3 = _mm256_add_epi32(_mm256_mullo_epi32(_mm256_srli_epi32(Rv3,TF_SHIFT),fv3),bv3);
-	Rv4 = _mm256_add_epi32(_mm256_mullo_epi32(_mm256_srli_epi32(Rv4,TF_SHIFT),fv4),bv4);
+        //  R[z] = f[z] * (R[z] >> TF_SHIFT) + b[z];
+        Rv3 = _mm256_add_epi32(_mm256_mullo_epi32(_mm256_srli_epi32(Rv3,TF_SHIFT),fv3),bv3);
+        Rv4 = _mm256_add_epi32(_mm256_mullo_epi32(_mm256_srli_epi32(Rv4,TF_SHIFT),fv4),bv4);
 
-	// Tricky one:  out[i+z] = s[z];
-	//             ---h---g ---f---e  ---d---c ---b---a
-	//             ---p---o ---n---m  ---l---k ---j---i
-	// packs_epi32 -p-o-n-m -h-g-f-e  -l-k-j-i -d-c-b-a
-	// permute4x64 -p-o-n-m -l-k-j-i  -h-g-f-e -d-c-b-a
-	// packs_epi16 ponmlkji ponmlkji  hgfedcba hgfedcba
-	sv3 = _mm256_packus_epi32(sv3, sv4);
-	sv3 = _mm256_permute4x64_epi64(sv3, 0xd8);
+        // Tricky one:  out[i+z] = s[z];
+        //             ---h---g ---f---e  ---d---c ---b---a
+        //             ---p---o ---n---m  ---l---k ---j---i
+        // packs_epi32 -p-o-n-m -h-g-f-e  -l-k-j-i -d-c-b-a
+        // permute4x64 -p-o-n-m -l-k-j-i  -h-g-f-e -d-c-b-a
+        // packs_epi16 ponmlkji ponmlkji  hgfedcba hgfedcba
+        sv3 = _mm256_packus_epi32(sv3, sv4);
+        sv3 = _mm256_permute4x64_epi64(sv3, 0xd8);
 
-	// c =  R[z] < RANS_BYTE_L;
-	__m256i renorm_mask3, renorm_mask4;
-	renorm_mask3 = _mm256_cmplt_epu32_imm(Rv3, RANS_BYTE_L);
-	sv3 = _mm256_packus_epi16(sv3, sv3);
-	renorm_mask4 = _mm256_cmplt_epu32_imm(Rv4, RANS_BYTE_L);
-	
-	*(uint64_t *)&out[i+16] = _mm256_extract_epi64(sv3, 0);
-	*(uint64_t *)&out[i+24] = _mm256_extract_epi64(sv3, 2);
+        // c =  R[z] < RANS_BYTE_L;
+        __m256i renorm_mask3, renorm_mask4;
+        renorm_mask3 = _mm256_cmplt_epu32_imm(Rv3, RANS_BYTE_L);
+        sv3 = _mm256_packus_epi16(sv3, sv3);
+        renorm_mask4 = _mm256_cmplt_epu32_imm(Rv4, RANS_BYTE_L);
+        
+        *(uint64_t *)&out[i+16] = _mm256_extract_epi64(sv3, 0);
+        *(uint64_t *)&out[i+24] = _mm256_extract_epi64(sv3, 2);
 
-	// y = (R[z] << 16) | V[z];
-	__m256i Vv3 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	__m256i Yv3 = _mm256_slli_epi32(Rv3, 16);
-	unsigned int imask3 = _mm256_movemask_ps((__m256)renorm_mask3);
-	__m256i idx3 = _mm256_load_si256((const __m256i*)permute[imask3]);
+        // y = (R[z] << 16) | V[z];
+        __m256i Vv3 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        __m256i Yv3 = _mm256_slli_epi32(Rv3, 16);
+        unsigned int imask3 = _mm256_movemask_ps((__m256)renorm_mask3);
+        __m256i idx3 = _mm256_load_si256((const __m256i*)permute[imask3]);
 
-	// Shuffle the renorm values to correct lanes and incr sp pointer
-	Vv3 = _mm256_permutevar8x32_epi32(Vv3, idx3);
-	__m256i Yv4 = _mm256_slli_epi32(Rv4, 16);
-	unsigned int imask4 = _mm256_movemask_ps((__m256)renorm_mask4);
-	sp += _mm_popcnt_u32(imask3);
+        // Shuffle the renorm values to correct lanes and incr sp pointer
+        Vv3 = _mm256_permutevar8x32_epi32(Vv3, idx3);
+        __m256i Yv4 = _mm256_slli_epi32(Rv4, 16);
+        unsigned int imask4 = _mm256_movemask_ps((__m256)renorm_mask4);
+        sp += _mm_popcnt_u32(imask3);
 
-	__m256i idx4 = _mm256_load_si256((const __m256i*)permute[imask4]);
-	__m256i Vv4 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        __m256i idx4 = _mm256_load_si256((const __m256i*)permute[imask4]);
+        __m256i Vv4 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
 
-	//Vv = _mm256_and_si256(Vv, renorm_mask);  (blend does the AND anyway)
-	Yv3 = _mm256_or_si256(Yv3, Vv3);
-	Vv4 = _mm256_permutevar8x32_epi32(Vv4, idx4);
-	Yv4 = _mm256_or_si256(Yv4, Vv4);
+        //Vv = _mm256_and_si256(Vv, renorm_mask);  (blend does the AND anyway)
+        Yv3 = _mm256_or_si256(Yv3, Vv3);
+        Vv4 = _mm256_permutevar8x32_epi32(Vv4, idx4);
+        Yv4 = _mm256_or_si256(Yv4, Vv4);
 
 #ifndef __clang__
-	// 26% faster here than above for gcc10, but former location is
-	// better on clang.
+        // 26% faster here than above for gcc10, but former location is
+        // better on clang.
 
-	// Protect against running off the end of in buffer.
-	// We copy it to a worst-case local buffer when near the end.
-	if ((uint8_t *)sp > cp_end) {
-	    memmove(overflow, sp, cp_end+64 - (uint8_t *)sp);
-	    sp = (uint16_t *)overflow;
-	    cp_end = overflow + sizeof(overflow) - 64;
-	}
+        // Protect against running off the end of in buffer.
+        // We copy it to a worst-case local buffer when near the end.
+        if ((uint8_t *)sp > cp_end) {
+            memmove(overflow, sp, cp_end+64 - (uint8_t *)sp);
+            sp = (uint16_t *)overflow;
+            cp_end = overflow + sizeof(overflow) - 64;
+        }
 #endif
 
-	sp += _mm_popcnt_u32(imask4);
+        sp += _mm_popcnt_u32(imask4);
 
-	// R[z] = c ? Y[z] : R[z];
-	Rv3 = _mm256_blendv_epi8(Rv3, Yv3, renorm_mask3);
-	Rv4 = _mm256_blendv_epi8(Rv4, Yv4, renorm_mask4);
+        // R[z] = c ? Y[z] : R[z];
+        Rv3 = _mm256_blendv_epi8(Rv3, Yv3, renorm_mask3);
+        Rv4 = _mm256_blendv_epi8(Rv4, Yv4, renorm_mask4);
     }
 
     STORE(Rv, R);
@@ -694,38 +694,38 @@ unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
 //-----------------------------------------------------------------------------
 
 unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_size,
-					   unsigned char *out, unsigned int *out_size) {
+                                           unsigned char *out, unsigned int *out_size) {
     unsigned char *cp, *out_end, *out_free = NULL;
     unsigned int tab_size;
     int bound = rans_compress_bound_4x16(in_size,1)-20, z;
     RansState ransN[NX] __attribute__((aligned(32)));
 
     if (in_size < NX) // force O0 instead
-	return NULL;
+        return NULL;
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     out_end = out + bound;
 
     RansEncSymbol (*syms)[256] = htscodecs_tls_alloc(256 * (sizeof(*syms)));
     if (!syms) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     cp = out;
     int shift = encode_freq1(in, in_size, 32, syms, &cp); 
     if (shift < 0) {
-	free(out_free);
-	htscodecs_tls_free(syms);
-	return NULL;
+        free(out_free);
+        htscodecs_tls_free(syms);
+        return NULL;
     }
     tab_size = cp - out;
 
@@ -736,19 +736,19 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
 
     int iN[NX], isz4 = in_size/NX;
     for (z = 0; z < NX; z++)
-	iN[z] = (z+1)*isz4-2;
+        iN[z] = (z+1)*isz4-2;
 
     unsigned char lN[NX];
     for (z = 0; z < NX; z++)
-	lN[z] = in[iN[z]+1];
+        lN[z] = in[iN[z]+1];
 
     // Deal with the remainder
     z = NX-1;
     lN[z] = in[in_size-1];
     for (iN[z] = in_size-2; iN[z] > NX*isz4-2; iN[z]--) {
-	unsigned char c = in[iN[z]];
-	RansEncPutSymbol(&ransN[z], &ptr, &syms[c][lN[z]]);
-	lN[z] = c;
+        unsigned char c = in[iN[z]];
+        RansEncPutSymbol(&ransN[z], &ptr, &syms[c][lN[z]]);
+        lN[z] = c;
     }
 
     uint16_t *ptr16 = (uint16_t *)ptr;
@@ -756,107 +756,107 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
     LOAD(Rv, ransN);
 
     for (; iN[0] >= 0; ) {
-	// We need to gather sym[curr_char][last_char] structs.
-	// These hold 4 32-bit values, so are 128 bit each, and
-	// are loaded from 32 distinct addresses.
-	//
-	// We load them into 32 128-bit lanes and then combine to get
-	// 16 avx-256 registers.
-	// These are now ABCD ABCD ABCD ABCD... orientation
-	// Code we can then "gather" from these registers via a combination
-	// of shuffle / permutes / and / or operations.  This is less
-	// IO than repeating 4 sets of gathers/loads 32-times over.
+        // We need to gather sym[curr_char][last_char] structs.
+        // These hold 4 32-bit values, so are 128 bit each, and
+        // are loaded from 32 distinct addresses.
+        //
+        // We load them into 32 128-bit lanes and then combine to get
+        // 16 avx-256 registers.
+        // These are now ABCD ABCD ABCD ABCD... orientation
+        // Code we can then "gather" from these registers via a combination
+        // of shuffle / permutes / and / or operations.  This is less
+        // IO than repeating 4 sets of gathers/loads 32-times over.
 
-	// DCBA holding 4 elements in a syms[] array
-	// -> 4-way rotate via shuffles
-	// [0] DCBA  11 10 01 00  E4
-	// [1] CBAD  10 01 00 11  93
-	// [2] BADC  01 00 11 10  4E
-	// [3] ADCB  00 11 10 01  39
-	//
-	// Then AND to select relevant lanes and OR
-	// [0] ......A0
-	// [1] ....A1..
-	// [2] ..A2....
-	// [3] A3......  OR to get A3A2A1A0
-	//
-	// or:
-	// [0] ....B0..
-	// [1] ..B1....
-	// [2] B2......
-	// [3] ......B3  OR to get B2B1B0B3 and shuffle to B3B2B1B0
+        // DCBA holding 4 elements in a syms[] array
+        // -> 4-way rotate via shuffles
+        // [0] DCBA  11 10 01 00  E4
+        // [1] CBAD  10 01 00 11  93
+        // [2] BADC  01 00 11 10  4E
+        // [3] ADCB  00 11 10 01  39
+        //
+        // Then AND to select relevant lanes and OR
+        // [0] ......A0
+        // [1] ....A1..
+        // [2] ..A2....
+        // [3] A3......  OR to get A3A2A1A0
+        //
+        // or:
+        // [0] ....B0..
+        // [1] ..B1....
+        // [2] B2......
+        // [3] ......B3  OR to get B2B1B0B3 and shuffle to B3B2B1B0
 
-	__m256i sh[16];
-	for (z = 0; z < 16; z+=4) {
-	    int Z = z*2;
+        __m256i sh[16];
+        for (z = 0; z < 16; z+=4) {
+            int Z = z*2;
 
 #define m128_to_256 _mm256_castsi128_si256
-	    __m256i t0, t1, t2, t3;
-	    __m128i *s0, *s1, *s2, *s3;
-	    s0 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+0]] + lN[Z+0]));
-	    s1 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+4]] + lN[Z+4]));
-	    s2 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+1]] + lN[Z+1]));
-	    s3 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+5]] + lN[Z+5]));
-	    t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0xE4);
-	    t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0xE4);
-	    t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x93);
-	    t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x93);
+            __m256i t0, t1, t2, t3;
+            __m128i *s0, *s1, *s2, *s3;
+            s0 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+0]] + lN[Z+0]));
+            s1 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+4]] + lN[Z+4]));
+            s2 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+1]] + lN[Z+1]));
+            s3 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+5]] + lN[Z+5]));
+            t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0xE4);
+            t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0xE4);
+            t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x93);
+            t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x93);
 
-	    lN[Z+0] = in[iN[Z+0]];
-	    lN[Z+4] = in[iN[Z+4]];
-	    lN[Z+1] = in[iN[Z+1]];
-	    lN[Z+5] = in[iN[Z+5]];
+            lN[Z+0] = in[iN[Z+0]];
+            lN[Z+4] = in[iN[Z+4]];
+            lN[Z+1] = in[iN[Z+1]];
+            lN[Z+5] = in[iN[Z+5]];
 
-	    sh[z+0] = _mm256_permute2x128_si256(t0, t1, 0x20);
-	    sh[z+1] = _mm256_permute2x128_si256(t2, t3, 0x20);
+            sh[z+0] = _mm256_permute2x128_si256(t0, t1, 0x20);
+            sh[z+1] = _mm256_permute2x128_si256(t2, t3, 0x20);
 
-	    s0 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+2]] + lN[Z+2]));
-	    s1 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+6]] + lN[Z+6]));
-	    s2 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+3]] + lN[Z+3]));
-	    s3 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+7]] + lN[Z+7]));
-	    t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0x4E);
-	    t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0x4E);
-	    t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x39);
-	    t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x39);
+            s0 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+2]] + lN[Z+2]));
+            s1 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+6]] + lN[Z+6]));
+            s2 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+3]] + lN[Z+3]));
+            s3 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+7]] + lN[Z+7]));
+            t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0x4E);
+            t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0x4E);
+            t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x39);
+            t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x39);
 
-	    lN[Z+2] = in[iN[Z+2]];
-	    lN[Z+6] = in[iN[Z+6]];
-	    lN[Z+3] = in[iN[Z+3]];
-	    lN[Z+7] = in[iN[Z+7]];
+            lN[Z+2] = in[iN[Z+2]];
+            lN[Z+6] = in[iN[Z+6]];
+            lN[Z+3] = in[iN[Z+3]];
+            lN[Z+7] = in[iN[Z+7]];
 
-	    sh[z+2] = _mm256_permute2x128_si256(t0, t1, 0x20);
-	    sh[z+3] = _mm256_permute2x128_si256(t2, t3, 0x20);
+            sh[z+2] = _mm256_permute2x128_si256(t0, t1, 0x20);
+            sh[z+3] = _mm256_permute2x128_si256(t2, t3, 0x20);
 
-	    // potential to set xmax, rf, bias, and SD in-situ here, removing
-	    // the need to hold sh[] in regs.  Doing so doesn't seem to speed
-	    // things up though.
-	}
+            // potential to set xmax, rf, bias, and SD in-situ here, removing
+            // the need to hold sh[] in regs.  Doing so doesn't seem to speed
+            // things up though.
+        }
 
-	__m256i xA = _mm256_set_epi32(0,0,0,-1, 0,0,0,-1);
-	__m256i xB = _mm256_set_epi32(0,0,-1,0, 0,0,-1,0);
-	__m256i xC = _mm256_set_epi32(0,-1,0,0, 0,-1,0,0);
-	__m256i xD = _mm256_set_epi32(-1,0,0,0, -1,0,0,0);
+        __m256i xA = _mm256_set_epi32(0,0,0,-1, 0,0,0,-1);
+        __m256i xB = _mm256_set_epi32(0,0,-1,0, 0,0,-1,0);
+        __m256i xC = _mm256_set_epi32(0,-1,0,0, 0,-1,0,0);
+        __m256i xD = _mm256_set_epi32(-1,0,0,0, -1,0,0,0);
 
-	// Extract 32-bit xmax elements from syms[] data (in sh vec array)
+        // Extract 32-bit xmax elements from syms[] data (in sh vec array)
 /*
-#define SYM_LOAD(x, A, B, C, D)						\
-	_mm256_or_si256(_mm256_or_si256(_mm256_and_si256(sh[x+0], A),	\
-					_mm256_and_si256(sh[x+1], B)),	\
-  	                _mm256_or_si256(_mm256_and_si256(sh[x+2], C),	\
-			                _mm256_and_si256(sh[x+3], D)))
+#define SYM_LOAD(x, A, B, C, D)                                         \
+        _mm256_or_si256(_mm256_or_si256(_mm256_and_si256(sh[x+0], A),   \
+                                        _mm256_and_si256(sh[x+1], B)),  \
+                        _mm256_or_si256(_mm256_and_si256(sh[x+2], C),   \
+                                        _mm256_and_si256(sh[x+3], D)))
 */
-	__m256i xmax1 = SYM_LOAD( 0, xA, xB, xC, xD);
-	__m256i xmax2 = SYM_LOAD( 4, xA, xB, xC, xD);
-	__m256i xmax3 = SYM_LOAD( 8, xA, xB, xC, xD);
-	__m256i xmax4 = SYM_LOAD(12, xA, xB, xC, xD);
+        __m256i xmax1 = SYM_LOAD( 0, xA, xB, xC, xD);
+        __m256i xmax2 = SYM_LOAD( 4, xA, xB, xC, xD);
+        __m256i xmax3 = SYM_LOAD( 8, xA, xB, xC, xD);
+        __m256i xmax4 = SYM_LOAD(12, xA, xB, xC, xD);
 
-	// ------------------------------------------------------------
-	//	for (z = NX-1; z >= 0; z--) {
-	//	    if (ransN[z] >= x_max[z]) {
-	//		*--ptr16 = ransN[z] & 0xffff;
-	//		ransN[z] >>= 16;
-	//	    }
-	//	}
+        // ------------------------------------------------------------
+        //      for (z = NX-1; z >= 0; z--) {
+        //          if (ransN[z] >= x_max[z]) {
+        //              *--ptr16 = ransN[z] & 0xffff;
+        //              ransN[z] >>= 16;
+        //          }
+        //      }
         __m256i cv1 = _mm256_cmpgt_epi32(Rv1, xmax1);
         __m256i cv2 = _mm256_cmpgt_epi32(Rv2, xmax2);
         __m256i cv3 = _mm256_cmpgt_epi32(Rv3, xmax3);
@@ -878,7 +878,7 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
         __m256i idx4 = _mm256_load_si256((const __m256i*)permutec[imask4]);
 
         // Permute; to gather together the rans states that need flushing
-	__m256i V1, V2, V3, V4;
+        __m256i V1, V2, V3, V4;
         V1 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv1, cv1), idx1);
         V2 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv2, cv2), idx2);
         V3 = _mm256_permutevar8x32_epi32(_mm256_and_si256(Rv3, cv3), idx3);
@@ -896,9 +896,9 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
         V12 = _mm256_permute4x64_epi64(V12, 0xd8);
         V34 = _mm256_permute4x64_epi64(V34, 0xd8);
 
-	// Load rcp_freq ready for later
-	__m256i rfv1 = _mm256_shuffle_epi32(SYM_LOAD( 0, xB, xC, xD, xA),0x39);
-	__m256i rfv2 = _mm256_shuffle_epi32(SYM_LOAD( 4, xB, xC, xD, xA),0x39);
+        // Load rcp_freq ready for later
+        __m256i rfv1 = _mm256_shuffle_epi32(SYM_LOAD( 0, xB, xC, xD, xA),0x39);
+        __m256i rfv2 = _mm256_shuffle_epi32(SYM_LOAD( 4, xB, xC, xD, xA),0x39);
 
         // Now we have bottom N 16-bit values in each V12/V34 to flush
         __m128i f =  _mm256_extractf128_si256(V34, 1);
@@ -917,8 +917,8 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
         _mm_storeu_si128((__m128i *)(ptr16-8), f);
         ptr16 -= _mm_popcnt_u32(imask1);
 
-	__m256i rfv3 = _mm256_shuffle_epi32(SYM_LOAD( 8, xB, xC, xD, xA),0x39);
-	__m256i rfv4 = _mm256_shuffle_epi32(SYM_LOAD(12, xB, xC, xD, xA),0x39);
+        __m256i rfv3 = _mm256_shuffle_epi32(SYM_LOAD( 8, xB, xC, xD, xA),0x39);
+        __m256i rfv4 = _mm256_shuffle_epi32(SYM_LOAD(12, xB, xC, xD, xA),0x39);
 
         __m256i Rs1, Rs2, Rs3, Rs4;
         Rs1 = _mm256_srli_epi32(Rv1,16);
@@ -926,42 +926,42 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
         Rs3 = _mm256_srli_epi32(Rv3,16);
         Rs4 = _mm256_srli_epi32(Rv4,16);
 
-	Rv1 = _mm256_blendv_epi8(Rv1, Rs1, cv1);
-	Rv2 = _mm256_blendv_epi8(Rv2, Rs2, cv2);
-	Rv3 = _mm256_blendv_epi8(Rv3, Rs3, cv3);
-	Rv4 = _mm256_blendv_epi8(Rv4, Rs4, cv4);
+        Rv1 = _mm256_blendv_epi8(Rv1, Rs1, cv1);
+        Rv2 = _mm256_blendv_epi8(Rv2, Rs2, cv2);
+        Rv3 = _mm256_blendv_epi8(Rv3, Rs3, cv3);
+        Rv4 = _mm256_blendv_epi8(Rv4, Rs4, cv4);
 
-	// ------------------------------------------------------------
-	// uint32_t q = (uint32_t) (((uint64_t)ransN[z] *
-	//                           rcp_freq[z]) >> rcp_shift[z]);
-	// ransN[z] = ransN[z] + bias[z] + q * cmpl_freq[z];
+        // ------------------------------------------------------------
+        // uint32_t q = (uint32_t) (((uint64_t)ransN[z] *
+        //                           rcp_freq[z]) >> rcp_shift[z]);
+        // ransN[z] = ransN[z] + bias[z] + q * cmpl_freq[z];
 
         // Cannot trivially replace the multiply as mulhi_epu32 doesn't exist
-	// (only mullo).  However we can use _mm256_mul_epu32 twice to get
-	// 64bit results (half our lanes) and shift/or to get the answer.
+        // (only mullo).  However we can use _mm256_mul_epu32 twice to get
+        // 64bit results (half our lanes) and shift/or to get the answer.
         //
         // (AVX512 allows us to hold it all in 64-bit lanes and use mullo_epi64
         // plus a shift.  KNC has mulhi_epi32, but not sure if this is
-	// available.)
+        // available.)
         rfv1 = _mm256_mulhi_epu32(Rv1, rfv1);
         rfv2 = _mm256_mulhi_epu32(Rv2, rfv2);
         rfv3 = _mm256_mulhi_epu32(Rv3, rfv3);
         rfv4 = _mm256_mulhi_epu32(Rv4, rfv4);
 
-	// Load cmpl_freq / rcp_shift from syms
-	__m256i SDv1 = _mm256_shuffle_epi32(SYM_LOAD( 0, xD, xA, xB, xC),0x93);
-	__m256i SDv2 = _mm256_shuffle_epi32(SYM_LOAD( 4, xD, xA, xB, xC),0x93);
-	// Load bias from syms[]
-	__m256i biasv1=_mm256_shuffle_epi32(SYM_LOAD( 0, xC, xD, xA, xB),0x4E);
-	__m256i biasv2=_mm256_shuffle_epi32(SYM_LOAD( 4, xC, xD, xA, xB),0x4E);
+        // Load cmpl_freq / rcp_shift from syms
+        __m256i SDv1 = _mm256_shuffle_epi32(SYM_LOAD( 0, xD, xA, xB, xC),0x93);
+        __m256i SDv2 = _mm256_shuffle_epi32(SYM_LOAD( 4, xD, xA, xB, xC),0x93);
+        // Load bias from syms[]
+        __m256i biasv1=_mm256_shuffle_epi32(SYM_LOAD( 0, xC, xD, xA, xB),0x4E);
+        __m256i biasv2=_mm256_shuffle_epi32(SYM_LOAD( 4, xC, xD, xA, xB),0x4E);
 
         __m256i shiftv1 = _mm256_srli_epi32(SDv1, 16);
         __m256i shiftv2 = _mm256_srli_epi32(SDv2, 16);
 
-	__m256i SDv3 = _mm256_shuffle_epi32(SYM_LOAD( 8, xD, xA, xB, xC),0x93);
-	__m256i SDv4 = _mm256_shuffle_epi32(SYM_LOAD(12, xD, xA, xB, xC),0x93);
-	__m256i biasv3=_mm256_shuffle_epi32(SYM_LOAD( 8, xC, xD, xA, xB),0x4E);
-	__m256i biasv4=_mm256_shuffle_epi32(SYM_LOAD(12, xC, xD, xA, xB),0x4E);
+        __m256i SDv3 = _mm256_shuffle_epi32(SYM_LOAD( 8, xD, xA, xB, xC),0x93);
+        __m256i SDv4 = _mm256_shuffle_epi32(SYM_LOAD(12, xD, xA, xB, xC),0x93);
+        __m256i biasv3=_mm256_shuffle_epi32(SYM_LOAD( 8, xC, xD, xA, xB),0x4E);
+        __m256i biasv4=_mm256_shuffle_epi32(SYM_LOAD(12, xC, xD, xA, xB),0x4E);
 
         __m256i shiftv3 = _mm256_srli_epi32(SDv3, 16);
         __m256i shiftv4 = _mm256_srli_epi32(SDv4, 16);
@@ -988,14 +988,14 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
         qv4 = _mm256_mullo_epi32(qv4, freqv4);
 
         qv1 = _mm256_add_epi32(qv1, biasv1);
-	qv2 = _mm256_add_epi32(qv2, biasv2);
+        qv2 = _mm256_add_epi32(qv2, biasv2);
         qv3 = _mm256_add_epi32(qv3, biasv3);
         qv4 = _mm256_add_epi32(qv4, biasv4);
 
-	for (z = 0; z < NX; z++)
-	    iN[z]--;
+        for (z = 0; z < NX; z++)
+            iN[z]--;
 
-	Rv1 = _mm256_add_epi32(Rv1, qv1);
+        Rv1 = _mm256_add_epi32(Rv1, qv1);
         Rv2 = _mm256_add_epi32(Rv2, qv2);
         Rv3 = _mm256_add_epi32(Rv3, qv3);
         Rv4 = _mm256_add_epi32(Rv4, qv4);
@@ -1006,10 +1006,10 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
     ptr = (uint8_t *)ptr16;
 
     for (z = NX-1; z>=0; z--)
-	RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
+        RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
 
     for (z = NX-1; z>=0; z--)
-	RansEncFlush(&ransN[z], &ptr);
+        RansEncFlush(&ransN[z], &ptr);
 
     *out_size = (out_end - ptr) + tab_size;
 
@@ -1026,12 +1026,12 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
  * can then flush to out in 1KB blocks.
  */
 static inline void transpose_and_copy(uint8_t *out, int iN[32],
-				      uint8_t t[32][32]) {
+                                      uint8_t t[32][32]) {
 //  int z;
 //  for (z = 0; z < NX; z++) {
 //      int k;
 //      for (k = 0; k < 32; k++)
-//  	out[iN[z]+k] = t[k][z];
+//      out[iN[z]+k] = t[k][z];
 //      iN[z] += 32;
 //  }
 
@@ -1039,18 +1039,18 @@ static inline void transpose_and_copy(uint8_t *out, int iN[32],
 }
 
 unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz) {
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz) {
     if (in_size < NX*4) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -1059,15 +1059,15 @@ unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
 
     uint32_t (*s3)[TOTFREQ_O1] = htscodecs_tls_alloc(256*TOTFREQ_O1*4);
     if (!s3)
-	return NULL;
+        return NULL;
     //uint32_t s3[256][TOTFREQ_O1] __attribute__((aligned(32)));
     uint32_t (*s3F)[TOTFREQ_O1_FAST] = (uint32_t (*)[TOTFREQ_O1_FAST])s3;
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
 
     if (!out)
-	goto err;
+        goto err;
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
@@ -1076,43 +1076,43 @@ unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
     unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
-	uint32_t u_freq_sz, c_freq_sz;
-	cp += var_get_u32(cp, cp_end, &u_freq_sz);
-	cp += var_get_u32(cp, cp_end, &c_freq_sz);
-	if (c_freq_sz >= cp_end - cp - 16)
-	    goto err;
-	tab_end = cp + c_freq_sz;
-	if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL,
-					       u_freq_sz)))
-	    goto err;
-	cp = c_freq;
-	c_freq_end = c_freq + u_freq_sz;
+        uint32_t u_freq_sz, c_freq_sz;
+        cp += var_get_u32(cp, cp_end, &u_freq_sz);
+        cp += var_get_u32(cp, cp_end, &c_freq_sz);
+        if (c_freq_sz >= cp_end - cp - 16)
+            goto err;
+        tab_end = cp + c_freq_sz;
+        if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL,
+                                               u_freq_sz)))
+            goto err;
+        cp = c_freq;
+        c_freq_end = c_freq + u_freq_sz;
     }
 
     // Decode order-0 symbol list; avoids needing in order-1 tables
     cp += decode_freq1(cp, c_freq_end, shift, s3, s3F, NULL, NULL);
 
     if (tab_end)
-	cp = tab_end;
+        cp = tab_end;
     free(c_freq);
     c_freq = NULL;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     RansState R[NX] __attribute__((aligned(32)));
     uint8_t *ptr = cp, *ptr_end = in + in_size;
     int z;
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &ptr);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &ptr);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     int isz4 = out_sz/NX;
     int iN[NX], lN[NX] __attribute__((aligned(32))) = {0};
     for (z = 0; z < NX; z++)
-	iN[z] = z*isz4;
+        iN[z] = z*isz4;
 
     uint16_t *sp = (uint16_t *)ptr;
     const uint32_t mask = (1u << shift)-1;
@@ -1122,516 +1122,516 @@ unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
     LOAD(Lv, lN);
 
     union {
-	unsigned char tbuf[32][32];
-	uint64_t tbuf64[32][4];
+        unsigned char tbuf[32][32];
+        uint64_t tbuf64[32][4];
     } u;
     unsigned int tidx = 0;
 
     if (0) {
-	int z;
-	for (z = 0; z < 32; z++)
-	    iN[z] = iN[z] & ~31;
+        int z;
+        for (z = 0; z < 32; z++)
+            iN[z] = iN[z] & ~31;
     }
 
     if (shift == TF_SHIFT_O1) {
-	isz4 -= 64;
-	for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
-	    // m[z] = R[z] & mask;
-	    __m256i masked1 = _mm256_and_si256(Rv1, maskv);
-	    __m256i masked2 = _mm256_and_si256(Rv2, maskv);
+        isz4 -= 64;
+        for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
+            // m[z] = R[z] & mask;
+            __m256i masked1 = _mm256_and_si256(Rv1, maskv);
+            __m256i masked2 = _mm256_and_si256(Rv2, maskv);
 
-	    //  S[z] = s3[lN[z]][m[z]];
-	    Lv1 = _mm256_slli_epi32(Lv1, TF_SHIFT_O1);
-	    masked1 = _mm256_add_epi32(masked1, Lv1);
+            //  S[z] = s3[lN[z]][m[z]];
+            Lv1 = _mm256_slli_epi32(Lv1, TF_SHIFT_O1);
+            masked1 = _mm256_add_epi32(masked1, Lv1);
 
-	    Lv2 = _mm256_slli_epi32(Lv2, TF_SHIFT_O1);
-	    masked2 = _mm256_add_epi32(masked2, Lv2);
+            Lv2 = _mm256_slli_epi32(Lv2, TF_SHIFT_O1);
+            masked2 = _mm256_add_epi32(masked2, Lv2);
 
-	    __m256i masked3 = _mm256_and_si256(Rv3, maskv);
-	    __m256i masked4 = _mm256_and_si256(Rv4, maskv);
+            __m256i masked3 = _mm256_and_si256(Rv3, maskv);
+            __m256i masked4 = _mm256_and_si256(Rv4, maskv);
 
-	    Lv3 = _mm256_slli_epi32(Lv3, TF_SHIFT_O1);
-	    masked3 = _mm256_add_epi32(masked3, Lv3);
+            Lv3 = _mm256_slli_epi32(Lv3, TF_SHIFT_O1);
+            masked3 = _mm256_add_epi32(masked3, Lv3);
 
-	    Lv4 = _mm256_slli_epi32(Lv4, TF_SHIFT_O1);
-	    masked4 = _mm256_add_epi32(masked4, Lv4);
+            Lv4 = _mm256_slli_epi32(Lv4, TF_SHIFT_O1);
+            masked4 = _mm256_add_epi32(masked4, Lv4);
 
-	    __m256i Sv1 = _mm256_i32gather_epi32x((int *)&s3[0][0], masked1,
-						  sizeof(s3[0][0]));
-	    __m256i Sv2 = _mm256_i32gather_epi32x((int *)&s3[0][0], masked2,
-						  sizeof(s3[0][0]));
+            __m256i Sv1 = _mm256_i32gather_epi32x((int *)&s3[0][0], masked1,
+                                                  sizeof(s3[0][0]));
+            __m256i Sv2 = _mm256_i32gather_epi32x((int *)&s3[0][0], masked2,
+                                                  sizeof(s3[0][0]));
 
-	    //  f[z] = S[z]>>(TF_SHIFT_O1+8);
-	    __m256i fv1 = _mm256_srli_epi32(Sv1, TF_SHIFT_O1+8);
-	    __m256i fv2 = _mm256_srli_epi32(Sv2, TF_SHIFT_O1+8);
+            //  f[z] = S[z]>>(TF_SHIFT_O1+8);
+            __m256i fv1 = _mm256_srli_epi32(Sv1, TF_SHIFT_O1+8);
+            __m256i fv2 = _mm256_srli_epi32(Sv2, TF_SHIFT_O1+8);
 
-	    __m256i Sv3 = _mm256_i32gather_epi32x((int *)&s3[0][0], masked3,
-						  sizeof(s3[0][0]));
-	    __m256i Sv4 = _mm256_i32gather_epi32x((int *)&s3[0][0], masked4,
-						  sizeof(s3[0][0]));
+            __m256i Sv3 = _mm256_i32gather_epi32x((int *)&s3[0][0], masked3,
+                                                  sizeof(s3[0][0]));
+            __m256i Sv4 = _mm256_i32gather_epi32x((int *)&s3[0][0], masked4,
+                                                  sizeof(s3[0][0]));
 
-	    __m256i fv3 = _mm256_srli_epi32(Sv3, TF_SHIFT_O1+8);
-	    __m256i fv4 = _mm256_srli_epi32(Sv4, TF_SHIFT_O1+8);
+            __m256i fv3 = _mm256_srli_epi32(Sv3, TF_SHIFT_O1+8);
+            __m256i fv4 = _mm256_srli_epi32(Sv4, TF_SHIFT_O1+8);
 
-	    //  b[z] = (S[z]>>8) & mask;
-	    __m256i bv1 = _mm256_and_si256(_mm256_srli_epi32(Sv1, 8), maskv);
-	    __m256i bv2 = _mm256_and_si256(_mm256_srli_epi32(Sv2, 8), maskv);
-	    __m256i bv3 = _mm256_and_si256(_mm256_srli_epi32(Sv3, 8), maskv);
-	    __m256i bv4 = _mm256_and_si256(_mm256_srli_epi32(Sv4, 8), maskv);
+            //  b[z] = (S[z]>>8) & mask;
+            __m256i bv1 = _mm256_and_si256(_mm256_srli_epi32(Sv1, 8), maskv);
+            __m256i bv2 = _mm256_and_si256(_mm256_srli_epi32(Sv2, 8), maskv);
+            __m256i bv3 = _mm256_and_si256(_mm256_srli_epi32(Sv3, 8), maskv);
+            __m256i bv4 = _mm256_and_si256(_mm256_srli_epi32(Sv4, 8), maskv);
 
-	    //  s[z] = S[z] & 0xff;
-	    __m256i sv1 = _mm256_and_si256(Sv1, _mm256_set1_epi32(0xff));
-	    __m256i sv2 = _mm256_and_si256(Sv2, _mm256_set1_epi32(0xff));
-	    __m256i sv3 = _mm256_and_si256(Sv3, _mm256_set1_epi32(0xff));
-	    __m256i sv4 = _mm256_and_si256(Sv4, _mm256_set1_epi32(0xff));
+            //  s[z] = S[z] & 0xff;
+            __m256i sv1 = _mm256_and_si256(Sv1, _mm256_set1_epi32(0xff));
+            __m256i sv2 = _mm256_and_si256(Sv2, _mm256_set1_epi32(0xff));
+            __m256i sv3 = _mm256_and_si256(Sv3, _mm256_set1_epi32(0xff));
+            __m256i sv4 = _mm256_and_si256(Sv4, _mm256_set1_epi32(0xff));
 
-	    if (1) {
-		// A maximum frequency of 4096 doesn't fit in our s3 array.
-		// as it's 12 bit + 12 bit + 8 bit.  It wraps around to zero.
-		// (We don't have this issue for TOTFREQ_O1_FAST.)
-		//
-		// Solution 1 is to change to spec to forbid freq of 4096.
-		// Easy hack is to add an extra symbol so it sums correctly.
-		// => 572 MB/s on q40 (deskpro).
-		//
-		// Solution 2 implemented here is to look for the wrap around
-		// and fix it.
-		// => 556 MB/s on q40
-		// cope with max freq of 4096.  Only 3% hit
-		__m256i max_freq = _mm256_set1_epi32(TOTFREQ_O1);
-		__m256i zero = _mm256_setzero_si256();
-		__m256i cmp1 = _mm256_cmpeq_epi32(fv1, zero);
-		fv1 = _mm256_blendv_epi8(fv1, max_freq, cmp1);
-		__m256i cmp2 = _mm256_cmpeq_epi32(fv2, zero);
-		fv2 = _mm256_blendv_epi8(fv2, max_freq, cmp2);
-	    }
+            if (1) {
+                // A maximum frequency of 4096 doesn't fit in our s3 array.
+                // as it's 12 bit + 12 bit + 8 bit.  It wraps around to zero.
+                // (We don't have this issue for TOTFREQ_O1_FAST.)
+                //
+                // Solution 1 is to change to spec to forbid freq of 4096.
+                // Easy hack is to add an extra symbol so it sums correctly.
+                // => 572 MB/s on q40 (deskpro).
+                //
+                // Solution 2 implemented here is to look for the wrap around
+                // and fix it.
+                // => 556 MB/s on q40
+                // cope with max freq of 4096.  Only 3% hit
+                __m256i max_freq = _mm256_set1_epi32(TOTFREQ_O1);
+                __m256i zero = _mm256_setzero_si256();
+                __m256i cmp1 = _mm256_cmpeq_epi32(fv1, zero);
+                fv1 = _mm256_blendv_epi8(fv1, max_freq, cmp1);
+                __m256i cmp2 = _mm256_cmpeq_epi32(fv2, zero);
+                fv2 = _mm256_blendv_epi8(fv2, max_freq, cmp2);
+            }
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
-	    Rv1 = _mm256_add_epi32(
-		      _mm256_mullo_epi32(
-		          _mm256_srli_epi32(Rv1,TF_SHIFT_O1), fv1), bv1);
-	    Rv2 = _mm256_add_epi32(
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
+            Rv1 = _mm256_add_epi32(
+                      _mm256_mullo_epi32(
+                          _mm256_srli_epi32(Rv1,TF_SHIFT_O1), fv1), bv1);
+            Rv2 = _mm256_add_epi32(
                       _mm256_mullo_epi32(
                           _mm256_srli_epi32(Rv2,TF_SHIFT_O1), fv2), bv2);
 
 
-	    //for (z = 0; z < NX; z++) lN[z] = c[z];
-	    Lv1 = sv1;
-	    Lv2 = sv2;
+            //for (z = 0; z < NX; z++) lN[z] = c[z];
+            Lv1 = sv1;
+            Lv2 = sv2;
 
-	    sv1 = _mm256_packus_epi32(sv1, sv2);
-	    sv1 = _mm256_permute4x64_epi64(sv1, 0xd8);
+            sv1 = _mm256_packus_epi32(sv1, sv2);
+            sv1 = _mm256_permute4x64_epi64(sv1, 0xd8);
 
-	    // Start loading next batch of normalised states
-	    __m256i Vv1 = _mm256_cvtepu16_epi32(
-			      _mm_loadu_si128((__m128i *)sp));
-
-	    sv1 = _mm256_packus_epi16(sv1, sv1);
-
-	    // out[iN[z]] = c[z];  // simulate scatter
-	    // RansDecRenorm(&R[z], &ptr);	
-	    __m256i renorm_mask1, renorm_mask2;
-	    renorm_mask1 = _mm256_xor_si256(Rv1,_mm256_set1_epi32(0x80000000));
-	    renorm_mask2 = _mm256_xor_si256(Rv2,_mm256_set1_epi32(0x80000000));
-
-	    renorm_mask1 = _mm256_cmpgt_epi32(
-			       _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
-			       renorm_mask1);
-	    renorm_mask2 = _mm256_cmpgt_epi32(
-			       _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
-			       renorm_mask2);
-
-	    unsigned int imask1 = _mm256_movemask_ps((__m256)renorm_mask1);
-	    __m256i idx1 = _mm256_load_si256((const __m256i*)permute[imask1]);
-	    __m256i Yv1 = _mm256_slli_epi32(Rv1, 16);
-	    __m256i Yv2 = _mm256_slli_epi32(Rv2, 16);
-
-	    unsigned int imask2 = _mm256_movemask_ps((__m256)renorm_mask2);
-	    Vv1 = _mm256_permutevar8x32_epi32(Vv1, idx1);
-	    sp += _mm_popcnt_u32(imask1);
-
-	    __m256i idx2 = _mm256_load_si256((const __m256i*)permute[imask2]);
-	    __m256i Vv2 = _mm256_cvtepu16_epi32(
+            // Start loading next batch of normalised states
+            __m256i Vv1 = _mm256_cvtepu16_epi32(
                               _mm_loadu_si128((__m128i *)sp));
-	    sp += _mm_popcnt_u32(imask2);
-	    Vv2 = _mm256_permutevar8x32_epi32(Vv2, idx2);
 
-	    Yv1 = _mm256_or_si256(Yv1, Vv1);
-	    Yv2 = _mm256_or_si256(Yv2, Vv2);
+            sv1 = _mm256_packus_epi16(sv1, sv1);
 
-	    Rv1 = _mm256_blendv_epi8(Rv1, Yv1, renorm_mask1);
-	    Rv2 = _mm256_blendv_epi8(Rv2, Yv2, renorm_mask2);
+            // out[iN[z]] = c[z];  // simulate scatter
+            // RansDecRenorm(&R[z], &ptr);      
+            __m256i renorm_mask1, renorm_mask2;
+            renorm_mask1 = _mm256_xor_si256(Rv1,_mm256_set1_epi32(0x80000000));
+            renorm_mask2 = _mm256_xor_si256(Rv2,_mm256_set1_epi32(0x80000000));
 
-	    //////////////////////////////////////////////////////////////////
-	    // Start loading next batch of normalised states
-	    __m256i Vv3 = _mm256_cvtepu16_epi32(
-			      _mm_loadu_si128((__m128i *)sp));
+            renorm_mask1 = _mm256_cmpgt_epi32(
+                               _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
+                               renorm_mask1);
+            renorm_mask2 = _mm256_cmpgt_epi32(
+                               _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
+                               renorm_mask2);
 
-	    if (1) {
-		// cope with max freq of 4096
-		__m256i max_freq = _mm256_set1_epi32(TOTFREQ_O1);
-		__m256i zero = _mm256_setzero_si256();
-		__m256i cmp3 = _mm256_cmpeq_epi32(fv3, zero);
-		fv3 = _mm256_blendv_epi8(fv3, max_freq, cmp3);
-		__m256i cmp4 = _mm256_cmpeq_epi32(fv4, zero);
-		fv4 = _mm256_blendv_epi8(fv4, max_freq, cmp4);
-	    }
+            unsigned int imask1 = _mm256_movemask_ps((__m256)renorm_mask1);
+            __m256i idx1 = _mm256_load_si256((const __m256i*)permute[imask1]);
+            __m256i Yv1 = _mm256_slli_epi32(Rv1, 16);
+            __m256i Yv2 = _mm256_slli_epi32(Rv2, 16);
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
-	    Rv3 = _mm256_add_epi32(
+            unsigned int imask2 = _mm256_movemask_ps((__m256)renorm_mask2);
+            Vv1 = _mm256_permutevar8x32_epi32(Vv1, idx1);
+            sp += _mm_popcnt_u32(imask1);
+
+            __m256i idx2 = _mm256_load_si256((const __m256i*)permute[imask2]);
+            __m256i Vv2 = _mm256_cvtepu16_epi32(
+                              _mm_loadu_si128((__m128i *)sp));
+            sp += _mm_popcnt_u32(imask2);
+            Vv2 = _mm256_permutevar8x32_epi32(Vv2, idx2);
+
+            Yv1 = _mm256_or_si256(Yv1, Vv1);
+            Yv2 = _mm256_or_si256(Yv2, Vv2);
+
+            Rv1 = _mm256_blendv_epi8(Rv1, Yv1, renorm_mask1);
+            Rv2 = _mm256_blendv_epi8(Rv2, Yv2, renorm_mask2);
+
+            //////////////////////////////////////////////////////////////////
+            // Start loading next batch of normalised states
+            __m256i Vv3 = _mm256_cvtepu16_epi32(
+                              _mm_loadu_si128((__m128i *)sp));
+
+            if (1) {
+                // cope with max freq of 4096
+                __m256i max_freq = _mm256_set1_epi32(TOTFREQ_O1);
+                __m256i zero = _mm256_setzero_si256();
+                __m256i cmp3 = _mm256_cmpeq_epi32(fv3, zero);
+                fv3 = _mm256_blendv_epi8(fv3, max_freq, cmp3);
+                __m256i cmp4 = _mm256_cmpeq_epi32(fv4, zero);
+                fv4 = _mm256_blendv_epi8(fv4, max_freq, cmp4);
+            }
+
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
+            Rv3 = _mm256_add_epi32(
                       _mm256_mullo_epi32(
                           _mm256_srli_epi32(Rv3,TF_SHIFT_O1), fv3), bv3);
-	    Rv4 = _mm256_add_epi32(
+            Rv4 = _mm256_add_epi32(
                       _mm256_mullo_epi32(
                           _mm256_srli_epi32(Rv4,TF_SHIFT_O1), fv4), bv4);
 
-	    //for (z = 0; z < NX; z++) lN[z] = c[z];
-	    Lv3 = sv3;
-	    Lv4 = sv4;
+            //for (z = 0; z < NX; z++) lN[z] = c[z];
+            Lv3 = sv3;
+            Lv4 = sv4;
 
-	    // out[iN[z]] = c[z];  // simulate scatter
-	    // RansDecRenorm(&R[z], &ptr);	
-	    __m256i renorm_mask3, renorm_mask4;
-	    renorm_mask3 = _mm256_xor_si256(Rv3,_mm256_set1_epi32(0x80000000));
-	    renorm_mask4 = _mm256_xor_si256(Rv4,_mm256_set1_epi32(0x80000000));
+            // out[iN[z]] = c[z];  // simulate scatter
+            // RansDecRenorm(&R[z], &ptr);      
+            __m256i renorm_mask3, renorm_mask4;
+            renorm_mask3 = _mm256_xor_si256(Rv3,_mm256_set1_epi32(0x80000000));
+            renorm_mask4 = _mm256_xor_si256(Rv4,_mm256_set1_epi32(0x80000000));
 
-	    renorm_mask3 = _mm256_cmpgt_epi32(
+            renorm_mask3 = _mm256_cmpgt_epi32(
                                _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
-			       renorm_mask3);
-	    renorm_mask4 = _mm256_cmpgt_epi32(
-			       _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
-			       renorm_mask4);
+                               renorm_mask3);
+            renorm_mask4 = _mm256_cmpgt_epi32(
+                               _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
+                               renorm_mask4);
 
-	    __m256i Yv3 = _mm256_slli_epi32(Rv3, 16);
-	    __m256i Yv4 = _mm256_slli_epi32(Rv4, 16);
+            __m256i Yv3 = _mm256_slli_epi32(Rv3, 16);
+            __m256i Yv4 = _mm256_slli_epi32(Rv4, 16);
 
-	    unsigned int imask3 = _mm256_movemask_ps((__m256)renorm_mask3);
-	    unsigned int imask4 = _mm256_movemask_ps((__m256)renorm_mask4);
-	    __m256i idx3 = _mm256_load_si256((const __m256i*)permute[imask3]);
-	    sp += _mm_popcnt_u32(imask3);
-	    Vv3 = _mm256_permutevar8x32_epi32(Vv3, idx3);
+            unsigned int imask3 = _mm256_movemask_ps((__m256)renorm_mask3);
+            unsigned int imask4 = _mm256_movemask_ps((__m256)renorm_mask4);
+            __m256i idx3 = _mm256_load_si256((const __m256i*)permute[imask3]);
+            sp += _mm_popcnt_u32(imask3);
+            Vv3 = _mm256_permutevar8x32_epi32(Vv3, idx3);
 
-	    sv3 = _mm256_packus_epi32(sv3, sv4);
-	    sv3 = _mm256_permute4x64_epi64(sv3, 0xd8);
-	    sv3 = _mm256_packus_epi16(sv3, sv3);
+            sv3 = _mm256_packus_epi32(sv3, sv4);
+            sv3 = _mm256_permute4x64_epi64(sv3, 0xd8);
+            sv3 = _mm256_packus_epi16(sv3, sv3);
 
-	    u.tbuf64[tidx][0] = _mm256_extract_epi64(sv1, 0);
-	    u.tbuf64[tidx][1] = _mm256_extract_epi64(sv1, 2);
-	    u.tbuf64[tidx][2] = _mm256_extract_epi64(sv3, 0);
-	    u.tbuf64[tidx][3] = _mm256_extract_epi64(sv3, 2);
+            u.tbuf64[tidx][0] = _mm256_extract_epi64(sv1, 0);
+            u.tbuf64[tidx][1] = _mm256_extract_epi64(sv1, 2);
+            u.tbuf64[tidx][2] = _mm256_extract_epi64(sv3, 0);
+            u.tbuf64[tidx][3] = _mm256_extract_epi64(sv3, 2);
 
-	    iN[0]++;
-	    if (++tidx == 32) {
-		iN[0]-=32;
+            iN[0]++;
+            if (++tidx == 32) {
+                iN[0]-=32;
 
-		transpose_and_copy(out, iN, u.tbuf);
-		tidx = 0;
-	    }
+                transpose_and_copy(out, iN, u.tbuf);
+                tidx = 0;
+            }
 
-	    __m256i idx4 = _mm256_load_si256((const __m256i*)permute[imask4]);
-	    __m256i Vv4 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            __m256i idx4 = _mm256_load_si256((const __m256i*)permute[imask4]);
+            __m256i Vv4 = _mm256_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
 
-	    //Vv = _mm256_and_si256(Vv, renorm_mask);  (blend does the AND anyway)
-	    Yv3 = _mm256_or_si256(Yv3, Vv3);
-	    Vv4 = _mm256_permutevar8x32_epi32(Vv4, idx4);
-	    Yv4 = _mm256_or_si256(Yv4, Vv4);
+            //Vv = _mm256_and_si256(Vv, renorm_mask);  (blend does the AND anyway)
+            Yv3 = _mm256_or_si256(Yv3, Vv3);
+            Vv4 = _mm256_permutevar8x32_epi32(Vv4, idx4);
+            Yv4 = _mm256_or_si256(Yv4, Vv4);
 
-	    sp += _mm_popcnt_u32(imask4);
+            sp += _mm_popcnt_u32(imask4);
 
-	    Rv3 = _mm256_blendv_epi8(Rv3, Yv3, renorm_mask3);
-	    Rv4 = _mm256_blendv_epi8(Rv4, Yv4, renorm_mask4);
+            Rv3 = _mm256_blendv_epi8(Rv3, Yv3, renorm_mask3);
+            Rv4 = _mm256_blendv_epi8(Rv4, Yv4, renorm_mask4);
 
-	}
-	isz4 += 64;
+        }
+        isz4 += 64;
 
-	STORE(Rv, R);
-	STORE(Lv, lN);
-	ptr = (uint8_t *)sp;
+        STORE(Rv, R);
+        STORE(Lv, lN);
+        ptr = (uint8_t *)sp;
 
-	if (1) {
-	    iN[0]-=tidx;
-	    int T;
-	    for (z = 0; z < NX; z++)
-		for (T = 0; T < tidx; T++)
-		    out[iN[z]++] = u.tbuf[T][z];
-	}
+        if (1) {
+            iN[0]-=tidx;
+            int T;
+            for (z = 0; z < NX; z++)
+                for (T = 0; T < tidx; T++)
+                    out[iN[z]++] = u.tbuf[T][z];
+        }
 
-	// Scalar version for close to the end of in[] array so we don't
-	// do SIMD loads beyond the end of the buffer
-	for (; iN[0] < isz4;) {
-	    for (z = 0; z < NX; z++) {
-		uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
-		uint32_t S = s3[lN[z]][m];
-		unsigned char c = S & 0xff;
-		out[iN[z]++] = c;
-		uint32_t F = S>>(TF_SHIFT_O1+8);
-		R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
-		    ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
-		RansDecRenormSafe(&R[z], &ptr, ptr_end);
-		lN[z] = c;
-	    }
-	}
+        // Scalar version for close to the end of in[] array so we don't
+        // do SIMD loads beyond the end of the buffer
+        for (; iN[0] < isz4;) {
+            for (z = 0; z < NX; z++) {
+                uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
+                uint32_t S = s3[lN[z]][m];
+                unsigned char c = S & 0xff;
+                out[iN[z]++] = c;
+                uint32_t F = S>>(TF_SHIFT_O1+8);
+                R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
+                    ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
+                RansDecRenormSafe(&R[z], &ptr, ptr_end);
+                lN[z] = c;
+            }
+        }
 
-	// Remainder
-	z = NX-1;
-	for (; iN[z] < out_sz; ) {
-	    uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
-	    uint32_t S = s3[lN[z]][m];
-	    unsigned char c = S & 0xff;
-	    out[iN[z]++] = c;
-	    uint32_t F = S>>(TF_SHIFT_O1+8);
-	    R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
-		((S>>8) & ((1u<<TF_SHIFT_O1)-1));
-	    RansDecRenormSafe(&R[z], &ptr, ptr_end);
-	    lN[z] = c;
-	}
+        // Remainder
+        z = NX-1;
+        for (; iN[z] < out_sz; ) {
+            uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
+            uint32_t S = s3[lN[z]][m];
+            unsigned char c = S & 0xff;
+            out[iN[z]++] = c;
+            uint32_t F = S>>(TF_SHIFT_O1+8);
+            R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
+                ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
+            RansDecRenormSafe(&R[z], &ptr, ptr_end);
+            lN[z] = c;
+        }
     } else {
-	// TF_SHIFT_O1_FAST.  This is the most commonly used variant.
+        // TF_SHIFT_O1_FAST.  This is the most commonly used variant.
 
-	// SIMD version ends decoding early as it reads at most 64 bytes
-	// from input via 4 vectorised loads.
-	isz4 -= 64;
-	for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
-	    // m[z] = R[z] & mask;
-	    __m256i masked1 = _mm256_and_si256(Rv1, maskv);
-	    __m256i masked2 = _mm256_and_si256(Rv2, maskv);
+        // SIMD version ends decoding early as it reads at most 64 bytes
+        // from input via 4 vectorised loads.
+        isz4 -= 64;
+        for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
+            // m[z] = R[z] & mask;
+            __m256i masked1 = _mm256_and_si256(Rv1, maskv);
+            __m256i masked2 = _mm256_and_si256(Rv2, maskv);
 
-	    //  S[z] = s3[lN[z]][m[z]];
-	    Lv1 = _mm256_slli_epi32(Lv1, TF_SHIFT_O1_FAST);
-	    masked1 = _mm256_add_epi32(masked1, Lv1);
+            //  S[z] = s3[lN[z]][m[z]];
+            Lv1 = _mm256_slli_epi32(Lv1, TF_SHIFT_O1_FAST);
+            masked1 = _mm256_add_epi32(masked1, Lv1);
 
-	    Lv2 = _mm256_slli_epi32(Lv2, TF_SHIFT_O1_FAST);
-	    masked2 = _mm256_add_epi32(masked2, Lv2);
+            Lv2 = _mm256_slli_epi32(Lv2, TF_SHIFT_O1_FAST);
+            masked2 = _mm256_add_epi32(masked2, Lv2);
 
-	    __m256i masked3 = _mm256_and_si256(Rv3, maskv);
-	    __m256i masked4 = _mm256_and_si256(Rv4, maskv);
+            __m256i masked3 = _mm256_and_si256(Rv3, maskv);
+            __m256i masked4 = _mm256_and_si256(Rv4, maskv);
 
-	    Lv3 = _mm256_slli_epi32(Lv3, TF_SHIFT_O1_FAST);
-	    masked3 = _mm256_add_epi32(masked3, Lv3);
+            Lv3 = _mm256_slli_epi32(Lv3, TF_SHIFT_O1_FAST);
+            masked3 = _mm256_add_epi32(masked3, Lv3);
 
-	    Lv4 = _mm256_slli_epi32(Lv4, TF_SHIFT_O1_FAST);
-	    masked4 = _mm256_add_epi32(masked4, Lv4);
+            Lv4 = _mm256_slli_epi32(Lv4, TF_SHIFT_O1_FAST);
+            masked4 = _mm256_add_epi32(masked4, Lv4);
 
-	    __m256i Sv1 = _mm256_i32gather_epi32x((int *)&s3F[0][0], masked1,
-						  sizeof(s3F[0][0]));
-	    __m256i Sv2 = _mm256_i32gather_epi32x((int *)&s3F[0][0], masked2,
-						  sizeof(s3F[0][0]));
+            __m256i Sv1 = _mm256_i32gather_epi32x((int *)&s3F[0][0], masked1,
+                                                  sizeof(s3F[0][0]));
+            __m256i Sv2 = _mm256_i32gather_epi32x((int *)&s3F[0][0], masked2,
+                                                  sizeof(s3F[0][0]));
 
-	    //  f[z] = S[z]>>(TF_SHIFT_O1+8);
-	    __m256i fv1 = _mm256_srli_epi32(Sv1, TF_SHIFT_O1_FAST+8);
-	    __m256i fv2 = _mm256_srli_epi32(Sv2, TF_SHIFT_O1_FAST+8);
+            //  f[z] = S[z]>>(TF_SHIFT_O1+8);
+            __m256i fv1 = _mm256_srli_epi32(Sv1, TF_SHIFT_O1_FAST+8);
+            __m256i fv2 = _mm256_srli_epi32(Sv2, TF_SHIFT_O1_FAST+8);
 
-	    __m256i Sv3 = _mm256_i32gather_epi32x((int *)&s3F[0][0], masked3,
-						  sizeof(s3F[0][0]));
-	    __m256i Sv4 = _mm256_i32gather_epi32x((int *)&s3F[0][0], masked4,
-						  sizeof(s3F[0][0]));
+            __m256i Sv3 = _mm256_i32gather_epi32x((int *)&s3F[0][0], masked3,
+                                                  sizeof(s3F[0][0]));
+            __m256i Sv4 = _mm256_i32gather_epi32x((int *)&s3F[0][0], masked4,
+                                                  sizeof(s3F[0][0]));
 
-	    __m256i fv3 = _mm256_srli_epi32(Sv3, TF_SHIFT_O1_FAST+8);
-	    __m256i fv4 = _mm256_srli_epi32(Sv4, TF_SHIFT_O1_FAST+8);
+            __m256i fv3 = _mm256_srli_epi32(Sv3, TF_SHIFT_O1_FAST+8);
+            __m256i fv4 = _mm256_srli_epi32(Sv4, TF_SHIFT_O1_FAST+8);
 
-	    //  b[z] = (S[z]>>8) & mask;
-	    __m256i bv1 = _mm256_and_si256(_mm256_srli_epi32(Sv1, 8), maskv);
-	    __m256i bv2 = _mm256_and_si256(_mm256_srli_epi32(Sv2, 8), maskv);
-	    __m256i bv3 = _mm256_and_si256(_mm256_srli_epi32(Sv3, 8), maskv);
-	    __m256i bv4 = _mm256_and_si256(_mm256_srli_epi32(Sv4, 8), maskv);
+            //  b[z] = (S[z]>>8) & mask;
+            __m256i bv1 = _mm256_and_si256(_mm256_srli_epi32(Sv1, 8), maskv);
+            __m256i bv2 = _mm256_and_si256(_mm256_srli_epi32(Sv2, 8), maskv);
+            __m256i bv3 = _mm256_and_si256(_mm256_srli_epi32(Sv3, 8), maskv);
+            __m256i bv4 = _mm256_and_si256(_mm256_srli_epi32(Sv4, 8), maskv);
 
-	    //  s[z] = S[z] & 0xff;
-	    __m256i sv1 = _mm256_and_si256(Sv1, _mm256_set1_epi32(0xff));
-	    __m256i sv2 = _mm256_and_si256(Sv2, _mm256_set1_epi32(0xff));
-	    __m256i sv3 = _mm256_and_si256(Sv3, _mm256_set1_epi32(0xff));
-	    __m256i sv4 = _mm256_and_si256(Sv4, _mm256_set1_epi32(0xff));
+            //  s[z] = S[z] & 0xff;
+            __m256i sv1 = _mm256_and_si256(Sv1, _mm256_set1_epi32(0xff));
+            __m256i sv2 = _mm256_and_si256(Sv2, _mm256_set1_epi32(0xff));
+            __m256i sv3 = _mm256_and_si256(Sv3, _mm256_set1_epi32(0xff));
+            __m256i sv4 = _mm256_and_si256(Sv4, _mm256_set1_epi32(0xff));
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
-	    Rv1 = _mm256_add_epi32(
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
+            Rv1 = _mm256_add_epi32(
                       _mm256_mullo_epi32(
                           _mm256_srli_epi32(Rv1,TF_SHIFT_O1_FAST), fv1), bv1);
-	    Rv2 = _mm256_add_epi32(
+            Rv2 = _mm256_add_epi32(
                       _mm256_mullo_epi32(
                           _mm256_srli_epi32(Rv2,TF_SHIFT_O1_FAST), fv2), bv2);
 
 
-	    //for (z = 0; z < NX; z++) lN[z] = c[z];
-	    Lv1 = sv1;
-	    Lv2 = sv2;
+            //for (z = 0; z < NX; z++) lN[z] = c[z];
+            Lv1 = sv1;
+            Lv2 = sv2;
 
-	    sv1 = _mm256_packus_epi32(sv1, sv2);
-	    sv1 = _mm256_permute4x64_epi64(sv1, 0xd8);
+            sv1 = _mm256_packus_epi32(sv1, sv2);
+            sv1 = _mm256_permute4x64_epi64(sv1, 0xd8);
 
-	    // Start loading next batch of normalised states
-	    __m256i Vv1 = _mm256_cvtepu16_epi32(
-			      _mm_loadu_si128((__m128i *)sp));
+            // Start loading next batch of normalised states
+            __m256i Vv1 = _mm256_cvtepu16_epi32(
+                              _mm_loadu_si128((__m128i *)sp));
 
-	    sv1 = _mm256_packus_epi16(sv1, sv1);
+            sv1 = _mm256_packus_epi16(sv1, sv1);
 
-	    // out[iN[z]] = c[z];  // simulate scatter
-	    // RansDecRenorm(&R[z], &ptr);	
-	    __m256i renorm_mask1, renorm_mask2;
-	    renorm_mask1 = _mm256_xor_si256(Rv1,_mm256_set1_epi32(0x80000000));
-	    renorm_mask2 = _mm256_xor_si256(Rv2,_mm256_set1_epi32(0x80000000));
+            // out[iN[z]] = c[z];  // simulate scatter
+            // RansDecRenorm(&R[z], &ptr);      
+            __m256i renorm_mask1, renorm_mask2;
+            renorm_mask1 = _mm256_xor_si256(Rv1,_mm256_set1_epi32(0x80000000));
+            renorm_mask2 = _mm256_xor_si256(Rv2,_mm256_set1_epi32(0x80000000));
 
-	    renorm_mask1 = _mm256_cmpgt_epi32(
+            renorm_mask1 = _mm256_cmpgt_epi32(
                                _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
-			       renorm_mask1);
-	    renorm_mask2 = _mm256_cmpgt_epi32(
-			       _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
-			       renorm_mask2);
+                               renorm_mask1);
+            renorm_mask2 = _mm256_cmpgt_epi32(
+                               _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
+                               renorm_mask2);
 
-	    unsigned int imask1 = _mm256_movemask_ps((__m256)renorm_mask1);
-	    __m256i idx1 = _mm256_load_si256((const __m256i*)permute[imask1]);
-	    __m256i Yv1 = _mm256_slli_epi32(Rv1, 16);
-	    __m256i Yv2 = _mm256_slli_epi32(Rv2, 16);
+            unsigned int imask1 = _mm256_movemask_ps((__m256)renorm_mask1);
+            __m256i idx1 = _mm256_load_si256((const __m256i*)permute[imask1]);
+            __m256i Yv1 = _mm256_slli_epi32(Rv1, 16);
+            __m256i Yv2 = _mm256_slli_epi32(Rv2, 16);
 
-	    unsigned int imask2 = _mm256_movemask_ps((__m256)renorm_mask2);
-	    Vv1 = _mm256_permutevar8x32_epi32(Vv1, idx1);
-	    sp += _mm_popcnt_u32(imask1);
+            unsigned int imask2 = _mm256_movemask_ps((__m256)renorm_mask2);
+            Vv1 = _mm256_permutevar8x32_epi32(Vv1, idx1);
+            sp += _mm_popcnt_u32(imask1);
 
-	    __m256i idx2 = _mm256_load_si256((const __m256i*)permute[imask2]);
-	    __m256i Vv2 = _mm256_cvtepu16_epi32(
-			      _mm_loadu_si128((__m128i *)sp));
-	    sp += _mm_popcnt_u32(imask2);
-	    Vv2 = _mm256_permutevar8x32_epi32(Vv2, idx2);
+            __m256i idx2 = _mm256_load_si256((const __m256i*)permute[imask2]);
+            __m256i Vv2 = _mm256_cvtepu16_epi32(
+                              _mm_loadu_si128((__m128i *)sp));
+            sp += _mm_popcnt_u32(imask2);
+            Vv2 = _mm256_permutevar8x32_epi32(Vv2, idx2);
 
-	    Yv1 = _mm256_or_si256(Yv1, Vv1);
-	    Yv2 = _mm256_or_si256(Yv2, Vv2);
+            Yv1 = _mm256_or_si256(Yv1, Vv1);
+            Yv2 = _mm256_or_si256(Yv2, Vv2);
 
-	    Rv1 = _mm256_blendv_epi8(Rv1, Yv1, renorm_mask1);
-	    Rv2 = _mm256_blendv_epi8(Rv2, Yv2, renorm_mask2);
+            Rv1 = _mm256_blendv_epi8(Rv1, Yv1, renorm_mask1);
+            Rv2 = _mm256_blendv_epi8(Rv2, Yv2, renorm_mask2);
 
-	    /////////////////////////////////////////////////////////////////
-	    // Start loading next batch of normalised states
-	    __m256i Vv3 = _mm256_cvtepu16_epi32(
-			      _mm_loadu_si128((__m128i *)sp));
+            /////////////////////////////////////////////////////////////////
+            // Start loading next batch of normalised states
+            __m256i Vv3 = _mm256_cvtepu16_epi32(
+                              _mm_loadu_si128((__m128i *)sp));
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
-	    Rv3 = _mm256_add_epi32(
-		      _mm256_mullo_epi32(
-			  _mm256_srli_epi32(Rv3,TF_SHIFT_O1_FAST), fv3), bv3);
-	    Rv4 = _mm256_add_epi32(
-		      _mm256_mullo_epi32(
-			  _mm256_srli_epi32(Rv4,TF_SHIFT_O1_FAST), fv4), bv4);
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
+            Rv3 = _mm256_add_epi32(
+                      _mm256_mullo_epi32(
+                          _mm256_srli_epi32(Rv3,TF_SHIFT_O1_FAST), fv3), bv3);
+            Rv4 = _mm256_add_epi32(
+                      _mm256_mullo_epi32(
+                          _mm256_srli_epi32(Rv4,TF_SHIFT_O1_FAST), fv4), bv4);
 
-	    //for (z = 0; z < NX; z++) lN[z] = c[z];
-	    Lv3 = sv3;
-	    Lv4 = sv4;
+            //for (z = 0; z < NX; z++) lN[z] = c[z];
+            Lv3 = sv3;
+            Lv4 = sv4;
 
-	    // out[iN[z]] = c[z];  // simulate scatter
-	    // RansDecRenorm(&R[z], &ptr);	
-	    __m256i renorm_mask3, renorm_mask4;
-	    renorm_mask3 = _mm256_xor_si256(Rv3,_mm256_set1_epi32(0x80000000));
-	    renorm_mask4 = _mm256_xor_si256(Rv4,_mm256_set1_epi32(0x80000000));
+            // out[iN[z]] = c[z];  // simulate scatter
+            // RansDecRenorm(&R[z], &ptr);      
+            __m256i renorm_mask3, renorm_mask4;
+            renorm_mask3 = _mm256_xor_si256(Rv3,_mm256_set1_epi32(0x80000000));
+            renorm_mask4 = _mm256_xor_si256(Rv4,_mm256_set1_epi32(0x80000000));
 
-	    renorm_mask3 = _mm256_cmpgt_epi32(
-			       _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
-			       renorm_mask3);
-	    renorm_mask4 = _mm256_cmpgt_epi32(
-			       _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
-			       renorm_mask4);
+            renorm_mask3 = _mm256_cmpgt_epi32(
+                               _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
+                               renorm_mask3);
+            renorm_mask4 = _mm256_cmpgt_epi32(
+                               _mm256_set1_epi32(RANS_BYTE_L-0x80000000),
+                               renorm_mask4);
 
-	    __m256i Yv3 = _mm256_slli_epi32(Rv3, 16);
-	    __m256i Yv4 = _mm256_slli_epi32(Rv4, 16);
+            __m256i Yv3 = _mm256_slli_epi32(Rv3, 16);
+            __m256i Yv4 = _mm256_slli_epi32(Rv4, 16);
 
-	    unsigned int imask3 = _mm256_movemask_ps((__m256)renorm_mask3);
-	    unsigned int imask4 = _mm256_movemask_ps((__m256)renorm_mask4);
-	    __m256i idx3 = _mm256_load_si256((const __m256i*)permute[imask3]);
-	    sp += _mm_popcnt_u32(imask3);
-	    Vv3 = _mm256_permutevar8x32_epi32(Vv3, idx3);
+            unsigned int imask3 = _mm256_movemask_ps((__m256)renorm_mask3);
+            unsigned int imask4 = _mm256_movemask_ps((__m256)renorm_mask4);
+            __m256i idx3 = _mm256_load_si256((const __m256i*)permute[imask3]);
+            sp += _mm_popcnt_u32(imask3);
+            Vv3 = _mm256_permutevar8x32_epi32(Vv3, idx3);
 
-	    // sv3 sv4 are 32-bit ints with lowest bit being char
-	    sv3 = _mm256_packus_epi32(sv3, sv4);       // 32 to 16; ABab
-	    sv3 = _mm256_permute4x64_epi64(sv3, 0xd8); // shuffle;  AaBb
-	    sv3 = _mm256_packus_epi16(sv3, sv3);       // 16 to 8
+            // sv3 sv4 are 32-bit ints with lowest bit being char
+            sv3 = _mm256_packus_epi32(sv3, sv4);       // 32 to 16; ABab
+            sv3 = _mm256_permute4x64_epi64(sv3, 0xd8); // shuffle;  AaBb
+            sv3 = _mm256_packus_epi16(sv3, sv3);       // 16 to 8
 
-	    // Method 1
-	    u.tbuf64[tidx][0] = _mm256_extract_epi64(sv1, 0);
-	    u.tbuf64[tidx][1] = _mm256_extract_epi64(sv1, 2);
-	    u.tbuf64[tidx][2] = _mm256_extract_epi64(sv3, 0);
-	    u.tbuf64[tidx][3] = _mm256_extract_epi64(sv3, 2);
+            // Method 1
+            u.tbuf64[tidx][0] = _mm256_extract_epi64(sv1, 0);
+            u.tbuf64[tidx][1] = _mm256_extract_epi64(sv1, 2);
+            u.tbuf64[tidx][2] = _mm256_extract_epi64(sv3, 0);
+            u.tbuf64[tidx][3] = _mm256_extract_epi64(sv3, 2);
 
-//	    // Method 2
-//	    sv1 = _mm256_permute4x64_epi64(sv1, 8); // x x 10 00
-//	    _mm_storeu_si128((__m128i *)&u.tbuf64[tidx][0],
-//			     _mm256_extractf128_si256(sv1, 0));
-//	    sv3 = _mm256_permute4x64_epi64(sv3, 8); // x x 10 00
-//	    _mm_storeu_si128((__m128i *)&u.tbuf64[tidx][2],
-//			     _mm256_extractf128_si256(sv3, 0));
+//          // Method 2
+//          sv1 = _mm256_permute4x64_epi64(sv1, 8); // x x 10 00
+//          _mm_storeu_si128((__m128i *)&u.tbuf64[tidx][0],
+//                           _mm256_extractf128_si256(sv1, 0));
+//          sv3 = _mm256_permute4x64_epi64(sv3, 8); // x x 10 00
+//          _mm_storeu_si128((__m128i *)&u.tbuf64[tidx][2],
+//                           _mm256_extractf128_si256(sv3, 0));
 
 //          // Method 3
-//	    sv1 = _mm256_and_si256(sv1, _mm256_set_epi64x(0,-1,0,-1)); // AxBx
-//	    sv3 = _mm256_and_si256(sv3, _mm256_set_epi64x(-1,0,-1,0)); // xCxD
-//	    sv1 = _mm256_or_si256(sv1, sv3);                           // ACBD
-//	    sv1 = _mm256_permute4x64_epi64(sv1, 0xD8); //rev 00 10 01 11; ABCD
-//	    _mm256_storeu_si256((__m256i *)u.tbuf64[tidx], sv1);
+//          sv1 = _mm256_and_si256(sv1, _mm256_set_epi64x(0,-1,0,-1)); // AxBx
+//          sv3 = _mm256_and_si256(sv3, _mm256_set_epi64x(-1,0,-1,0)); // xCxD
+//          sv1 = _mm256_or_si256(sv1, sv3);                           // ACBD
+//          sv1 = _mm256_permute4x64_epi64(sv1, 0xD8); //rev 00 10 01 11; ABCD
+//          _mm256_storeu_si256((__m256i *)u.tbuf64[tidx], sv1);
 
-	    iN[0]++;
-	    if (++tidx == 32) {
-		iN[0]-=32;
+            iN[0]++;
+            if (++tidx == 32) {
+                iN[0]-=32;
 
-		// We have tidx[x][y] which we want to store in
-		// memory in out[y][z] instead.  This is an unrolled
-		// transposition.
-		//
-		// A straight memcpy (obviously wrong) decodes my test
-		// data in around 1030MB/s vs 930MB/s for this transpose,
-		// giving an idea of the time spent in this portion.
-		transpose_and_copy(out, iN, u.tbuf);
+                // We have tidx[x][y] which we want to store in
+                // memory in out[y][z] instead.  This is an unrolled
+                // transposition.
+                //
+                // A straight memcpy (obviously wrong) decodes my test
+                // data in around 1030MB/s vs 930MB/s for this transpose,
+                // giving an idea of the time spent in this portion.
+                transpose_and_copy(out, iN, u.tbuf);
 
-		tidx = 0;
-	    }
+                tidx = 0;
+            }
 
-	    __m256i idx4 = _mm256_load_si256((const __m256i*)permute[imask4]);
-	    __m256i Vv4 = _mm256_cvtepu16_epi32(
-			      _mm_loadu_si128((__m128i *)sp));
+            __m256i idx4 = _mm256_load_si256((const __m256i*)permute[imask4]);
+            __m256i Vv4 = _mm256_cvtepu16_epi32(
+                              _mm_loadu_si128((__m128i *)sp));
 
-	    Yv3 = _mm256_or_si256(Yv3, Vv3);
-	    Vv4 = _mm256_permutevar8x32_epi32(Vv4, idx4);
-	    Yv4 = _mm256_or_si256(Yv4, Vv4);
+            Yv3 = _mm256_or_si256(Yv3, Vv3);
+            Vv4 = _mm256_permutevar8x32_epi32(Vv4, idx4);
+            Yv4 = _mm256_or_si256(Yv4, Vv4);
 
-	    sp += _mm_popcnt_u32(imask4);
+            sp += _mm_popcnt_u32(imask4);
 
-	    Rv3 = _mm256_blendv_epi8(Rv3, Yv3, renorm_mask3);
-	    Rv4 = _mm256_blendv_epi8(Rv4, Yv4, renorm_mask4);
-	}
-	isz4 += 64;
+            Rv3 = _mm256_blendv_epi8(Rv3, Yv3, renorm_mask3);
+            Rv4 = _mm256_blendv_epi8(Rv4, Yv4, renorm_mask4);
+        }
+        isz4 += 64;
 
-	STORE(Rv, R);
-	STORE(Lv, lN);
-	ptr = (uint8_t *)sp;
+        STORE(Rv, R);
+        STORE(Lv, lN);
+        ptr = (uint8_t *)sp;
 
-	if (1) {
-	    iN[0]-=tidx;
-	    int T;
-	    for (z = 0; z < NX; z++)
-		for (T = 0; T < tidx; T++)
-		    out[iN[z]++] = u.tbuf[T][z];
-	}
+        if (1) {
+            iN[0]-=tidx;
+            int T;
+            for (z = 0; z < NX; z++)
+                for (T = 0; T < tidx; T++)
+                    out[iN[z]++] = u.tbuf[T][z];
+        }
 
-	// Scalar version for close to the end of in[] array so we don't
-	// do SIMD loads beyond the end of the buffer
-	for (; iN[0] < isz4;) {
-	    for (z = 0; z < NX; z++) {
-		uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
-		uint32_t S = s3F[lN[z]][m];
-		unsigned char c = S & 0xff;
-		out[iN[z]++] = c;
-		R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
-		    ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-		RansDecRenormSafe(&R[z], &ptr, ptr_end);
-		lN[z] = c;
-	    }
-	}
+        // Scalar version for close to the end of in[] array so we don't
+        // do SIMD loads beyond the end of the buffer
+        for (; iN[0] < isz4;) {
+            for (z = 0; z < NX; z++) {
+                uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
+                uint32_t S = s3F[lN[z]][m];
+                unsigned char c = S & 0xff;
+                out[iN[z]++] = c;
+                R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
+                    ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+                RansDecRenormSafe(&R[z], &ptr, ptr_end);
+                lN[z] = c;
+            }
+        }
 
-	// Remainder
-	z = NX-1;
-	for (; iN[z] < out_sz; ) {
-	    uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
-	    uint32_t S = s3F[lN[z]][m];
-	    unsigned char c = S & 0xff;
-	    out[iN[z]++] = c;
-	    R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
-		((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-	    RansDecRenormSafe(&R[z], &ptr, ptr_end);
-	    lN[z] = c;
-	}
+        // Remainder
+        z = NX-1;
+        for (; iN[z] < out_sz; ) {
+            uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
+            uint32_t S = s3F[lN[z]][m];
+            unsigned char c = S & 0xff;
+            out[iN[z]++] = c;
+            R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
+                ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+            RansDecRenormSafe(&R[z], &ptr, ptr_end);
+            lN[z] = c;
+        }
     }
 
     htscodecs_tls_free(s3);

--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -62,9 +62,9 @@
 #include "utils.h"
 
 unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int *out_size) {
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int *out_size) {
     unsigned char *cp, *out_end;
     RansEncSymbol syms[256];
     RansState ransN[32] __attribute__((aligned(64)));
@@ -75,20 +75,20 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
     int bound = rans_compress_bound_4x16(in_size,0)-20;
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     // If "out" isn't word aligned, tweak out_end/ptr to ensure it is.
     // We already added more round in bound to allow for this.
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     ptr = out_end = out + bound;
 
     if (in_size == 0)
-	goto empty;
+        goto empty;
 
     // Compute statistics
     hist8(in, in_size, F);
@@ -97,10 +97,10 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
     uint32_t fsum = in_size;
     uint32_t max_val = round2(fsum);
     if (max_val > TOTFREQ)
-	max_val = TOTFREQ;
+        max_val = TOTFREQ;
 
     if (normalise_freq(F, fsum, max_val) < 0)
-	return NULL;
+        return NULL;
     fsum=max_val;
 
     cp = out;
@@ -109,19 +109,19 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
     //write(2, out+4, cp-(out+4));
 
     if (normalise_freq(F, fsum, TOTFREQ) < 0)
-	return NULL;
+        return NULL;
 
     // Encode statistics and build lookup tables for SIMD encoding.
     uint32_t SB[256], SA[256], SD[256], SC[256];
     for (x = rle = j = 0; j < 256; j++) {
-	if (F[j]) {
-	    RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
+        if (F[j]) {
+            RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
             SB[j] = syms[j].x_max;
             SA[j] = syms[j].rcp_freq;
             SD[j] = (syms[j].cmpl_freq<<0) | ((syms[j].rcp_shift-32)<<16);
             SC[j] = syms[j].bias;
-	    x += F[j];
-	}
+            x += F[j];
+        }
     }
 
     for (z = 0; z < 32; z++)
@@ -131,11 +131,11 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
     while (z-- > 0)
       RansEncPutSymbol(&ransN[z], &ptr, &syms[in[in_size-(i-z)]]);
 
-#define LOAD512(a,b)					 \
+#define LOAD512(a,b)                                     \
     __m512i a##1 = _mm512_load_si512((__m512i *)&b[0]); \
     __m512i a##2 = _mm512_load_si512((__m512i *)&b[16]);
 
-#define STORE512(a,b)				\
+#define STORE512(a,b)                           \
     _mm512_store_si512((__m256i *)&b[0], a##1); \
     _mm512_store_si512((__m256i *)&b[16], a##2);
 
@@ -143,105 +143,105 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
 
     uint16_t *ptr16 = (uint16_t *)ptr;
     for (i=(in_size &~(32-1)); i>0; i-=32) {
-	uint8_t *c = &in[i-32];
+        uint8_t *c = &in[i-32];
 
-	// GATHER versions
-	// Much faster now we have an efficient loadu mechanism in place,
-	// BUT...
-	// Try this for avx2 variant too?  Better way to populate the mm256
-	// regs for mix of avx2 and avx512 opcodes.
-	__m256i c12 = _mm256_loadu_si256((__m256i const *)c);
-	__m512i c1 = _mm512_cvtepu8_epi32(_mm256_extracti128_si256(c12,0));
-	__m512i c2 = _mm512_cvtepu8_epi32(_mm256_extracti128_si256(c12,1));
+        // GATHER versions
+        // Much faster now we have an efficient loadu mechanism in place,
+        // BUT...
+        // Try this for avx2 variant too?  Better way to populate the mm256
+        // regs for mix of avx2 and avx512 opcodes.
+        __m256i c12 = _mm256_loadu_si256((__m256i const *)c);
+        __m512i c1 = _mm512_cvtepu8_epi32(_mm256_extracti128_si256(c12,0));
+        __m512i c2 = _mm512_cvtepu8_epi32(_mm256_extracti128_si256(c12,1));
 #define SET512(a,b) \
         __m512i a##1 = _mm512_i32gather_epi32(c1, b, 4); \
         __m512i a##2 = _mm512_i32gather_epi32(c2, b, 4)
 
-	SET512(xmax, SB);
+        SET512(xmax, SB);
 
-	uint16_t gt_mask1 = _mm512_cmpgt_epi32_mask(Rv1, xmax1);
-	int pc1 = _mm_popcnt_u32(gt_mask1);
+        uint16_t gt_mask1 = _mm512_cmpgt_epi32_mask(Rv1, xmax1);
+        int pc1 = _mm_popcnt_u32(gt_mask1);
         __m512i Rp1 = _mm512_and_si512(Rv1, _mm512_set1_epi32(0xffff));
         __m512i Rp2 = _mm512_and_si512(Rv2, _mm512_set1_epi32(0xffff));
-	uint16_t gt_mask2 = _mm512_cmpgt_epi32_mask(Rv2, xmax2);
-	SET512(SDv,  SD);
-	int pc2 = _mm_popcnt_u32(gt_mask2);
+        uint16_t gt_mask2 = _mm512_cmpgt_epi32_mask(Rv2, xmax2);
+        SET512(SDv,  SD);
+        int pc2 = _mm_popcnt_u32(gt_mask2);
 
-	//Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
-	Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
-	Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
+        //Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
+        Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
+        Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
 
-	_mm512_mask_cvtepi32_storeu_epi16(ptr16-pc2, (1<<pc2)-1, Rp2);
-	ptr16 -= pc2;
-	_mm512_mask_cvtepi32_storeu_epi16(ptr16-pc1, (1<<pc1)-1, Rp1);
-	ptr16 -= pc1;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr16-pc2, (1<<pc2)-1, Rp2);
+        ptr16 -= pc2;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr16-pc1, (1<<pc1)-1, Rp1);
+        ptr16 -= pc1;
 
-	SET512(rfv,  SA);
-	Rv1 = _mm512_mask_srli_epi32(Rv1, gt_mask1, Rv1, 16);
-	Rv2 = _mm512_mask_srli_epi32(Rv2, gt_mask2, Rv2, 16);
+        SET512(rfv,  SA);
+        Rv1 = _mm512_mask_srli_epi32(Rv1, gt_mask1, Rv1, 16);
+        Rv2 = _mm512_mask_srli_epi32(Rv2, gt_mask2, Rv2, 16);
 
-	// interleaved form of this, helps on icc a bit
-	//rfv1 = _mm512_mulhi_epu32(Rv1, rfv1);
-	//rfv2 = _mm512_mulhi_epu32(Rv2, rfv2);
+        // interleaved form of this, helps on icc a bit
+        //rfv1 = _mm512_mulhi_epu32(Rv1, rfv1);
+        //rfv2 = _mm512_mulhi_epu32(Rv2, rfv2);
 
-	// Alternatives here:
-	// SHIFT right/left instead of AND: (very marginally slower)
-	//   rf1_hm = _mm512_and_epi32(
-	//           rf1_hm, _mm512_set1_epi64((uint64_t)0xffffffff00000000));
-	// vs
-	//   rf1_hm = _mm512_srli_epi64(rf1_hm, 32);
-	//   rf1_hm = _mm512_slli_epi64(rf1_hm, 32);
-	__m512i rf1_hm = _mm512_mul_epu32(_mm512_srli_epi64(Rv1,  32),
-					  _mm512_srli_epi64(rfv1, 32));
-	__m512i rf2_hm = _mm512_mul_epu32(_mm512_srli_epi64(Rv2,  32),
-					  _mm512_srli_epi64(rfv2, 32));
-	__m512i rf1_lm = _mm512_srli_epi64(_mm512_mul_epu32(Rv1, rfv1), 32);
-	__m512i rf2_lm = _mm512_srli_epi64(_mm512_mul_epu32(Rv2, rfv2), 32);
-	rf1_hm = _mm512_and_epi32(rf1_hm,
-				  _mm512_set1_epi64((uint64_t)0xffffffff<<32));
-	rf2_hm = _mm512_and_epi32(rf2_hm,
-				  _mm512_set1_epi64((uint64_t)0xffffffff<<32));
-	rfv1 = _mm512_or_epi32(rf1_lm, rf1_hm);
-	rfv2 = _mm512_or_epi32(rf2_lm, rf2_hm);
+        // Alternatives here:
+        // SHIFT right/left instead of AND: (very marginally slower)
+        //   rf1_hm = _mm512_and_epi32(
+        //           rf1_hm, _mm512_set1_epi64((uint64_t)0xffffffff00000000));
+        // vs
+        //   rf1_hm = _mm512_srli_epi64(rf1_hm, 32);
+        //   rf1_hm = _mm512_slli_epi64(rf1_hm, 32);
+        __m512i rf1_hm = _mm512_mul_epu32(_mm512_srli_epi64(Rv1,  32),
+                                          _mm512_srli_epi64(rfv1, 32));
+        __m512i rf2_hm = _mm512_mul_epu32(_mm512_srli_epi64(Rv2,  32),
+                                          _mm512_srli_epi64(rfv2, 32));
+        __m512i rf1_lm = _mm512_srli_epi64(_mm512_mul_epu32(Rv1, rfv1), 32);
+        __m512i rf2_lm = _mm512_srli_epi64(_mm512_mul_epu32(Rv2, rfv2), 32);
+        rf1_hm = _mm512_and_epi32(rf1_hm,
+                                  _mm512_set1_epi64((uint64_t)0xffffffff<<32));
+        rf2_hm = _mm512_and_epi32(rf2_hm,
+                                  _mm512_set1_epi64((uint64_t)0xffffffff<<32));
+        rfv1 = _mm512_or_epi32(rf1_lm, rf1_hm);
+        rfv2 = _mm512_or_epi32(rf2_lm, rf2_hm);
 
-	// Or a pure masked blend approach, sadly slower.
-	// rfv1 = _mm512_mask_blend_epi32(0x5555,
-	//            _mm512_mul_epu32(
-	//                _mm512_srli_epi64(Rv1, 32),
-	//                _mm512_srli_epi64(rfv1, 32)),
-	//            _mm512_srli_epi64(
-	//                _mm512_mul_epu32(Rv1, rfv1),
-	//                32));
-	// rfv2 = _mm512_mask_blend_epi32(0xaaaa,
-	//            _mm512_srli_epi64(
-	//                _mm512_mul_epu32(Rv2, rfv2),
-	//                32),
-	//            _mm512_mul_epu32(
-	//                _mm512_srli_epi64(Rv2, 32),
-	//                _mm512_srli_epi64(rfv2, 32)));
+        // Or a pure masked blend approach, sadly slower.
+        // rfv1 = _mm512_mask_blend_epi32(0x5555,
+        //            _mm512_mul_epu32(
+        //                _mm512_srli_epi64(Rv1, 32),
+        //                _mm512_srli_epi64(rfv1, 32)),
+        //            _mm512_srli_epi64(
+        //                _mm512_mul_epu32(Rv1, rfv1),
+        //                32));
+        // rfv2 = _mm512_mask_blend_epi32(0xaaaa,
+        //            _mm512_srli_epi64(
+        //                _mm512_mul_epu32(Rv2, rfv2),
+        //                32),
+        //            _mm512_mul_epu32(
+        //                _mm512_srli_epi64(Rv2, 32),
+        //                _mm512_srli_epi64(rfv2, 32)));
 
-	SET512(biasv, SC);
-	__m512i shiftv1 = _mm512_srli_epi32(SDv1, 16);
-	__m512i shiftv2 = _mm512_srli_epi32(SDv2, 16);
+        SET512(biasv, SC);
+        __m512i shiftv1 = _mm512_srli_epi32(SDv1, 16);
+        __m512i shiftv2 = _mm512_srli_epi32(SDv2, 16);
 
-	__m512i qv1 = _mm512_srlv_epi32(rfv1, shiftv1);
-	__m512i qv2 = _mm512_srlv_epi32(rfv2, shiftv2);
+        __m512i qv1 = _mm512_srlv_epi32(rfv1, shiftv1);
+        __m512i qv2 = _mm512_srlv_epi32(rfv2, shiftv2);
 
-	qv1 = _mm512_mullo_epi32(qv1,
-	          _mm512_and_si512(SDv1,_mm512_set1_epi32(0xffff)));
-	qv1 = _mm512_add_epi32(qv1, biasv1);
-	Rv1 = _mm512_add_epi32(Rv1, qv1);
+        qv1 = _mm512_mullo_epi32(qv1,
+                  _mm512_and_si512(SDv1,_mm512_set1_epi32(0xffff)));
+        qv1 = _mm512_add_epi32(qv1, biasv1);
+        Rv1 = _mm512_add_epi32(Rv1, qv1);
 
-	qv2 = _mm512_mullo_epi32(qv2,
+        qv2 = _mm512_mullo_epi32(qv2,
                   _mm512_and_si512(SDv2, _mm512_set1_epi32(0xffff)));
-	qv2 = _mm512_add_epi32(qv2, biasv2);
-	Rv2 = _mm512_add_epi32(Rv2, qv2);
+        qv2 = _mm512_add_epi32(qv2, biasv2);
+        Rv2 = _mm512_add_epi32(Rv2, qv2);
     }
     ptr = (uint8_t *)ptr16;
     STORE512(Rv, ransN);
 
     for (z = 32-1; z >= 0; z--)
-	RansEncFlush(&ransN[z], &ptr);
+        RansEncFlush(&ransN[z], &ptr);
     
  empty:
     // Finalise block size and return it
@@ -253,14 +253,14 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
 }
 
 unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
-					       unsigned int in_size,
-					       unsigned char *out,
-					       unsigned int out_sz) {
+                                               unsigned int in_size,
+                                               unsigned char *out,
+                                               unsigned int out_sz) {
     if (in_size < 32*4) // 32-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
     /* Load in the static tables */
     unsigned char *cp = in, *out_free = NULL;
@@ -269,22 +269,22 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
     uint32_t s3[TOTFREQ]  __attribute__((aligned(64))); // For TF_SHIFT <= 12
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     // Precompute reverse lookup of frequency.
     uint32_t F[256] = {0}, fsum;
     int fsz = decode_freq(cp, cp_end, F, &fsum);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     normalise_freq_shift(F, fsum, TOTFREQ);
 
     // Build symbols; fixme, do as part of decode, see the _d variant
     if (rans_F_to_s3(F, TF_SHIFT, s3))
-	goto err;
+        goto err;
 
     if (cp_end - cp < 32 * 4)
         goto err;
@@ -292,9 +292,9 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
     int z;
     RansState Rv[32] __attribute__((aligned(64)));
     for (z = 0; z < 32; z++) {
-	RansDecInit(&Rv[z], &cp);
-	if (Rv[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&Rv[z], &cp);
+        if (Rv[z] < RANS_BYTE_L)
+            goto err;
     }
 
     uint16_t *sp = (uint16_t *)cp;
@@ -320,9 +320,9 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
       // Protect against running off the end of in buffer.
       // We copy it to a worst-case local buffer when near the end.
       if ((uint8_t *)sp+64 > cp_end) {
-	memmove(overflow, sp, cp_end - (uint8_t *)sp);
-	sp = (uint16_t *)overflow;
-	cp_end = overflow + sizeof(overflow);
+        memmove(overflow, sp, cp_end - (uint8_t *)sp);
+        sp = (uint16_t *)overflow;
+        cp_end = overflow + sizeof(overflow);
       }
 
       //uint32_t S = s3[R[z] & mask];
@@ -338,7 +338,7 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
       // approx 10 cycle latency on mullo.
       R1 = _mm512_add_epi32(
                _mm512_mullo_epi32(
-	           _mm512_srli_epi32(R1, TF_SHIFT), f1), b1);
+                   _mm512_srli_epi32(R1, TF_SHIFT), f1), b1);
       R2 = _mm512_add_epi32(
                _mm512_mullo_epi32(
                    _mm512_srli_epi32(R2, TF_SHIFT), f2), b2);
@@ -350,7 +350,7 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
       // advance by however many words we actually read
       sp += _mm_popcnt_u32(renorm_mask1);
       __m512i renorm_words2 = _mm512_cvtepu16_epi32(_mm256_loadu_si256(
-				      (const __m256i *)sp));
+                                      (const __m256i *)sp));
 
       // select masked only
       __m512i renorm_vals1, renorm_vals2;
@@ -403,12 +403,12 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
 // NB: This uses AVX2 though and we could rewrite using AVX512 for
 // further speed gains.
 static inline void transpose_and_copy(uint8_t *out, int iN[32],
-				      uint8_t t[32][32]) {
+                                      uint8_t t[32][32]) {
 //  int z;
 //  for (z = 0; z < 32; z++) {
 //      int k;
 //      for (k = 0; k < 32; k++)
-//  	    out[iN[z]+k] = t[k][z];
+//          out[iN[z]+k] = t[k][z];
 //      iN[z] += 32;
 //  }
 
@@ -420,65 +420,65 @@ static inline void transpose_and_copy(uint8_t *out, int iN[32],
 // This is faster than a naive scalar implementation, but doesn't beat the
 // AVX2 vectorised 32x32 transpose function.
 static inline void transpose_and_copy_avx512(uint8_t *out, int iN[32],
-					     uint32_t t32[32][32]) {
+                                             uint32_t t32[32][32]) {
     int z;
 //  for (z = 0; z < 32; z++) {
 //      int k;
 //      for (k = 0; k < 32; k++)
-//  	    out[iN[z]+k] = t32[k][z];
+//          out[iN[z]+k] = t32[k][z];
 //      iN[z] += 32;
 //  }
 
     
     __m512i v1 = _mm512_set_epi32(15, 14, 13, 12, 11, 10,  9,  8,
-				   7,  6,  5,  4,  3,  2,  1,  0);
+                                   7,  6,  5,  4,  3,  2,  1,  0);
     v1 = _mm512_slli_epi32(v1, 5);
     
     for (z = 0; z < 32; z++) {
-	__m512i t1 = _mm512_i32gather_epi32(v1, &t32[ 0][z], 4);
-	__m512i t2 = _mm512_i32gather_epi32(v1, &t32[16][z], 4);
-	_mm_storeu_si128((__m128i*)(&out[iN[z]   ]), _mm512_cvtepi32_epi8(t1));
-	_mm_storeu_si128((__m128i*)(&out[iN[z]+16]), _mm512_cvtepi32_epi8(t2));
-	iN[z] += 32;
+        __m512i t1 = _mm512_i32gather_epi32(v1, &t32[ 0][z], 4);
+        __m512i t2 = _mm512_i32gather_epi32(v1, &t32[16][z], 4);
+        _mm_storeu_si128((__m128i*)(&out[iN[z]   ]), _mm512_cvtepi32_epi8(t1));
+        _mm_storeu_si128((__m128i*)(&out[iN[z]+16]), _mm512_cvtepi32_epi8(t2));
+        iN[z] += 32;
     }
 }
 #endif // TBUF
 
 unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int *out_size) {
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int *out_size) {
     unsigned char *cp, *out_end, *out_free = NULL;
     unsigned int tab_size;
     int bound = rans_compress_bound_4x16(in_size,1)-20, z;
     RansState ransN[32] __attribute__((aligned(64)));
 
     if (in_size < 32) // force O0 instead
-	return NULL;
+        return NULL;
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     out_end = out + bound;
 
     RansEncSymbol (*syms)[256] = htscodecs_tls_alloc(256 * (sizeof(*syms)));
     if (!syms) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     cp = out;
     int shift = encode_freq1(in, in_size, 32, syms, &cp); 
     if (shift < 0) {
-	free(out_free);
-	htscodecs_tls_free(syms);
-	return NULL;
+        free(out_free);
+        htscodecs_tls_free(syms);
+        return NULL;
     }
     tab_size = cp - out;
 
@@ -489,41 +489,41 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
 
     int iN[32], isz4 = in_size/32;
     for (z = 0; z < 32; z++)
-	iN[z] = (z+1)*isz4-2;
+        iN[z] = (z+1)*isz4-2;
 
     uint32_t lN[32] __attribute__((aligned(64)));
     for (z = 0; z < 32; z++)
-	lN[z] = in[iN[z]+1];
+        lN[z] = in[iN[z]+1];
 
     // Deal with the remainder
     z = 32-1;
     lN[z] = in[in_size-1];
     for (iN[z] = in_size-2; iN[z] > 32*isz4-2; iN[z]--) {
-	unsigned char c = in[iN[z]];
-	RansEncPutSymbol(&ransN[z], &ptr, &syms[c][lN[z]]);
-	lN[z] = c;
+        unsigned char c = in[iN[z]];
+        RansEncPutSymbol(&ransN[z], &ptr, &syms[c][lN[z]]);
+        lN[z] = c;
     }
 
     LOAD512(Rv, ransN);
 
     uint16_t *ptr16 = (uint16_t *)ptr;
     __m512i last2 = _mm512_set_epi32(lN[31], lN[30], lN[29], lN[28],
-				     lN[27], lN[26], lN[25], lN[24],
-				     lN[23], lN[22], lN[21], lN[20],
-				     lN[19], lN[18], lN[17], lN[16]);
+                                     lN[27], lN[26], lN[25], lN[24],
+                                     lN[23], lN[22], lN[21], lN[20],
+                                     lN[19], lN[18], lN[17], lN[16]);
     __m512i last1 = _mm512_set_epi32(lN[15], lN[14], lN[13], lN[12],
-				     lN[11], lN[10], lN[ 9], lN[ 8],
-				     lN[ 7], lN[ 6], lN[ 5], lN[ 4],
-				     lN[ 3], lN[ 2], lN[ 1], lN[ 0]);
+                                     lN[11], lN[10], lN[ 9], lN[ 8],
+                                     lN[ 7], lN[ 6], lN[ 5], lN[ 4],
+                                     lN[ 3], lN[ 2], lN[ 1], lN[ 0]);
     
     __m512i iN2 = _mm512_set_epi32(iN[31], iN[30], iN[29], iN[28],
-				   iN[27], iN[26], iN[25], iN[24],
-				   iN[23], iN[22], iN[21], iN[20],
-				   iN[19], iN[18], iN[17], iN[16]);
+                                   iN[27], iN[26], iN[25], iN[24],
+                                   iN[23], iN[22], iN[21], iN[20],
+                                   iN[19], iN[18], iN[17], iN[16]);
     __m512i iN1 = _mm512_set_epi32(iN[15], iN[14], iN[13], iN[12],
-				   iN[11], iN[10], iN[ 9], iN[ 8],
-				   iN[ 7], iN[ 6], iN[ 5], iN[ 4],
-				   iN[ 3], iN[ 2], iN[ 1], iN[ 0]);
+                                   iN[11], iN[10], iN[ 9], iN[ 8],
+                                   iN[ 7], iN[ 6], iN[ 5], iN[ 4],
+                                   iN[ 3], iN[ 2], iN[ 1], iN[ 0]);
 
     __m512i c1 = _mm512_i32gather_epi32(iN1, in, 1);
     __m512i c2 = _mm512_i32gather_epi32(iN2, in, 1);
@@ -531,105 +531,105 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
     for (; iN[0] >= 0; iN[0]--) {
         // Note, consider doing the same approach for the AVX2 encoder.
         // Maybe we can also get gather working well there?
-	// Gather here is still a major latency bottleneck, consuming
-	// around 40% of CPU cycles overall.
+        // Gather here is still a major latency bottleneck, consuming
+        // around 40% of CPU cycles overall.
 
-	// FIXME: maybe we need to cope with in[31] read over-flow
-	// on loop cycles 0, 1, 2 where gather reads 32-bits instead of
-	// 8 bits.  Use set instead there on c2?
-	c1 = _mm512_and_si512(c1, _mm512_set1_epi32(0xff));
-	c2 = _mm512_and_si512(c2, _mm512_set1_epi32(0xff));
+        // FIXME: maybe we need to cope with in[31] read over-flow
+        // on loop cycles 0, 1, 2 where gather reads 32-bits instead of
+        // 8 bits.  Use set instead there on c2?
+        c1 = _mm512_and_si512(c1, _mm512_set1_epi32(0xff));
+        c2 = _mm512_and_si512(c2, _mm512_set1_epi32(0xff));
 
-	// index into syms[0][0] array, used for x_max, rcp_freq, and bias
-	__m512i vidx1 = _mm512_slli_epi32(c1, 8);
-	__m512i vidx2 = _mm512_slli_epi32(c2, 8);
-	vidx1 = _mm512_add_epi32(vidx1, last1);
-	vidx2 = _mm512_add_epi32(vidx2, last2);
-	vidx1 = _mm512_slli_epi32(vidx1, 2);
-	vidx2 = _mm512_slli_epi32(vidx2, 2);
+        // index into syms[0][0] array, used for x_max, rcp_freq, and bias
+        __m512i vidx1 = _mm512_slli_epi32(c1, 8);
+        __m512i vidx2 = _mm512_slli_epi32(c2, 8);
+        vidx1 = _mm512_add_epi32(vidx1, last1);
+        vidx2 = _mm512_add_epi32(vidx2, last2);
+        vidx1 = _mm512_slli_epi32(vidx1, 2);
+        vidx2 = _mm512_slli_epi32(vidx2, 2);
 
-	// ------------------------------------------------------------
-	//	for (z = NX-1; z >= 0; z--) {
-	//	    if (ransN[z] >= x_max[z]) {
-	//		*--ptr16 = ransN[z] & 0xffff;
-	//		ransN[z] >>= 16;
-	//	    }
-	//	}
+        // ------------------------------------------------------------
+        //      for (z = NX-1; z >= 0; z--) {
+        //          if (ransN[z] >= x_max[z]) {
+        //              *--ptr16 = ransN[z] & 0xffff;
+        //              ransN[z] >>= 16;
+        //          }
+        //      }
 
 #define SET512x(a,x) \
-	__m512i a##1 = _mm512_i32gather_epi32(vidx1, &syms[0][0].x, 4); \
-	__m512i a##2 = _mm512_i32gather_epi32(vidx2, &syms[0][0].x, 4)
+        __m512i a##1 = _mm512_i32gather_epi32(vidx1, &syms[0][0].x, 4); \
+        __m512i a##2 = _mm512_i32gather_epi32(vidx2, &syms[0][0].x, 4)
 
-	// Start of next loop, moved here to remove latency.
-	// last[z] = c[z]
-	// iN[z]--
-	// c[z] = in[iN[z]]
-	last1 = c1;
-	last2 = c2;
-	iN1 = _mm512_sub_epi32(iN1, _mm512_set1_epi32(1));
-	iN2 = _mm512_sub_epi32(iN2, _mm512_set1_epi32(1));
-	c1 = _mm512_i32gather_epi32(iN1, in, 1);
-	c2 = _mm512_i32gather_epi32(iN2, in, 1);
+        // Start of next loop, moved here to remove latency.
+        // last[z] = c[z]
+        // iN[z]--
+        // c[z] = in[iN[z]]
+        last1 = c1;
+        last2 = c2;
+        iN1 = _mm512_sub_epi32(iN1, _mm512_set1_epi32(1));
+        iN2 = _mm512_sub_epi32(iN2, _mm512_set1_epi32(1));
+        c1 = _mm512_i32gather_epi32(iN1, in, 1);
+        c2 = _mm512_i32gather_epi32(iN2, in, 1);
 
         SET512x(xmax, x_max); // high latency
 
-	uint16_t gt_mask1 = _mm512_cmpgt_epi32_mask(Rv1, xmax1);
-	int pc1 = _mm_popcnt_u32(gt_mask1);
+        uint16_t gt_mask1 = _mm512_cmpgt_epi32_mask(Rv1, xmax1);
+        int pc1 = _mm_popcnt_u32(gt_mask1);
         __m512i Rp1 = _mm512_and_si512(Rv1, _mm512_set1_epi32(0xffff));
         __m512i Rp2 = _mm512_and_si512(Rv2, _mm512_set1_epi32(0xffff));
-	uint16_t gt_mask2 = _mm512_cmpgt_epi32_mask(Rv2, xmax2);
-	SET512x(SDv, cmpl_freq); // good
-	int pc2 = _mm_popcnt_u32(gt_mask2);
+        uint16_t gt_mask2 = _mm512_cmpgt_epi32_mask(Rv2, xmax2);
+        SET512x(SDv, cmpl_freq); // good
+        int pc2 = _mm_popcnt_u32(gt_mask2);
 
-	Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
-	Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
+        Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
+        Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
 
-	_mm512_mask_cvtepi32_storeu_epi16(ptr16-pc2, (1<<pc2)-1, Rp2);
-	ptr16 -= pc2;
-	_mm512_mask_cvtepi32_storeu_epi16(ptr16-pc1, (1<<pc1)-1, Rp1);
-	ptr16 -= pc1;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr16-pc2, (1<<pc2)-1, Rp2);
+        ptr16 -= pc2;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr16-pc1, (1<<pc1)-1, Rp1);
+        ptr16 -= pc1;
 
-	Rv1 = _mm512_mask_srli_epi32(Rv1, gt_mask1, Rv1, 16);
-	Rv2 = _mm512_mask_srli_epi32(Rv2, gt_mask2, Rv2, 16);
+        Rv1 = _mm512_mask_srli_epi32(Rv1, gt_mask1, Rv1, 16);
+        Rv2 = _mm512_mask_srli_epi32(Rv2, gt_mask2, Rv2, 16);
 
-	// ------------------------------------------------------------
-	// uint32_t q = (uint32_t) (((uint64_t)ransN[z] * rcp_freq[z])
-	//                          >> rcp_shift[z]);
-	// ransN[z] = ransN[z] + bias[z] + q * cmpl_freq[z];
-	SET512x(rfv, rcp_freq); // good-ish
+        // ------------------------------------------------------------
+        // uint32_t q = (uint32_t) (((uint64_t)ransN[z] * rcp_freq[z])
+        //                          >> rcp_shift[z]);
+        // ransN[z] = ransN[z] + bias[z] + q * cmpl_freq[z];
+        SET512x(rfv, rcp_freq); // good-ish
 
-	__m512i rf1_hm = _mm512_mul_epu32(_mm512_srli_epi64(Rv1, 32),
-					  _mm512_srli_epi64(rfv1, 32));
-	__m512i rf2_hm = _mm512_mul_epu32(_mm512_srli_epi64(Rv2, 32),
-					  _mm512_srli_epi64(rfv2, 32));
-	__m512i rf1_lm = _mm512_srli_epi64(_mm512_mul_epu32(Rv1, rfv1), 32);
-	__m512i rf2_lm = _mm512_srli_epi64(_mm512_mul_epu32(Rv2, rfv2), 32);
+        __m512i rf1_hm = _mm512_mul_epu32(_mm512_srli_epi64(Rv1, 32),
+                                          _mm512_srli_epi64(rfv1, 32));
+        __m512i rf2_hm = _mm512_mul_epu32(_mm512_srli_epi64(Rv2, 32),
+                                          _mm512_srli_epi64(rfv2, 32));
+        __m512i rf1_lm = _mm512_srli_epi64(_mm512_mul_epu32(Rv1, rfv1), 32);
+        __m512i rf2_lm = _mm512_srli_epi64(_mm512_mul_epu32(Rv2, rfv2), 32);
 
-	const __m512i top32 = _mm512_set1_epi64((uint64_t)0xffffffff00000000);
-	rf1_hm = _mm512_and_epi32(rf1_hm, top32);
-	rf2_hm = _mm512_and_epi32(rf2_hm, top32);
-	rfv1 = _mm512_or_epi32(rf1_lm, rf1_hm);
-	rfv2 = _mm512_or_epi32(rf2_lm, rf2_hm);
+        const __m512i top32 = _mm512_set1_epi64((uint64_t)0xffffffff00000000);
+        rf1_hm = _mm512_and_epi32(rf1_hm, top32);
+        rf2_hm = _mm512_and_epi32(rf2_hm, top32);
+        rfv1 = _mm512_or_epi32(rf1_lm, rf1_hm);
+        rfv2 = _mm512_or_epi32(rf2_lm, rf2_hm);
 
-	SET512x(biasv, bias); // good
-	__m512i shiftv1 = _mm512_srli_epi32(SDv1, 16);
-	__m512i shiftv2 = _mm512_srli_epi32(SDv2, 16);
+        SET512x(biasv, bias); // good
+        __m512i shiftv1 = _mm512_srli_epi32(SDv1, 16);
+        __m512i shiftv2 = _mm512_srli_epi32(SDv2, 16);
 
-	shiftv1 = _mm512_sub_epi32(shiftv1, _mm512_set1_epi32(32));
-	shiftv2 = _mm512_sub_epi32(shiftv2, _mm512_set1_epi32(32));
+        shiftv1 = _mm512_sub_epi32(shiftv1, _mm512_set1_epi32(32));
+        shiftv2 = _mm512_sub_epi32(shiftv2, _mm512_set1_epi32(32));
 
-	__m512i qv1 = _mm512_srlv_epi32(rfv1, shiftv1);
-	__m512i qv2 = _mm512_srlv_epi32(rfv2, shiftv2);
+        __m512i qv1 = _mm512_srlv_epi32(rfv1, shiftv1);
+        __m512i qv2 = _mm512_srlv_epi32(rfv2, shiftv2);
 
-	const __m512i bot16 = _mm512_set1_epi32(0xffff);
-	qv1 = _mm512_mullo_epi32(qv1, _mm512_and_si512(SDv1, bot16));
-	qv2 = _mm512_mullo_epi32(qv2, _mm512_and_si512(SDv2, bot16));
+        const __m512i bot16 = _mm512_set1_epi32(0xffff);
+        qv1 = _mm512_mullo_epi32(qv1, _mm512_and_si512(SDv1, bot16));
+        qv2 = _mm512_mullo_epi32(qv2, _mm512_and_si512(SDv2, bot16));
 
-	qv1 = _mm512_add_epi32(qv1, biasv1);
-	Rv1 = _mm512_add_epi32(Rv1, qv1);
+        qv1 = _mm512_add_epi32(qv1, biasv1);
+        Rv1 = _mm512_add_epi32(Rv1, qv1);
 
-	qv2 = _mm512_add_epi32(qv2, biasv2);
-	Rv2 = _mm512_add_epi32(Rv2, qv2);
+        qv2 = _mm512_add_epi32(qv2, biasv2);
+        Rv2 = _mm512_add_epi32(Rv2, qv2);
     }
 
     STORE512(Rv, ransN);
@@ -638,7 +638,7 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
     ptr = (uint8_t *)ptr16;
 
     for (z = 32-1; z>=0; z--)
-	RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
+        RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
 
     for (z = 32-1; z >= 0; z--)
         RansEncFlush(&ransN[z], &ptr);
@@ -660,14 +660,14 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
 
 #define NX 32
 unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
-					       unsigned int in_size,
-					       unsigned char *out,
-					       unsigned int out_sz) {
+                                               unsigned int in_size,
+                                               unsigned char *out,
+                                               unsigned int out_sz) {
     if (in_size < NX*4) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
     /* Load in the static tables */
     unsigned char *cp = in, *cp_end = in+in_size, *out_free = NULL;
@@ -675,14 +675,14 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
 
     uint32_t (*s3)[TOTFREQ_O1] = htscodecs_tls_alloc(256*TOTFREQ_O1*4);
     if (!s3)
-	return NULL;
+        return NULL;
     uint32_t (*s3F)[TOTFREQ_O1_FAST] = (uint32_t (*)[TOTFREQ_O1_FAST])s3;
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
 
     if (!out)
-	goto err;
+        goto err;
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
@@ -691,43 +691,43 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
     unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
-	uint32_t u_freq_sz, c_freq_sz;
-	cp += var_get_u32(cp, cp_end, &u_freq_sz);
-	cp += var_get_u32(cp, cp_end, &c_freq_sz);
-	if (c_freq_sz >= cp_end - cp - 16)
-	    goto err;
-	tab_end = cp + c_freq_sz;
-	if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL,
-					       u_freq_sz)))
-	    goto err;
-	cp = c_freq;
-	c_freq_end = c_freq + u_freq_sz;
+        uint32_t u_freq_sz, c_freq_sz;
+        cp += var_get_u32(cp, cp_end, &u_freq_sz);
+        cp += var_get_u32(cp, cp_end, &c_freq_sz);
+        if (c_freq_sz >= cp_end - cp - 16)
+            goto err;
+        tab_end = cp + c_freq_sz;
+        if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL,
+                                               u_freq_sz)))
+            goto err;
+        cp = c_freq;
+        c_freq_end = c_freq + u_freq_sz;
     }
 
     // Decode order-0 symbol list; avoids needing in order-1 tables
     cp += decode_freq1(cp, c_freq_end, shift, s3, s3F, NULL, NULL);
 
     if (tab_end)
-	cp = tab_end;
+        cp = tab_end;
     free(c_freq);
     c_freq = NULL;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     RansState R[NX] __attribute__((aligned(64)));
     uint8_t *ptr = cp, *ptr_end = in + in_size;
     int z;
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &ptr);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &ptr);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     int isz4 = out_sz/NX;
     int iN[NX], lN[NX] __attribute__((aligned(64))) = {0};
     for (z = 0; z < NX; z++)
-	iN[z] = z*isz4;
+        iN[z] = z*isz4;
 
     uint16_t *sp = (uint16_t *)ptr;
     const uint32_t mask = (1u << shift)-1;
@@ -738,8 +738,8 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
 
 #ifdef TBUF8
     union {
-	unsigned char tbuf[32][32];
-	uint64_t tbuf64[32][4];
+        unsigned char tbuf[32][32];
+        uint64_t tbuf64[32][4];
     } u;
 #else
     uint32_t tbuf[32][32];
@@ -748,316 +748,316 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
     unsigned int tidx = 0;
 
     if (shift == TF_SHIFT_O1) {
-	isz4 -= 64;
-	for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
-	    // m[z] = R[z] & mask;
-	    __m512i _masked1 = _mm512_and_si512(_Rv1, _maskv);
-	    __m512i _masked2 = _mm512_and_si512(_Rv2, _maskv);
+        isz4 -= 64;
+        for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
+            // m[z] = R[z] & mask;
+            __m512i _masked1 = _mm512_and_si512(_Rv1, _maskv);
+            __m512i _masked2 = _mm512_and_si512(_Rv2, _maskv);
 
-	    //  S[z] = s3[lN[z]][m[z]];
-	    _Lv1 = _mm512_slli_epi32(_Lv1, TF_SHIFT_O1);
-	    _Lv2 = _mm512_slli_epi32(_Lv2, TF_SHIFT_O1);
+            //  S[z] = s3[lN[z]][m[z]];
+            _Lv1 = _mm512_slli_epi32(_Lv1, TF_SHIFT_O1);
+            _Lv2 = _mm512_slli_epi32(_Lv2, TF_SHIFT_O1);
 
-	    _masked1 = _mm512_add_epi32(_masked1, _Lv1);
-	    _masked2 = _mm512_add_epi32(_masked2, _Lv2);
+            _masked1 = _mm512_add_epi32(_masked1, _Lv1);
+            _masked2 = _mm512_add_epi32(_masked2, _Lv2);
 
-	    // This is the biggest bottleneck
-	    __m512i _Sv1 = _mm512_i32gather_epi32(_masked1, (int *)&s3F[0][0],
-						  sizeof(s3F[0][0]));
-	    __m512i _Sv2 = _mm512_i32gather_epi32(_masked2, (int *)&s3F[0][0],
-						  sizeof(s3F[0][0]));
+            // This is the biggest bottleneck
+            __m512i _Sv1 = _mm512_i32gather_epi32(_masked1, (int *)&s3F[0][0],
+                                                  sizeof(s3F[0][0]));
+            __m512i _Sv2 = _mm512_i32gather_epi32(_masked2, (int *)&s3F[0][0],
+                                                  sizeof(s3F[0][0]));
 
-	    //  f[z] = S[z]>>(TF_SHIFT_O1+8);
-	    __m512i _fv1 = _mm512_srli_epi32(_Sv1, TF_SHIFT_O1+8);
-	    __m512i _fv2 = _mm512_srli_epi32(_Sv2, TF_SHIFT_O1+8);
+            //  f[z] = S[z]>>(TF_SHIFT_O1+8);
+            __m512i _fv1 = _mm512_srli_epi32(_Sv1, TF_SHIFT_O1+8);
+            __m512i _fv2 = _mm512_srli_epi32(_Sv2, TF_SHIFT_O1+8);
 
-	    //  b[z] = (S[z]>>8) & mask;
-	    __m512i _bv1 = _mm512_and_si512(_mm512_srli_epi32(_Sv1,8), _maskv);
-	    __m512i _bv2 = _mm512_and_si512(_mm512_srli_epi32(_Sv2,8), _maskv);
+            //  b[z] = (S[z]>>8) & mask;
+            __m512i _bv1 = _mm512_and_si512(_mm512_srli_epi32(_Sv1,8), _maskv);
+            __m512i _bv2 = _mm512_and_si512(_mm512_srli_epi32(_Sv2,8), _maskv);
 
-	    //  s[z] = S[z] & 0xff;
-	    __m512i _sv1 = _mm512_and_si512(_Sv1, _mm512_set1_epi32(0xff));
-	    __m512i _sv2 = _mm512_and_si512(_Sv2, _mm512_set1_epi32(0xff));
+            //  s[z] = S[z] & 0xff;
+            __m512i _sv1 = _mm512_and_si512(_Sv1, _mm512_set1_epi32(0xff));
+            __m512i _sv2 = _mm512_and_si512(_Sv2, _mm512_set1_epi32(0xff));
 
-	    // A maximum frequency of 4096 doesn't fit in our s3 array.
-	    // as it's 12 bit + 12 bit + 8 bit.  It wraps around to zero.
-	    // (We don't have this issue for TOTFREQ_O1_FAST.)
-	    //
-	    // Solution 1 is to change to spec to forbid freq of 4096.
-	    // Easy hack is to add an extra symbol so it sums correctly.
-	    // => 572 MB/s on q40 (deskpro).
-	    //
-	    // Solution 2 implemented here is to look for the wrap around
-	    // and fix it.
-	    // => 556 MB/s on q40
-	    // cope with max freq of 4096.  Only 3% hit
-	    __m512i max_freq = _mm512_set1_epi32(TOTFREQ_O1);
-	    __m512i zero = _mm512_setzero_si512();
-	    __mmask16 cmp1 = _mm512_cmpeq_epi32_mask(_fv1, zero);
-	    __mmask16 cmp2 = _mm512_cmpeq_epi32_mask(_fv2, zero);
-	    _fv1 = _mm512_mask_blend_epi32(cmp1, _fv1, max_freq);
-	    _fv2 = _mm512_mask_blend_epi32(cmp2, _fv2, max_freq);
+            // A maximum frequency of 4096 doesn't fit in our s3 array.
+            // as it's 12 bit + 12 bit + 8 bit.  It wraps around to zero.
+            // (We don't have this issue for TOTFREQ_O1_FAST.)
+            //
+            // Solution 1 is to change to spec to forbid freq of 4096.
+            // Easy hack is to add an extra symbol so it sums correctly.
+            // => 572 MB/s on q40 (deskpro).
+            //
+            // Solution 2 implemented here is to look for the wrap around
+            // and fix it.
+            // => 556 MB/s on q40
+            // cope with max freq of 4096.  Only 3% hit
+            __m512i max_freq = _mm512_set1_epi32(TOTFREQ_O1);
+            __m512i zero = _mm512_setzero_si512();
+            __mmask16 cmp1 = _mm512_cmpeq_epi32_mask(_fv1, zero);
+            __mmask16 cmp2 = _mm512_cmpeq_epi32_mask(_fv2, zero);
+            _fv1 = _mm512_mask_blend_epi32(cmp1, _fv1, max_freq);
+            _fv2 = _mm512_mask_blend_epi32(cmp2, _fv2, max_freq);
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
-	    _Rv1 = _mm512_add_epi32(
-		       _mm512_mullo_epi32(
-			   _mm512_srli_epi32(_Rv1,TF_SHIFT_O1), _fv1), _bv1);
-	    _Rv2 = _mm512_add_epi32(
-		       _mm512_mullo_epi32(
-			   _mm512_srli_epi32(_Rv2,TF_SHIFT_O1), _fv2), _bv2);
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
+            _Rv1 = _mm512_add_epi32(
+                       _mm512_mullo_epi32(
+                           _mm512_srli_epi32(_Rv1,TF_SHIFT_O1), _fv1), _bv1);
+            _Rv2 = _mm512_add_epi32(
+                       _mm512_mullo_epi32(
+                           _mm512_srli_epi32(_Rv2,TF_SHIFT_O1), _fv2), _bv2);
 
-	    //for (z = 0; z < NX; z++) lN[z] = c[z];
-	    _Lv1 = _sv1;
-	    _Lv2 = _sv2;
+            //for (z = 0; z < NX; z++) lN[z] = c[z];
+            _Lv1 = _sv1;
+            _Lv2 = _sv2;
 
-	    // RansDecRenorm(&R[z], &ptr);
-	    __m512i _renorm_mask1 = _mm512_xor_si512(_Rv1,
-				        _mm512_set1_epi32(0x80000000));
-	    __m512i _renorm_mask2 = _mm512_xor_si512(_Rv2,
-					_mm512_set1_epi32(0x80000000));
+            // RansDecRenorm(&R[z], &ptr);
+            __m512i _renorm_mask1 = _mm512_xor_si512(_Rv1,
+                                        _mm512_set1_epi32(0x80000000));
+            __m512i _renorm_mask2 = _mm512_xor_si512(_Rv2,
+                                        _mm512_set1_epi32(0x80000000));
 
-	    int _imask1 =_mm512_cmpgt_epi32_mask
-	        (_mm512_set1_epi32(RANS_BYTE_L-0x80000000), _renorm_mask1);
-	    int _imask2 = _mm512_cmpgt_epi32_mask
-		(_mm512_set1_epi32(RANS_BYTE_L-0x80000000), _renorm_mask2);
+            int _imask1 =_mm512_cmpgt_epi32_mask
+                (_mm512_set1_epi32(RANS_BYTE_L-0x80000000), _renorm_mask1);
+            int _imask2 = _mm512_cmpgt_epi32_mask
+                (_mm512_set1_epi32(RANS_BYTE_L-0x80000000), _renorm_mask2);
 
-	    __m512i renorm_words1 = _mm512_cvtepu16_epi32
-		(_mm256_loadu_si256((const __m256i *)sp));
-	    sp += _mm_popcnt_u32(_imask1);
+            __m512i renorm_words1 = _mm512_cvtepu16_epi32
+                (_mm256_loadu_si256((const __m256i *)sp));
+            sp += _mm_popcnt_u32(_imask1);
 
-	    __m512i renorm_words2 = _mm512_cvtepu16_epi32
-		(_mm256_loadu_si256((const __m256i *)sp));
-	    sp += _mm_popcnt_u32(_imask2);
+            __m512i renorm_words2 = _mm512_cvtepu16_epi32
+                (_mm256_loadu_si256((const __m256i *)sp));
+            sp += _mm_popcnt_u32(_imask2);
 
-	    __m512i _renorm_vals1 =
-		_mm512_maskz_expand_epi32(_imask1, renorm_words1);
-	    __m512i _renorm_vals2 =
-		_mm512_maskz_expand_epi32(_imask2, renorm_words2);
+            __m512i _renorm_vals1 =
+                _mm512_maskz_expand_epi32(_imask1, renorm_words1);
+            __m512i _renorm_vals2 =
+                _mm512_maskz_expand_epi32(_imask2, renorm_words2);
 
-	    _Rv1 = _mm512_mask_slli_epi32(_Rv1, _imask1, _Rv1, 16);
-	    _Rv2 = _mm512_mask_slli_epi32(_Rv2, _imask2, _Rv2, 16);
+            _Rv1 = _mm512_mask_slli_epi32(_Rv1, _imask1, _Rv1, 16);
+            _Rv2 = _mm512_mask_slli_epi32(_Rv2, _imask2, _Rv2, 16);
 
-	    _Rv1 = _mm512_add_epi32(_Rv1, _renorm_vals1);
-	    _Rv2 = _mm512_add_epi32(_Rv2, _renorm_vals2);
+            _Rv1 = _mm512_add_epi32(_Rv1, _renorm_vals1);
+            _Rv2 = _mm512_add_epi32(_Rv2, _renorm_vals2);
 
 #ifdef TBUF8
-	    _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][0]),
-			     _mm512_cvtepi32_epi8(_Sv1)); // or _sv1?
-	    _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][2]),
-			     _mm512_cvtepi32_epi8(_Sv2));
+            _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][0]),
+                             _mm512_cvtepi32_epi8(_Sv1)); // or _sv1?
+            _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][2]),
+                             _mm512_cvtepi32_epi8(_Sv2));
 #else
-	    _mm512_storeu_si512((__m512i *)(&tbuf[tidx][ 0]), _sv1);
-	    _mm512_storeu_si512((__m512i *)(&tbuf[tidx][16]), _sv2);
+            _mm512_storeu_si512((__m512i *)(&tbuf[tidx][ 0]), _sv1);
+            _mm512_storeu_si512((__m512i *)(&tbuf[tidx][16]), _sv2);
 #endif
 
-	    iN[0]++;
-	    if (++tidx == 32) {
-		iN[0]-=32;
+            iN[0]++;
+            if (++tidx == 32) {
+                iN[0]-=32;
 
-		// We have tidx[x][y] which we want to store in
-		// memory in out[y][z] instead.  This is an unrolled
-		// transposition.
+                // We have tidx[x][y] which we want to store in
+                // memory in out[y][z] instead.  This is an unrolled
+                // transposition.
 #ifdef TBUF8
-		transpose_and_copy(out, iN, u.tbuf);
+                transpose_and_copy(out, iN, u.tbuf);
 #else
-		transpose_and_copy_avx512(out, iN, tbuf);
+                transpose_and_copy_avx512(out, iN, tbuf);
 #endif
-		tidx = 0;
-	    }
-	}
-	isz4 += 64;
+                tidx = 0;
+            }
+        }
+        isz4 += 64;
 
-	STORE512(_Rv, R);
-	STORE512(_Lv, lN);
-	ptr = (uint8_t *)sp;
+        STORE512(_Rv, R);
+        STORE512(_Lv, lN);
+        ptr = (uint8_t *)sp;
 
-	if (1) {
-	    iN[0]-=tidx;
-	    int T;
-	    for (z = 0; z < NX; z++)
-		for (T = 0; T < tidx; T++)
+        if (1) {
+            iN[0]-=tidx;
+            int T;
+            for (z = 0; z < NX; z++)
+                for (T = 0; T < tidx; T++)
 #ifdef TBUF8
-		    out[iN[z]++] = u.tbuf[T][z];
+                    out[iN[z]++] = u.tbuf[T][z];
 #else
-		    out[iN[z]++] = tbuf[T][z];
+                    out[iN[z]++] = tbuf[T][z];
 #endif
-	}
+        }
 
-	// Scalar version for close to the end of in[] array so we don't
-	// do SIMD loads beyond the end of the buffer
-	for (; iN[0] < isz4;) {
-	    for (z = 0; z < NX; z++) {
-		uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
-		uint32_t S = s3[lN[z]][m];
-		unsigned char c = S & 0xff;
-		out[iN[z]++] = c;
-		uint32_t F = S>>(TF_SHIFT_O1+8);
-		R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
-		    ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
-		RansDecRenormSafe(&R[z], &ptr, ptr_end);
-		lN[z] = c;
-	    }
-	}
+        // Scalar version for close to the end of in[] array so we don't
+        // do SIMD loads beyond the end of the buffer
+        for (; iN[0] < isz4;) {
+            for (z = 0; z < NX; z++) {
+                uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
+                uint32_t S = s3[lN[z]][m];
+                unsigned char c = S & 0xff;
+                out[iN[z]++] = c;
+                uint32_t F = S>>(TF_SHIFT_O1+8);
+                R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
+                    ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
+                RansDecRenormSafe(&R[z], &ptr, ptr_end);
+                lN[z] = c;
+            }
+        }
 
-	// Remainder
-	z = NX-1;
-	for (; iN[z] < out_sz; ) {
-	    uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
-	    uint32_t S = s3[lN[z]][m];
-	    unsigned char c = S & 0xff;
-	    out[iN[z]++] = c;
-	    uint32_t F = S>>(TF_SHIFT_O1+8);
-	    R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
-		((S>>8) & ((1u<<TF_SHIFT_O1)-1));
-	    RansDecRenormSafe(&R[z], &ptr, ptr_end);
-	    lN[z] = c;
-	}
+        // Remainder
+        z = NX-1;
+        for (; iN[z] < out_sz; ) {
+            uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
+            uint32_t S = s3[lN[z]][m];
+            unsigned char c = S & 0xff;
+            out[iN[z]++] = c;
+            uint32_t F = S>>(TF_SHIFT_O1+8);
+            R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
+                ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
+            RansDecRenormSafe(&R[z], &ptr, ptr_end);
+            lN[z] = c;
+        }
     } else {
-	// TF_SHIFT_O1_FAST.  This is the most commonly used variant.
+        // TF_SHIFT_O1_FAST.  This is the most commonly used variant.
 
-	// SIMD version ends decoding early as it reads at most 64 bytes
-	// from input via 4 vectorised loads.
-	isz4 -= 64;
-	for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
-	    // m[z] = R[z] & mask;
-	    __m512i _masked1 = _mm512_and_si512(_Rv1, _maskv);
-	    __m512i _masked2 = _mm512_and_si512(_Rv2, _maskv);
+        // SIMD version ends decoding early as it reads at most 64 bytes
+        // from input via 4 vectorised loads.
+        isz4 -= 64;
+        for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
+            // m[z] = R[z] & mask;
+            __m512i _masked1 = _mm512_and_si512(_Rv1, _maskv);
+            __m512i _masked2 = _mm512_and_si512(_Rv2, _maskv);
 
-	    //  S[z] = s3[lN[z]][m[z]];
-	    _Lv1 = _mm512_slli_epi32(_Lv1, TF_SHIFT_O1_FAST);
-	    _Lv2 = _mm512_slli_epi32(_Lv2, TF_SHIFT_O1_FAST);
+            //  S[z] = s3[lN[z]][m[z]];
+            _Lv1 = _mm512_slli_epi32(_Lv1, TF_SHIFT_O1_FAST);
+            _Lv2 = _mm512_slli_epi32(_Lv2, TF_SHIFT_O1_FAST);
 
-	    _masked1 = _mm512_add_epi32(_masked1, _Lv1);
-	    _masked2 = _mm512_add_epi32(_masked2, _Lv2);
+            _masked1 = _mm512_add_epi32(_masked1, _Lv1);
+            _masked2 = _mm512_add_epi32(_masked2, _Lv2);
 
-	    // This is the biggest bottleneck
-	    __m512i _Sv1 = _mm512_i32gather_epi32(_masked1, (int *)&s3F[0][0],
-						  sizeof(s3F[0][0]));
-	    __m512i _Sv2 = _mm512_i32gather_epi32(_masked2, (int *)&s3F[0][0],
-						  sizeof(s3F[0][0]));
+            // This is the biggest bottleneck
+            __m512i _Sv1 = _mm512_i32gather_epi32(_masked1, (int *)&s3F[0][0],
+                                                  sizeof(s3F[0][0]));
+            __m512i _Sv2 = _mm512_i32gather_epi32(_masked2, (int *)&s3F[0][0],
+                                                  sizeof(s3F[0][0]));
 
-	    //  f[z] = S[z]>>(TF_SHIFT_O1+8);
-	    __m512i _fv1 = _mm512_srli_epi32(_Sv1, TF_SHIFT_O1_FAST+8);
-	    __m512i _fv2 = _mm512_srli_epi32(_Sv2, TF_SHIFT_O1_FAST+8);
+            //  f[z] = S[z]>>(TF_SHIFT_O1+8);
+            __m512i _fv1 = _mm512_srli_epi32(_Sv1, TF_SHIFT_O1_FAST+8);
+            __m512i _fv2 = _mm512_srli_epi32(_Sv2, TF_SHIFT_O1_FAST+8);
 
-	    //  b[z] = (S[z]>>8) & mask;
-	    __m512i _bv1 = _mm512_and_si512(_mm512_srli_epi32(_Sv1,8), _maskv);
-	    __m512i _bv2 = _mm512_and_si512(_mm512_srli_epi32(_Sv2,8), _maskv);
+            //  b[z] = (S[z]>>8) & mask;
+            __m512i _bv1 = _mm512_and_si512(_mm512_srli_epi32(_Sv1,8), _maskv);
+            __m512i _bv2 = _mm512_and_si512(_mm512_srli_epi32(_Sv2,8), _maskv);
 
-	    //  s[z] = S[z] & 0xff;
-	    __m512i _sv1 = _mm512_and_si512(_Sv1, _mm512_set1_epi32(0xff));
-	    __m512i _sv2 = _mm512_and_si512(_Sv2, _mm512_set1_epi32(0xff));
+            //  s[z] = S[z] & 0xff;
+            __m512i _sv1 = _mm512_and_si512(_Sv1, _mm512_set1_epi32(0xff));
+            __m512i _sv2 = _mm512_and_si512(_Sv2, _mm512_set1_epi32(0xff));
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
-	    _Rv1 = _mm512_add_epi32(
-		       _mm512_mullo_epi32(
-			   _mm512_srli_epi32(_Rv1,TF_SHIFT_O1_FAST),
-			   _fv1), _bv1);
-	    _Rv2 = _mm512_add_epi32(
-		       _mm512_mullo_epi32(
-			   _mm512_srli_epi32(_Rv2,TF_SHIFT_O1_FAST),
-			   _fv2), _bv2);
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
+            _Rv1 = _mm512_add_epi32(
+                       _mm512_mullo_epi32(
+                           _mm512_srli_epi32(_Rv1,TF_SHIFT_O1_FAST),
+                           _fv1), _bv1);
+            _Rv2 = _mm512_add_epi32(
+                       _mm512_mullo_epi32(
+                           _mm512_srli_epi32(_Rv2,TF_SHIFT_O1_FAST),
+                           _fv2), _bv2);
 
-	    //for (z = 0; z < NX; z++) lN[z] = c[z];
-	    _Lv1 = _sv1;
-	    _Lv2 = _sv2;
+            //for (z = 0; z < NX; z++) lN[z] = c[z];
+            _Lv1 = _sv1;
+            _Lv2 = _sv2;
 
-	    // RansDecRenorm(&R[z], &ptr);
-	    __m512i _renorm_mask1 = _mm512_xor_si512(_Rv1,
-					_mm512_set1_epi32(0x80000000));
-	    __m512i _renorm_mask2 = _mm512_xor_si512(_Rv2,
-				        _mm512_set1_epi32(0x80000000));
+            // RansDecRenorm(&R[z], &ptr);
+            __m512i _renorm_mask1 = _mm512_xor_si512(_Rv1,
+                                        _mm512_set1_epi32(0x80000000));
+            __m512i _renorm_mask2 = _mm512_xor_si512(_Rv2,
+                                        _mm512_set1_epi32(0x80000000));
 
-	    int _imask1 =_mm512_cmpgt_epi32_mask
-	        (_mm512_set1_epi32(RANS_BYTE_L-0x80000000), _renorm_mask1);
-	    int _imask2 = _mm512_cmpgt_epi32_mask
-		(_mm512_set1_epi32(RANS_BYTE_L-0x80000000), _renorm_mask2);
+            int _imask1 =_mm512_cmpgt_epi32_mask
+                (_mm512_set1_epi32(RANS_BYTE_L-0x80000000), _renorm_mask1);
+            int _imask2 = _mm512_cmpgt_epi32_mask
+                (_mm512_set1_epi32(RANS_BYTE_L-0x80000000), _renorm_mask2);
 
-	    __m512i renorm_words1 = _mm512_cvtepu16_epi32
-		(_mm256_loadu_si256((const __m256i *)sp));
-	    sp += _mm_popcnt_u32(_imask1);
+            __m512i renorm_words1 = _mm512_cvtepu16_epi32
+                (_mm256_loadu_si256((const __m256i *)sp));
+            sp += _mm_popcnt_u32(_imask1);
 
-	    __m512i renorm_words2 = _mm512_cvtepu16_epi32
-		(_mm256_loadu_si256((const __m256i *)sp));
-	    sp += _mm_popcnt_u32(_imask2);
+            __m512i renorm_words2 = _mm512_cvtepu16_epi32
+                (_mm256_loadu_si256((const __m256i *)sp));
+            sp += _mm_popcnt_u32(_imask2);
 
-	    __m512i _renorm_vals1 =
-		_mm512_maskz_expand_epi32(_imask1, renorm_words1);
-	    __m512i _renorm_vals2 =
-		_mm512_maskz_expand_epi32(_imask2, renorm_words2);
+            __m512i _renorm_vals1 =
+                _mm512_maskz_expand_epi32(_imask1, renorm_words1);
+            __m512i _renorm_vals2 =
+                _mm512_maskz_expand_epi32(_imask2, renorm_words2);
 
-	    _Rv1 = _mm512_mask_slli_epi32(_Rv1, _imask1, _Rv1, 16);
-	    _Rv2 = _mm512_mask_slli_epi32(_Rv2, _imask2, _Rv2, 16);
+            _Rv1 = _mm512_mask_slli_epi32(_Rv1, _imask1, _Rv1, 16);
+            _Rv2 = _mm512_mask_slli_epi32(_Rv2, _imask2, _Rv2, 16);
 
-	    _Rv1 = _mm512_add_epi32(_Rv1, _renorm_vals1);
-	    _Rv2 = _mm512_add_epi32(_Rv2, _renorm_vals2);
+            _Rv1 = _mm512_add_epi32(_Rv1, _renorm_vals1);
+            _Rv2 = _mm512_add_epi32(_Rv2, _renorm_vals2);
 
 #ifdef TBUF8
-	    _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][0]),
-			     _mm512_cvtepi32_epi8(_Sv1)); // or _sv1?
-	    _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][2]),
-			     _mm512_cvtepi32_epi8(_Sv2));
+            _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][0]),
+                             _mm512_cvtepi32_epi8(_Sv1)); // or _sv1?
+            _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][2]),
+                             _mm512_cvtepi32_epi8(_Sv2));
 #else
-	    _mm512_storeu_si512((__m512i *)(&tbuf[tidx][ 0]), _sv1);
-	    _mm512_storeu_si512((__m512i *)(&tbuf[tidx][16]), _sv2);
+            _mm512_storeu_si512((__m512i *)(&tbuf[tidx][ 0]), _sv1);
+            _mm512_storeu_si512((__m512i *)(&tbuf[tidx][16]), _sv2);
 #endif
 
-	    iN[0]++;
-	    if (++tidx == 32) {
-		iN[0]-=32;
+            iN[0]++;
+            if (++tidx == 32) {
+                iN[0]-=32;
 #ifdef TBUF8
-		transpose_and_copy(out, iN, u.tbuf);
+                transpose_and_copy(out, iN, u.tbuf);
 #else
-		transpose_and_copy_avx512(out, iN, tbuf);
+                transpose_and_copy_avx512(out, iN, tbuf);
 #endif
-		tidx = 0;
-	    }
-	}
-	isz4 += 64;
+                tidx = 0;
+            }
+        }
+        isz4 += 64;
 
-	STORE512(_Rv, R);
-	STORE512(_Lv, lN);
-	ptr = (uint8_t *)sp;
+        STORE512(_Rv, R);
+        STORE512(_Lv, lN);
+        ptr = (uint8_t *)sp;
 
-	if (1) {
-	    iN[0]-=tidx;
-	    int T;
-	    for (z = 0; z < NX; z++)
-		for (T = 0; T < tidx; T++)
+        if (1) {
+            iN[0]-=tidx;
+            int T;
+            for (z = 0; z < NX; z++)
+                for (T = 0; T < tidx; T++)
 #ifdef TBUF8
-		    out[iN[z]++] = u.tbuf[T][z];
+                    out[iN[z]++] = u.tbuf[T][z];
 #else
-		    out[iN[z]++] = tbuf[T][z];
+                    out[iN[z]++] = tbuf[T][z];
 #endif
-	}
+        }
 
-	// Scalar version for close to the end of in[] array so we don't
-	// do SIMD loads beyond the end of the buffer
-	for (; iN[0] < isz4;) {
-	    for (z = 0; z < NX; z++) {
-		uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
-		uint32_t S = s3F[lN[z]][m];
-		unsigned char c = S & 0xff;
-		out[iN[z]++] = c;
-		R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
-		    ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-		RansDecRenormSafe(&R[z], &ptr, ptr_end);
-		lN[z] = c;
-	    }
-	}
+        // Scalar version for close to the end of in[] array so we don't
+        // do SIMD loads beyond the end of the buffer
+        for (; iN[0] < isz4;) {
+            for (z = 0; z < NX; z++) {
+                uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
+                uint32_t S = s3F[lN[z]][m];
+                unsigned char c = S & 0xff;
+                out[iN[z]++] = c;
+                R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
+                    ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+                RansDecRenormSafe(&R[z], &ptr, ptr_end);
+                lN[z] = c;
+            }
+        }
 
-	// Remainder
-	z = NX-1;
-	for (; iN[z] < out_sz; ) {
-	    uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
-	    uint32_t S = s3F[lN[z]][m];
-	    unsigned char c = S & 0xff;
-	    out[iN[z]++] = c;
-	    R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
-		((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-	    RansDecRenormSafe(&R[z], &ptr, ptr_end);
-	    lN[z] = c;
-	}
+        // Remainder
+        z = NX-1;
+        for (; iN[z] < out_sz; ) {
+            uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
+            uint32_t S = s3F[lN[z]][m];
+            unsigned char c = S & 0xff;
+            out[iN[z]++] = c;
+            R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
+                ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+            RansDecRenormSafe(&R[z], &ptr, ptr_end);
+            lN[z] = c;
+        }
     }
 
     htscodecs_tls_free(s3);

--- a/htscodecs/rANS_static32x16pr_neon.c
+++ b/htscodecs/rANS_static32x16pr_neon.c
@@ -76,9 +76,9 @@ static uint8x8_t vtab[16] = {
 #undef _
 
 unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size) {
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size) {
     unsigned char *cp, *out_end;
     RansEncSymbol syms[256];
     RansState R[NX];
@@ -88,20 +88,20 @@ unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
     int bound = rans_compress_bound_4x16(in_size,0)-20; // -20 for order/size/meta
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     // If "out" isn't word aligned, tweak out_end/ptr to ensure it is.
     // We already added more round in bound to allow for this.
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     ptr = out_end = out + bound;
 
     if (in_size == 0)
-	goto empty;
+        goto empty;
 
     // Compute statistics
     hist8(in, in_size, F);
@@ -110,10 +110,10 @@ unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
     uint32_t fsum = in_size;
     uint32_t max_val = round2(fsum);
     if (max_val > TOTFREQ)
-	max_val = TOTFREQ;
+        max_val = TOTFREQ;
 
     if (normalise_freq(F, fsum, max_val) < 0)
-	return NULL;
+        return NULL;
     fsum=max_val;
 
     cp = out;
@@ -122,14 +122,14 @@ unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
     //write(2, out+4, cp-(out+4));
 
     if (normalise_freq(F, fsum, TOTFREQ) < 0)
-	return NULL;
+        return NULL;
 
     // Encode statistics.
     for (x = rle = j = 0; j < 256; j++) {
-	if (F[j]) {
-	    RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
-	    x += F[j];
-	}
+        if (F[j]) {
+            RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
+            x += F[j];
+        }
     }
 
     for (z = 0; z < NX; z++)
@@ -140,161 +140,161 @@ unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
       RansEncPutSymbol(&R[z], &ptr, &syms[in[in_size-(i-z)]]);
 
     for (i=(in_size &~(NX-1)); i>0; i-=NX) {
-//	// Scalar equivalent
-//	for (z = NX-1; z >= 0; z-=4) {
-//	    // 327 / 272
-//	    RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
-//	    RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
-//	    RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
-//	    RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
+//      // Scalar equivalent
+//      for (z = NX-1; z >= 0; z-=4) {
+//          // 327 / 272
+//          RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
+//          RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
+//          RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
+//          RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
 //
-//	    RansEncPutSymbol(&R[z-0], &ptr, s0);
-//	    RansEncPutSymbol(&R[z-1], &ptr, s1);
-//	    RansEncPutSymbol(&R[z-2], &ptr, s2);
-//	    RansEncPutSymbol(&R[z-3], &ptr, s3);
-//	}
+//          RansEncPutSymbol(&R[z-0], &ptr, s0);
+//          RansEncPutSymbol(&R[z-1], &ptr, s1);
+//          RansEncPutSymbol(&R[z-2], &ptr, s2);
+//          RansEncPutSymbol(&R[z-3], &ptr, s3);
+//      }
 
-	// SIMD with 16-way unrolling
-	for (z = NX-1; z >= 0; z-=8) {
-	    RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
-	    RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
-	    RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
-	    RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
+        // SIMD with 16-way unrolling
+        for (z = NX-1; z >= 0; z-=8) {
+            RansEncSymbol *s0 = &syms[in[i-(NX-z+0)]];
+            RansEncSymbol *s1 = &syms[in[i-(NX-z+1)]];
+            RansEncSymbol *s2 = &syms[in[i-(NX-z+2)]];
+            RansEncSymbol *s3 = &syms[in[i-(NX-z+3)]];
 
-	    RansEncSymbol *s4 = &syms[in[i-(NX-z+4)]];
-	    RansEncSymbol *s5 = &syms[in[i-(NX-z+5)]];
-	    RansEncSymbol *s6 = &syms[in[i-(NX-z+6)]];
-	    RansEncSymbol *s7 = &syms[in[i-(NX-z+7)]];
+            RansEncSymbol *s4 = &syms[in[i-(NX-z+4)]];
+            RansEncSymbol *s5 = &syms[in[i-(NX-z+5)]];
+            RansEncSymbol *s6 = &syms[in[i-(NX-z+6)]];
+            RansEncSymbol *s7 = &syms[in[i-(NX-z+7)]];
 
-	    uint32x4_t Rv1 = vld1q_u32(&R[z-3]);
-	    uint32x4_t Rv2 = vld1q_u32(&R[z-7]);
+            uint32x4_t Rv1 = vld1q_u32(&R[z-3]);
+            uint32x4_t Rv2 = vld1q_u32(&R[z-7]);
 
-	    // Sym bit sizes = 128bits
-	    // 32: x_max
-	    // 32: rcp_freq
-	    // 32: bias
-	    // 16: cmpl_freq
-	    // 16: rcp_shift
+            // Sym bit sizes = 128bits
+            // 32: x_max
+            // 32: rcp_freq
+            // 32: bias
+            // 16: cmpl_freq
+            // 16: rcp_shift
 
-	    // Load and shuffle around
-	    //   A <---Xmax---><---RFreq--><---Bias---><-cf-><-rs->
-	    //   B <---Xmax---><---RFreq--><---Bias---><-cf-><-rs->
-	    //   C <---Xmax---><---RFreq--><---Bias---><-cf-><-rs->
-	    //   D <---Xmax---><---RFreq--><---Bias---><-cf-><-rs->
-	    // vtrn1q_u32 vtrn2q_u32  (A1 = A+B)
-	    //   A1  <---Xmax---><---Xmax---><---Bias---><---Bias--->
-	    //   C1  <---Xmax---><---Xmax---><---Bias---><---Bias--->
-	    //   A2  <---RFreq--><---RFreq--><-cf-><-rs-><-cf-><-rs->
-	    //   C2  <---RFreq--><---RFreq--><-cf-><-rs-><-cf-><-rs->
-	    // vtrn1q_u64 vtrn2q_u64  (A11 = A1+C1)
-	    //   A11 <---Xmax---><---Xmax---><---Xmax---><---Xmax--->
-	    //   A12 <---Bias---><---Bias---><---Bias---><---Bias--->
-	    //   A21 <---RFreq--><---RFreq--><---RFreq--><---RFreq-->
-	    //   A22 <-cf-><-rs-><-cf-><-rs-><-cf-><-rs-><-cf-><-rs->
-	    uint32x4_t A_1 = vld1q_u32((void *)s3);
-	    uint32x4_t B_1 = vld1q_u32((void *)s2);
-	    uint32x4_t C_1 = vld1q_u32((void *)s1);
-	    uint32x4_t D_1 = vld1q_u32((void *)s0);
+            // Load and shuffle around
+            //   A <---Xmax---><---RFreq--><---Bias---><-cf-><-rs->
+            //   B <---Xmax---><---RFreq--><---Bias---><-cf-><-rs->
+            //   C <---Xmax---><---RFreq--><---Bias---><-cf-><-rs->
+            //   D <---Xmax---><---RFreq--><---Bias---><-cf-><-rs->
+            // vtrn1q_u32 vtrn2q_u32  (A1 = A+B)
+            //   A1  <---Xmax---><---Xmax---><---Bias---><---Bias--->
+            //   C1  <---Xmax---><---Xmax---><---Bias---><---Bias--->
+            //   A2  <---RFreq--><---RFreq--><-cf-><-rs-><-cf-><-rs->
+            //   C2  <---RFreq--><---RFreq--><-cf-><-rs-><-cf-><-rs->
+            // vtrn1q_u64 vtrn2q_u64  (A11 = A1+C1)
+            //   A11 <---Xmax---><---Xmax---><---Xmax---><---Xmax--->
+            //   A12 <---Bias---><---Bias---><---Bias---><---Bias--->
+            //   A21 <---RFreq--><---RFreq--><---RFreq--><---RFreq-->
+            //   A22 <-cf-><-rs-><-cf-><-rs-><-cf-><-rs-><-cf-><-rs->
+            uint32x4_t A_1 = vld1q_u32((void *)s3);
+            uint32x4_t B_1 = vld1q_u32((void *)s2);
+            uint32x4_t C_1 = vld1q_u32((void *)s1);
+            uint32x4_t D_1 = vld1q_u32((void *)s0);
 
-	    uint32x4_t A1_1 = vtrn1q_u32(A_1, B_1);
-	    uint32x4_t C1_1 = vtrn1q_u32(C_1, D_1);
-	    uint32x4_t A2_1 = vtrn2q_u32(A_1, B_1);
-	    uint32x4_t C2_1 = vtrn2q_u32(C_1, D_1);
+            uint32x4_t A1_1 = vtrn1q_u32(A_1, B_1);
+            uint32x4_t C1_1 = vtrn1q_u32(C_1, D_1);
+            uint32x4_t A2_1 = vtrn2q_u32(A_1, B_1);
+            uint32x4_t C2_1 = vtrn2q_u32(C_1, D_1);
 
 #define u32_u64(x) vreinterpretq_u32_u64((x))
 #define u64_u32(x) vreinterpretq_u64_u32((x))
-	    uint32x4_t Xmaxv1=u32_u64(vtrn1q_u64(u64_u32(A1_1),u64_u32(C1_1)));
-	    uint32x4_t Biasv1=u32_u64(vtrn2q_u64(u64_u32(A1_1),u64_u32(C1_1)));
-	    uint32x4_t RFv1  =u32_u64(vtrn1q_u64(u64_u32(A2_1),u64_u32(C2_1)));
-	    uint32x4_t FSv1  =u32_u64(vtrn2q_u64(u64_u32(A2_1),u64_u32(C2_1)));
+            uint32x4_t Xmaxv1=u32_u64(vtrn1q_u64(u64_u32(A1_1),u64_u32(C1_1)));
+            uint32x4_t Biasv1=u32_u64(vtrn2q_u64(u64_u32(A1_1),u64_u32(C1_1)));
+            uint32x4_t RFv1  =u32_u64(vtrn1q_u64(u64_u32(A2_1),u64_u32(C2_1)));
+            uint32x4_t FSv1  =u32_u64(vtrn2q_u64(u64_u32(A2_1),u64_u32(C2_1)));
 
-	    uint32x4_t A_2 = vld1q_u32((void *)s7);
-	    uint32x4_t B_2 = vld1q_u32((void *)s6);
-	    uint32x4_t C_2 = vld1q_u32((void *)s5);
-	    uint32x4_t D_2 = vld1q_u32((void *)s4);
+            uint32x4_t A_2 = vld1q_u32((void *)s7);
+            uint32x4_t B_2 = vld1q_u32((void *)s6);
+            uint32x4_t C_2 = vld1q_u32((void *)s5);
+            uint32x4_t D_2 = vld1q_u32((void *)s4);
 
-	    uint32x4_t A1_2 = vtrn1q_u32(A_2, B_2);
-	    uint32x4_t C1_2 = vtrn1q_u32(C_2, D_2);
-	    uint32x4_t A2_2 = vtrn2q_u32(A_2, B_2);
-	    uint32x4_t C2_2 = vtrn2q_u32(C_2, D_2);
+            uint32x4_t A1_2 = vtrn1q_u32(A_2, B_2);
+            uint32x4_t C1_2 = vtrn1q_u32(C_2, D_2);
+            uint32x4_t A2_2 = vtrn2q_u32(A_2, B_2);
+            uint32x4_t C2_2 = vtrn2q_u32(C_2, D_2);
 
-	    uint32x4_t Xmaxv2=u32_u64(vtrn1q_u64(u64_u32(A1_2),u64_u32(C1_2)));
-	    uint32x4_t Biasv2=u32_u64(vtrn2q_u64(u64_u32(A1_2),u64_u32(C1_2)));
-	    uint32x4_t RFv2  =u32_u64(vtrn1q_u64(u64_u32(A2_2),u64_u32(C2_2)));
-	    uint32x4_t FSv2  =u32_u64(vtrn2q_u64(u64_u32(A2_2),u64_u32(C2_2)));
-	    
-	    // Turn multi R<xmax checks into a bit-field (imask)
-	    uint32x4_t Cv1 = vcgtq_u32(Rv1, Xmaxv1);
-	    uint32x4_t Cv2 = vcgtq_u32(Rv2, Xmaxv2);
+            uint32x4_t Xmaxv2=u32_u64(vtrn1q_u64(u64_u32(A1_2),u64_u32(C1_2)));
+            uint32x4_t Biasv2=u32_u64(vtrn2q_u64(u64_u32(A1_2),u64_u32(C1_2)));
+            uint32x4_t RFv2  =u32_u64(vtrn1q_u64(u64_u32(A2_2),u64_u32(C2_2)));
+            uint32x4_t FSv2  =u32_u64(vtrn2q_u64(u64_u32(A2_2),u64_u32(C2_2)));
+            
+            // Turn multi R<xmax checks into a bit-field (imask)
+            uint32x4_t Cv1 = vcgtq_u32(Rv1, Xmaxv1);
+            uint32x4_t Cv2 = vcgtq_u32(Rv2, Xmaxv2);
 
-	    uint32x4_t bit = {8,4,2,1};
-	    uint32_t imask1 = vaddvq_u32(vandq_u32(Cv1, bit));
-	    uint32_t imask2 = vaddvq_u32(vandq_u32(Cv2, bit));
+            uint32x4_t bit = {8,4,2,1};
+            uint32_t imask1 = vaddvq_u32(vandq_u32(Cv1, bit));
+            uint32_t imask2 = vaddvq_u32(vandq_u32(Cv2, bit));
 
-	    // Select low 16-bits from Rv based on imask, using tbl
+            // Select low 16-bits from Rv based on imask, using tbl
             uint8x8_t norm1, norm2;
-	    norm1 = vqtbl1_u8(vreinterpretq_u8_u32(Rv1),vtab[imask1]);
-	    norm2 = vqtbl1_u8(vreinterpretq_u8_u32(Rv2),vtab[imask2]);
+            norm1 = vqtbl1_u8(vreinterpretq_u8_u32(Rv1),vtab[imask1]);
+            norm2 = vqtbl1_u8(vreinterpretq_u8_u32(Rv2),vtab[imask2]);
 
-	    static int nbits[16] = { 0,2,2,4, 2,4,4,6, 2,4,4,6, 4,6,6,8 };
-	    vst1_u8(ptr-8, norm1);   ptr -= nbits[imask1];
-	    vst1_u8(ptr-8, norm2);   ptr -= nbits[imask2];
+            static int nbits[16] = { 0,2,2,4, 2,4,4,6, 2,4,4,6, 4,6,6,8 };
+            vst1_u8(ptr-8, norm1);   ptr -= nbits[imask1];
+            vst1_u8(ptr-8, norm2);   ptr -= nbits[imask2];
 
-	    // R' = R>>16
-	    uint32x4_t Rv1_r = vshrq_n_u32(Rv1, 16);
-	    uint32x4_t Rv2_r = vshrq_n_u32(Rv2, 16);
+            // R' = R>>16
+            uint32x4_t Rv1_r = vshrq_n_u32(Rv1, 16);
+            uint32x4_t Rv2_r = vshrq_n_u32(Rv2, 16);
 
-	    // Blend R and R' based on Cv.
-	    Rv1 = vbslq_u32(Cv1, Rv1_r, Rv1);
-	    Rv2 = vbslq_u32(Cv2, Rv2_r, Rv2);
+            // Blend R and R' based on Cv.
+            Rv1 = vbslq_u32(Cv1, Rv1_r, Rv1);
+            Rv2 = vbslq_u32(Cv2, Rv2_r, Rv2);
 
-	    // R -> R' update
-	    //   q = (uint32_t) (((uint64_t)x * rcp_freq) >> rcp_shift);
-	    //   R' = R + sym->bias + q * sym->cmpl_freq;
+            // R -> R' update
+            //   q = (uint32_t) (((uint64_t)x * rcp_freq) >> rcp_shift);
+            //   R' = R + sym->bias + q * sym->cmpl_freq;
 
-	    // Mix SIMD (mul) & scalar (shift). 365MB/s
+            // Mix SIMD (mul) & scalar (shift). 365MB/s
 
-	    // We do 32 x 32 mul to get 64-bit, but then extract this
-	    // a 64-bit quantity and shift as scalar, before
-	    // recreating the 32x4 result.  Despite SIMD-scalar-SIMD reg
-	    // it's slightly quicker.
+            // We do 32 x 32 mul to get 64-bit, but then extract this
+            // a 64-bit quantity and shift as scalar, before
+            // recreating the 32x4 result.  Despite SIMD-scalar-SIMD reg
+            // it's slightly quicker.
 
-	    uint64x2_t qvl1 = vmull_u32(vget_low_u32(Rv1), vget_low_u32(RFv1));
-	    uint64x2_t qvh1 = vmull_high_u32(Rv1, RFv1);
+            uint64x2_t qvl1 = vmull_u32(vget_low_u32(Rv1), vget_low_u32(RFv1));
+            uint64x2_t qvh1 = vmull_high_u32(Rv1, RFv1);
 
-	    uint64x2_t qvl2 = vmull_u32(vget_low_u32(Rv2), vget_low_u32(RFv2));
-	    uint64x2_t qvh2 = vmull_high_u32(Rv2, RFv2);
+            uint64x2_t qvl2 = vmull_u32(vget_low_u32(Rv2), vget_low_u32(RFv2));
+            uint64x2_t qvh2 = vmull_high_u32(Rv2, RFv2);
 
-	    uint32x2_t qv1a =
-		 vcreate_u32(vgetq_lane_u64(qvl1, 1) >> s2->rcp_shift << 32 |
-			     vgetq_lane_u64(qvl1, 0) >> s3->rcp_shift);
-	    uint32x2_t qv1b =
-		 vcreate_u32(vgetq_lane_u64(qvh1, 1) >> s0->rcp_shift << 32 |
-			     vgetq_lane_u64(qvh1, 0) >> s1->rcp_shift);
+            uint32x2_t qv1a =
+                 vcreate_u32(vgetq_lane_u64(qvl1, 1) >> s2->rcp_shift << 32 |
+                             vgetq_lane_u64(qvl1, 0) >> s3->rcp_shift);
+            uint32x2_t qv1b =
+                 vcreate_u32(vgetq_lane_u64(qvh1, 1) >> s0->rcp_shift << 32 |
+                             vgetq_lane_u64(qvh1, 0) >> s1->rcp_shift);
 
-	    uint32x2_t qv2a =
-		 vcreate_u32(vgetq_lane_u64(qvl2, 1) >> s6->rcp_shift << 32 |
-			     vgetq_lane_u64(qvl2, 0) >> s7->rcp_shift);
-	    uint32x2_t qv2b =
-		 vcreate_u32(vgetq_lane_u64(qvh2, 1) >> s4->rcp_shift << 32 |
-			     vgetq_lane_u64(qvh2, 0) >> s5->rcp_shift);
+            uint32x2_t qv2a =
+                 vcreate_u32(vgetq_lane_u64(qvl2, 1) >> s6->rcp_shift << 32 |
+                             vgetq_lane_u64(qvl2, 0) >> s7->rcp_shift);
+            uint32x2_t qv2b =
+                 vcreate_u32(vgetq_lane_u64(qvh2, 1) >> s4->rcp_shift << 32 |
+                             vgetq_lane_u64(qvh2, 0) >> s5->rcp_shift);
 
-	    uint32x4_t qv1 = vcombine_u32(qv1a, qv1b);
-	    uint32x4_t qv2 = vcombine_u32(qv2a, qv2b);
-		
+            uint32x4_t qv1 = vcombine_u32(qv1a, qv1b);
+            uint32x4_t qv2 = vcombine_u32(qv2a, qv2b);
+                
             FSv1 = vandq_u32(FSv1, vdupq_n_u32(0xffff)); // cmpl_freq
             FSv2 = vandq_u32(FSv2, vdupq_n_u32(0xffff));
-	
-	    qv1 = vmlaq_u32(Biasv1, qv1, FSv1);
-	    qv2 = vmlaq_u32(Biasv2, qv2, FSv2);
+        
+            qv1 = vmlaq_u32(Biasv1, qv1, FSv1);
+            qv2 = vmlaq_u32(Biasv2, qv2, FSv2);
 
-	    Rv1 = vaddq_u32(Rv1, qv1);
-	    Rv2 = vaddq_u32(Rv2, qv2);
+            Rv1 = vaddq_u32(Rv1, qv1);
+            Rv2 = vaddq_u32(Rv2, qv2);
 
-	    vst1q_u32(&R[z-3], Rv1);
-	    vst1q_u32(&R[z-7], Rv2);
-	}
-	if (z < -1) abort();
+            vst1q_u32(&R[z-3], Rv1);
+            vst1q_u32(&R[z-7], Rv2);
+        }
+        if (z < -1) abort();
     }
     for (z = NX-1; z >= 0; z--)
       RansEncFlush(&R[z], &ptr);
@@ -593,14 +593,14 @@ static uint8x8_t idx2[256] = {
 
 // SIMD: 650MB/s
 unsigned char *rans_uncompress_O0_32x16_neon(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz) {
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz) {
     if (in_size < 16) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
     /* Load in the static tables */
     unsigned char *cp = in, *out_free = NULL;
@@ -609,32 +609,32 @@ unsigned char *rans_uncompress_O0_32x16_neon(unsigned char *in,
     uint32_t s3[TOTFREQ]; // For TF_SHIFT <= 12
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     // Precompute reverse lookup of frequency.
     uint32_t F[256] = {0}, fsum;
     int fsz = decode_freq(cp, cp_end, F, &fsum);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     normalise_freq_shift(F, fsum, TOTFREQ);
 
     // Build symbols; fixme, do as part of decode, see the _d variant
     if (rans_F_to_s3(F, TF_SHIFT, s3))
-	goto err;
+        goto err;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     int z;
     RansState R[NX];
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &cp);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &cp);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     int out_end = (out_sz&~(NX-1));
@@ -667,230 +667,230 @@ unsigned char *rans_uncompress_O0_32x16_neon(unsigned char *in,
     uint16_t *sp = (uint16_t *)cp;
     uint8_t overflow[64+64] = {0};
     for (i=0; i < out_end; i+=NX) {
-	// Decode freq, bias and symbol from s3 lookups
-	uint32x4_t Sv1, Sv2, Sv3, Sv4, Sv5, Sv6, Sv7, Sv8;
-	uint32x4_t Fv1, Fv2, Fv3, Fv4, Fv5, Fv6, Fv7, Fv8;
-	uint32x4_t Bv1, Bv2, Bv3, Bv4, Bv5, Bv6, Bv7, Bv8;
+        // Decode freq, bias and symbol from s3 lookups
+        uint32x4_t Sv1, Sv2, Sv3, Sv4, Sv5, Sv6, Sv7, Sv8;
+        uint32x4_t Fv1, Fv2, Fv3, Fv4, Fv5, Fv6, Fv7, Fv8;
+        uint32x4_t Bv1, Bv2, Bv3, Bv4, Bv5, Bv6, Bv7, Bv8;
 
-	// Note we could check __ARM_FEATURE_MVE & 1 and use
-	// vcreateq_u32 here, but I don't have a system to test with
-	// so cannot validate if the code works.
-	uint32x2_t s1a, s1b, s2a, s2b, s3a, s3b, s4a, s4b;
-	s1a = vcreate_u32((uint64_t)(s3[R[ 1]&mask])<<32 | (s3[R[ 0]&mask]));
-	s2a = vcreate_u32((uint64_t)(s3[R[ 5]&mask])<<32 | (s3[R[ 4]&mask]));
-	s1b = vcreate_u32((uint64_t)(s3[R[ 3]&mask])<<32 | (s3[R[ 2]&mask]));
-	s2b = vcreate_u32((uint64_t)(s3[R[ 7]&mask])<<32 | (s3[R[ 6]&mask]));
-	s3a = vcreate_u32((uint64_t)(s3[R[ 9]&mask])<<32 | (s3[R[ 8]&mask]));
-	s3b = vcreate_u32((uint64_t)(s3[R[11]&mask])<<32 | (s3[R[10]&mask]));
-	s4a = vcreate_u32((uint64_t)(s3[R[13]&mask])<<32 | (s3[R[12]&mask]));
-	s4b = vcreate_u32((uint64_t)(s3[R[15]&mask])<<32 | (s3[R[14]&mask]));
+        // Note we could check __ARM_FEATURE_MVE & 1 and use
+        // vcreateq_u32 here, but I don't have a system to test with
+        // so cannot validate if the code works.
+        uint32x2_t s1a, s1b, s2a, s2b, s3a, s3b, s4a, s4b;
+        s1a = vcreate_u32((uint64_t)(s3[R[ 1]&mask])<<32 | (s3[R[ 0]&mask]));
+        s2a = vcreate_u32((uint64_t)(s3[R[ 5]&mask])<<32 | (s3[R[ 4]&mask]));
+        s1b = vcreate_u32((uint64_t)(s3[R[ 3]&mask])<<32 | (s3[R[ 2]&mask]));
+        s2b = vcreate_u32((uint64_t)(s3[R[ 7]&mask])<<32 | (s3[R[ 6]&mask]));
+        s3a = vcreate_u32((uint64_t)(s3[R[ 9]&mask])<<32 | (s3[R[ 8]&mask]));
+        s3b = vcreate_u32((uint64_t)(s3[R[11]&mask])<<32 | (s3[R[10]&mask]));
+        s4a = vcreate_u32((uint64_t)(s3[R[13]&mask])<<32 | (s3[R[12]&mask]));
+        s4b = vcreate_u32((uint64_t)(s3[R[15]&mask])<<32 | (s3[R[14]&mask]));
 
         Sv1 = vcombine_u32(s1a, s1b);
         Sv2 = vcombine_u32(s2a, s2b);
         Sv3 = vcombine_u32(s3a, s3b);
         Sv4 = vcombine_u32(s4a, s4b);
 
-	Fv1 = vshrq_n_u32(Sv1, TF_SHIFT+8); // Freq = S >> TF_SHIFT+8
-	Fv2 = vshrq_n_u32(Sv2, TF_SHIFT+8);
-	Fv3 = vshrq_n_u32(Sv3, TF_SHIFT+8);
-	Fv4 = vshrq_n_u32(Sv4, TF_SHIFT+8);
+        Fv1 = vshrq_n_u32(Sv1, TF_SHIFT+8); // Freq = S >> TF_SHIFT+8
+        Fv2 = vshrq_n_u32(Sv2, TF_SHIFT+8);
+        Fv3 = vshrq_n_u32(Sv3, TF_SHIFT+8);
+        Fv4 = vshrq_n_u32(Sv4, TF_SHIFT+8);
 
-	uint32x2_t s5a, s5b, s6a, s6b, s7a, s7b, s8a, s8b;
-	s5a = vcreate_u32((uint64_t)(s3[R[17]&mask])<<32 | (s3[R[16]&mask]));
-	s5b = vcreate_u32((uint64_t)(s3[R[19]&mask])<<32 | (s3[R[18]&mask]));
-	s6a = vcreate_u32((uint64_t)(s3[R[21]&mask])<<32 | (s3[R[20]&mask]));
-	s6b = vcreate_u32((uint64_t)(s3[R[23]&mask])<<32 | (s3[R[22]&mask]));
-	s7a = vcreate_u32((uint64_t)(s3[R[25]&mask])<<32 | (s3[R[24]&mask]));
-	s7b = vcreate_u32((uint64_t)(s3[R[27]&mask])<<32 | (s3[R[26]&mask]));
-	s8a = vcreate_u32((uint64_t)(s3[R[29]&mask])<<32 | (s3[R[28]&mask]));
-	s8b = vcreate_u32((uint64_t)(s3[R[31]&mask])<<32 | (s3[R[30]&mask]));
+        uint32x2_t s5a, s5b, s6a, s6b, s7a, s7b, s8a, s8b;
+        s5a = vcreate_u32((uint64_t)(s3[R[17]&mask])<<32 | (s3[R[16]&mask]));
+        s5b = vcreate_u32((uint64_t)(s3[R[19]&mask])<<32 | (s3[R[18]&mask]));
+        s6a = vcreate_u32((uint64_t)(s3[R[21]&mask])<<32 | (s3[R[20]&mask]));
+        s6b = vcreate_u32((uint64_t)(s3[R[23]&mask])<<32 | (s3[R[22]&mask]));
+        s7a = vcreate_u32((uint64_t)(s3[R[25]&mask])<<32 | (s3[R[24]&mask]));
+        s7b = vcreate_u32((uint64_t)(s3[R[27]&mask])<<32 | (s3[R[26]&mask]));
+        s8a = vcreate_u32((uint64_t)(s3[R[29]&mask])<<32 | (s3[R[28]&mask]));
+        s8b = vcreate_u32((uint64_t)(s3[R[31]&mask])<<32 | (s3[R[30]&mask]));
 
-	Bv1 = vshrq_n_u32(Sv1, 8);          // Bias = (S >> 8)
-	Bv2 = vshrq_n_u32(Sv2, 8);
-	Bv3 = vshrq_n_u32(Sv3, 8);
-	Bv4 = vshrq_n_u32(Sv4, 8);
+        Bv1 = vshrq_n_u32(Sv1, 8);          // Bias = (S >> 8)
+        Bv2 = vshrq_n_u32(Sv2, 8);
+        Bv3 = vshrq_n_u32(Sv3, 8);
+        Bv4 = vshrq_n_u32(Sv4, 8);
 
-	// R[0] = (freq * (R[0] >> TF_SHIFT) + bias;
-	Rv1 = vshrq_n_u32(Rv1, TF_SHIFT);   // R >> TF_SHIFT
-	Rv2 = vshrq_n_u32(Rv2, TF_SHIFT);
-	Rv3 = vshrq_n_u32(Rv3, TF_SHIFT);
-	Rv4 = vshrq_n_u32(Rv4, TF_SHIFT);
+        // R[0] = (freq * (R[0] >> TF_SHIFT) + bias;
+        Rv1 = vshrq_n_u32(Rv1, TF_SHIFT);   // R >> TF_SHIFT
+        Rv2 = vshrq_n_u32(Rv2, TF_SHIFT);
+        Rv3 = vshrq_n_u32(Rv3, TF_SHIFT);
+        Rv4 = vshrq_n_u32(Rv4, TF_SHIFT);
 
         Sv5 = vcombine_u32(s5a, s5b);
-	Sv6 = vcombine_u32(s6a, s6b);
+        Sv6 = vcombine_u32(s6a, s6b);
         Sv7 = vcombine_u32(s7a, s7b);
         Sv8 = vcombine_u32(s8a, s8b);
 
-	Bv1 = vandq_u32(Bv1, maskv);        //      & mask
-	Bv2 = vandq_u32(Bv2, maskv);
-	Bv3 = vandq_u32(Bv3, maskv);
-	Bv4 = vandq_u32(Bv4, maskv);
+        Bv1 = vandq_u32(Bv1, maskv);        //      & mask
+        Bv2 = vandq_u32(Bv2, maskv);
+        Bv3 = vandq_u32(Bv3, maskv);
+        Bv4 = vandq_u32(Bv4, maskv);
 
-	Fv5 = vshrq_n_u32(Sv5, TF_SHIFT+8);
-	Fv6 = vshrq_n_u32(Sv6, TF_SHIFT+8);
-	Fv7 = vshrq_n_u32(Sv7, TF_SHIFT+8);
-	Fv8 = vshrq_n_u32(Sv8, TF_SHIFT+8);
+        Fv5 = vshrq_n_u32(Sv5, TF_SHIFT+8);
+        Fv6 = vshrq_n_u32(Sv6, TF_SHIFT+8);
+        Fv7 = vshrq_n_u32(Sv7, TF_SHIFT+8);
+        Fv8 = vshrq_n_u32(Sv8, TF_SHIFT+8);
 
-	// A mix of mul+add and mla instructions seems to win.
-	//Rv1 = vmulq_u32(Fv1, Rv1); Rv1 = vaddq_u32(Rv1, Bv1);
-	Rv1 = vmlaq_u32(Bv1, Fv1, Rv1);     // R = R*Freq + Bias
-	Rv2 = vmulq_u32(Fv2, Rv2); Rv2 = vaddq_u32(Rv2, Bv2);
-	//Rv2 = vmlaq_u32(Bv2, Fv2, Rv2);
-	//Rv3 = vmulq_u32(Fv3, Rv3); Rv3 = vaddq_u32(Rv3, Bv3);
-	Rv3 = vmlaq_u32(Bv3, Fv3, Rv3);
-	Rv4 = vmulq_u32(Fv4, Rv4); Rv4 = vaddq_u32(Rv4, Bv4);
-	//Rv4 = vmlaq_u32(Bv4, Fv4, Rv4);
+        // A mix of mul+add and mla instructions seems to win.
+        //Rv1 = vmulq_u32(Fv1, Rv1); Rv1 = vaddq_u32(Rv1, Bv1);
+        Rv1 = vmlaq_u32(Bv1, Fv1, Rv1);     // R = R*Freq + Bias
+        Rv2 = vmulq_u32(Fv2, Rv2); Rv2 = vaddq_u32(Rv2, Bv2);
+        //Rv2 = vmlaq_u32(Bv2, Fv2, Rv2);
+        //Rv3 = vmulq_u32(Fv3, Rv3); Rv3 = vaddq_u32(Rv3, Bv3);
+        Rv3 = vmlaq_u32(Bv3, Fv3, Rv3);
+        Rv4 = vmulq_u32(Fv4, Rv4); Rv4 = vaddq_u32(Rv4, Bv4);
+        //Rv4 = vmlaq_u32(Bv4, Fv4, Rv4);
 
-	Bv5 = vshrq_n_u32(Sv5, 8);
-	Bv6 = vshrq_n_u32(Sv6, 8);
-	Bv7 = vshrq_n_u32(Sv7, 8);
-	Bv8 = vshrq_n_u32(Sv8, 8);
+        Bv5 = vshrq_n_u32(Sv5, 8);
+        Bv6 = vshrq_n_u32(Sv6, 8);
+        Bv7 = vshrq_n_u32(Sv7, 8);
+        Bv8 = vshrq_n_u32(Sv8, 8);
 
-	// Renorm
-	uint32x4_t Rlt1 = vcltq_u32(Rv1, vdupq_n_u32(RANS_BYTE_L)); // R<L
-	uint32x4_t Rlt2 = vcltq_u32(Rv2, vdupq_n_u32(RANS_BYTE_L));
-	uint32x4_t Rlt3 = vcltq_u32(Rv3, vdupq_n_u32(RANS_BYTE_L));
-	uint32x4_t Rlt4 = vcltq_u32(Rv4, vdupq_n_u32(RANS_BYTE_L));
+        // Renorm
+        uint32x4_t Rlt1 = vcltq_u32(Rv1, vdupq_n_u32(RANS_BYTE_L)); // R<L
+        uint32x4_t Rlt2 = vcltq_u32(Rv2, vdupq_n_u32(RANS_BYTE_L));
+        uint32x4_t Rlt3 = vcltq_u32(Rv3, vdupq_n_u32(RANS_BYTE_L));
+        uint32x4_t Rlt4 = vcltq_u32(Rv4, vdupq_n_u32(RANS_BYTE_L));
 
-	Rv5 = vshrq_n_u32(Rv5, TF_SHIFT);
-	Rv6 = vshrq_n_u32(Rv6, TF_SHIFT);
-	Rv7 = vshrq_n_u32(Rv7, TF_SHIFT);
-	Rv8 = vshrq_n_u32(Rv8, TF_SHIFT);
+        Rv5 = vshrq_n_u32(Rv5, TF_SHIFT);
+        Rv6 = vshrq_n_u32(Rv6, TF_SHIFT);
+        Rv7 = vshrq_n_u32(Rv7, TF_SHIFT);
+        Rv8 = vshrq_n_u32(Rv8, TF_SHIFT);
 
-	static int nbits[16] = { 0,1,1,2, 1,2,2,3, 1,2,2,3, 2,3,3,4 };
+        static int nbits[16] = { 0,1,1,2, 1,2,2,3, 1,2,2,3, 2,3,3,4 };
 
-	// Combine with Rlt & {8,4,2,1} to get single bits.
-	// Sum lanes to git a bit-field indicating which R < L
-	uint32x4_t bit = {8,4,2,1};
-	uint32_t imask1 = vaddvq_u32(vandq_u32(Rlt1, bit));
-	uint32_t imask2 = vaddvq_u32(vandq_u32(Rlt2, bit));
-	uint32_t imask3 = vaddvq_u32(vandq_u32(Rlt3, bit));
-	uint32_t imask4 = vaddvq_u32(vandq_u32(Rlt4, bit));
+        // Combine with Rlt & {8,4,2,1} to get single bits.
+        // Sum lanes to git a bit-field indicating which R < L
+        uint32x4_t bit = {8,4,2,1};
+        uint32_t imask1 = vaddvq_u32(vandq_u32(Rlt1, bit));
+        uint32_t imask2 = vaddvq_u32(vandq_u32(Rlt2, bit));
+        uint32_t imask3 = vaddvq_u32(vandq_u32(Rlt3, bit));
+        uint32_t imask4 = vaddvq_u32(vandq_u32(Rlt4, bit));
 
-	// Protect against running off the end of in buffer.
-	// We copy it to a worst-case local buffer when near the end.
-	if ((uint8_t *)sp+64 > cp_end) {
-	    memmove(overflow, sp, cp_end - (uint8_t *)sp);
-	    sp = (uint16_t *)overflow;
-	    cp_end = overflow + sizeof(overflow);
-	}
+        // Protect against running off the end of in buffer.
+        // We copy it to a worst-case local buffer when near the end.
+        if ((uint8_t *)sp+64 > cp_end) {
+            memmove(overflow, sp, cp_end - (uint8_t *)sp);
+            sp = (uint16_t *)overflow;
+            cp_end = overflow + sizeof(overflow);
+        }
 
-	uint16x8_t norm12 =  vld1q_u16(sp);
-	sp += nbits[imask1] + nbits[imask2];
-	uint16x8_t norm34 =  vld1q_u16(sp);
-	sp += nbits[imask3] + nbits[imask4];
+        uint16x8_t norm12 =  vld1q_u16(sp);
+        sp += nbits[imask1] + nbits[imask2];
+        uint16x8_t norm34 =  vld1q_u16(sp);
+        sp += nbits[imask3] + nbits[imask4];
 
-	Bv5 = vandq_u32(Bv5, maskv);
-	Bv6 = vandq_u32(Bv6, maskv);
-	Bv7 = vandq_u32(Bv7, maskv);
-	Bv8 = vandq_u32(Bv8, maskv);
+        Bv5 = vandq_u32(Bv5, maskv);
+        Bv6 = vandq_u32(Bv6, maskv);
+        Bv7 = vandq_u32(Bv7, maskv);
+        Bv8 = vandq_u32(Bv8, maskv);
 
-	// Shuffle norm to the corresponding R lanes, via imask
-	//Rv5 = vmulq_u32(Fv5, Rv5); Rv5 = vaddq_u32(Rv5, Bv5);
-	Rv5 = vmlaq_u32(Bv5, Fv5, Rv5);
-	Rv6 = vmulq_u32(Fv6, Rv6); Rv6 = vaddq_u32(Rv6, Bv6);
-	//Rv6 = vmlaq_u32(Bv6, Fv6, Rv6);
-	//Rv7 = vmulq_u32(Fv7, Rv7); Rv7 = vaddq_u32(Rv7, Bv7);
-	Rv7 = vmlaq_u32(Bv7, Fv7, Rv7);
-	Rv8 = vmulq_u32(Fv8, Rv8); Rv8 = vaddq_u32(Rv8, Bv8);
-	//Rv8 = vmlaq_u32(Bv8, Fv8, Rv8);
-	
-	uint32_t imask12 = (imask1<<4)|imask2;
-	uint32_t imask34 = (imask3<<4)|imask4;
+        // Shuffle norm to the corresponding R lanes, via imask
+        //Rv5 = vmulq_u32(Fv5, Rv5); Rv5 = vaddq_u32(Rv5, Bv5);
+        Rv5 = vmlaq_u32(Bv5, Fv5, Rv5);
+        Rv6 = vmulq_u32(Fv6, Rv6); Rv6 = vaddq_u32(Rv6, Bv6);
+        //Rv6 = vmlaq_u32(Bv6, Fv6, Rv6);
+        //Rv7 = vmulq_u32(Fv7, Rv7); Rv7 = vaddq_u32(Rv7, Bv7);
+        Rv7 = vmlaq_u32(Bv7, Fv7, Rv7);
+        Rv8 = vmulq_u32(Fv8, Rv8); Rv8 = vaddq_u32(Rv8, Bv8);
+        //Rv8 = vmlaq_u32(Bv8, Fv8, Rv8);
+        
+        uint32_t imask12 = (imask1<<4)|imask2;
+        uint32_t imask34 = (imask3<<4)|imask4;
 
-	// #define for brevity and formatting
+        // #define for brevity and formatting
 #define cast_u16_u8 vreinterpret_u16_u8
 #define cast_u8_u16 vreinterpretq_u8_u16
-	uint16x4_t norm1, norm2, norm3, norm4, norm5, norm6, norm7, norm8;
-	norm1 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),idx [imask1]));
-	norm2 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),idx2[imask12]));
-	norm3 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),idx [imask3]));
-	norm4 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),idx2[imask34]));
+        uint16x4_t norm1, norm2, norm3, norm4, norm5, norm6, norm7, norm8;
+        norm1 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),idx [imask1]));
+        norm2 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),idx2[imask12]));
+        norm3 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),idx [imask3]));
+        norm4 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),idx2[imask34]));
 
-	uint32x4_t Rlt5 = vcltq_u32(Rv5, vdupq_n_u32(RANS_BYTE_L));
-	uint32x4_t Rlt6 = vcltq_u32(Rv6, vdupq_n_u32(RANS_BYTE_L));
-	uint32x4_t Rlt7 = vcltq_u32(Rv7, vdupq_n_u32(RANS_BYTE_L));
-	uint32x4_t Rlt8 = vcltq_u32(Rv8, vdupq_n_u32(RANS_BYTE_L));
+        uint32x4_t Rlt5 = vcltq_u32(Rv5, vdupq_n_u32(RANS_BYTE_L));
+        uint32x4_t Rlt6 = vcltq_u32(Rv6, vdupq_n_u32(RANS_BYTE_L));
+        uint32x4_t Rlt7 = vcltq_u32(Rv7, vdupq_n_u32(RANS_BYTE_L));
+        uint32x4_t Rlt8 = vcltq_u32(Rv8, vdupq_n_u32(RANS_BYTE_L));
 
-	// Add norm to R<<16 (Rsl) and blend back in with R
-	uint32x4_t Rsl1 = vshlq_n_u32(Rv1, 16); // Rsl = R << 16
-	uint32x4_t Rsl2 = vshlq_n_u32(Rv2, 16);
-	uint32x4_t Rsl3 = vshlq_n_u32(Rv3, 16);
-	uint32x4_t Rsl4 = vshlq_n_u32(Rv4, 16);
+        // Add norm to R<<16 (Rsl) and blend back in with R
+        uint32x4_t Rsl1 = vshlq_n_u32(Rv1, 16); // Rsl = R << 16
+        uint32x4_t Rsl2 = vshlq_n_u32(Rv2, 16);
+        uint32x4_t Rsl3 = vshlq_n_u32(Rv3, 16);
+        uint32x4_t Rsl4 = vshlq_n_u32(Rv4, 16);
 
-	uint16x8_t norm56 =  vld1q_u16(sp);
-	uint32_t imask5 = vaddvq_u32(vandq_u32(Rlt5, bit));
-	uint32_t imask6 = vaddvq_u32(vandq_u32(Rlt6, bit));
-	uint32_t imask7 = vaddvq_u32(vandq_u32(Rlt7, bit));
-	uint32_t imask8 = vaddvq_u32(vandq_u32(Rlt8, bit));
+        uint16x8_t norm56 =  vld1q_u16(sp);
+        uint32_t imask5 = vaddvq_u32(vandq_u32(Rlt5, bit));
+        uint32_t imask6 = vaddvq_u32(vandq_u32(Rlt6, bit));
+        uint32_t imask7 = vaddvq_u32(vandq_u32(Rlt7, bit));
+        uint32_t imask8 = vaddvq_u32(vandq_u32(Rlt8, bit));
 
-	sp += nbits[imask5] + nbits[imask6];
-	uint16x8_t norm78 =  vld1q_u16(sp);
-	sp += nbits[imask7] + nbits[imask8];
+        sp += nbits[imask5] + nbits[imask6];
+        uint16x8_t norm78 =  vld1q_u16(sp);
+        sp += nbits[imask7] + nbits[imask8];
 
-	Rsl1 = vaddw_u16(Rsl1, norm1);          // Rsl += norm
-	Rsl2 = vaddw_u16(Rsl2, norm2);
-	Rsl3 = vaddw_u16(Rsl3, norm3);
-	Rsl4 = vaddw_u16(Rsl4, norm4);
+        Rsl1 = vaddw_u16(Rsl1, norm1);          // Rsl += norm
+        Rsl2 = vaddw_u16(Rsl2, norm2);
+        Rsl3 = vaddw_u16(Rsl3, norm3);
+        Rsl4 = vaddw_u16(Rsl4, norm4);
 
-	uint32_t imask56 = (imask5<<4)|imask6;
-	uint32_t imask78 = (imask7<<4)|imask8;
+        uint32_t imask56 = (imask5<<4)|imask6;
+        uint32_t imask78 = (imask7<<4)|imask8;
 
-	Rv1 = vbslq_u32(Rlt1, Rsl1, Rv1);       // R = R<L ? Rsl : R
-	Rv2 = vbslq_u32(Rlt2, Rsl2, Rv2);
-	Rv3 = vbslq_u32(Rlt3, Rsl3, Rv3);
-	Rv4 = vbslq_u32(Rlt4, Rsl4, Rv4);
+        Rv1 = vbslq_u32(Rlt1, Rsl1, Rv1);       // R = R<L ? Rsl : R
+        Rv2 = vbslq_u32(Rlt2, Rsl2, Rv2);
+        Rv3 = vbslq_u32(Rlt3, Rsl3, Rv3);
+        Rv4 = vbslq_u32(Rlt4, Rsl4, Rv4);
 
-	norm5 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm56),idx [imask5]));
-	norm6 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm56),idx2[imask56]));
-	norm7 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm78),idx [imask7]));
-	norm8 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm78),idx2[imask78]));
+        norm5 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm56),idx [imask5]));
+        norm6 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm56),idx2[imask56]));
+        norm7 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm78),idx [imask7]));
+        norm8 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm78),idx2[imask78]));
 
-	uint32x4_t Rsl5 = vshlq_n_u32(Rv5, 16);
-	uint32x4_t Rsl6 = vshlq_n_u32(Rv6, 16);
-	uint32x4_t Rsl7 = vshlq_n_u32(Rv7, 16);
-	uint32x4_t Rsl8 = vshlq_n_u32(Rv8, 16);
+        uint32x4_t Rsl5 = vshlq_n_u32(Rv5, 16);
+        uint32x4_t Rsl6 = vshlq_n_u32(Rv6, 16);
+        uint32x4_t Rsl7 = vshlq_n_u32(Rv7, 16);
+        uint32x4_t Rsl8 = vshlq_n_u32(Rv8, 16);
 
-	Rsl5 = vaddw_u16(Rsl5, norm5);
-	Rsl6 = vaddw_u16(Rsl6, norm6);
-	Rsl7 = vaddw_u16(Rsl7, norm7);
-	Rsl8 = vaddw_u16(Rsl8, norm8);
+        Rsl5 = vaddw_u16(Rsl5, norm5);
+        Rsl6 = vaddw_u16(Rsl6, norm6);
+        Rsl7 = vaddw_u16(Rsl7, norm7);
+        Rsl8 = vaddw_u16(Rsl8, norm8);
 
-	// Can we avoid storing this in memory?
-	// It's tricky due to the need to do s3[R[z] & mask] and no
-	// vector gathers.  So we need to have something in memory.
-	vst1q_u32(&R[ 0], Rv1); // store R for Sv creation
-	vst1q_u32(&R[ 4], Rv2);
-	vst1q_u32(&R[ 8], Rv3);
-	vst1q_u32(&R[12], Rv4);
+        // Can we avoid storing this in memory?
+        // It's tricky due to the need to do s3[R[z] & mask] and no
+        // vector gathers.  So we need to have something in memory.
+        vst1q_u32(&R[ 0], Rv1); // store R for Sv creation
+        vst1q_u32(&R[ 4], Rv2);
+        vst1q_u32(&R[ 8], Rv3);
+        vst1q_u32(&R[12], Rv4);
 
-	Rv5 = vbslq_u32(Rlt5, Rsl5, Rv5);
-	Rv6 = vbslq_u32(Rlt6, Rsl6, Rv6);
-	Rv7 = vbslq_u32(Rlt7, Rsl7, Rv7);
-	Rv8 = vbslq_u32(Rlt8, Rsl8, Rv8);
+        Rv5 = vbslq_u32(Rlt5, Rsl5, Rv5);
+        Rv6 = vbslq_u32(Rlt6, Rsl6, Rv6);
+        Rv7 = vbslq_u32(Rlt7, Rsl7, Rv7);
+        Rv8 = vbslq_u32(Rlt8, Rsl8, Rv8);
 
-	vst1q_u32(&R[16], Rv5);
-	vst1q_u32(&R[20], Rv6);
-	vst1q_u32(&R[24], Rv7);
-	vst1q_u32(&R[28], Rv8);
+        vst1q_u32(&R[16], Rv5);
+        vst1q_u32(&R[20], Rv6);
+        vst1q_u32(&R[24], Rv7);
+        vst1q_u32(&R[28], Rv8);
 
-	// out[i+z+?] = S[?]
-	uint16x4_t p16_1 = vmovn_u32(Sv1);
-	uint16x4_t p16_2 = vmovn_u32(Sv2);
-	uint16x4_t p16_3 = vmovn_u32(Sv3);
-	uint16x4_t p16_4 = vmovn_u32(Sv4);
-	uint16x4_t p16_5 = vmovn_u32(Sv5);
-	uint16x4_t p16_6 = vmovn_u32(Sv6);
-	uint16x4_t p16_7 = vmovn_u32(Sv7);
-	uint16x4_t p16_8 = vmovn_u32(Sv8);
-	uint8x8_t  p8_12  = vmovn_u16(vcombine_u16(p16_1,p16_2));
-	uint8x8_t  p8_34  = vmovn_u16(vcombine_u16(p16_3,p16_4));
-	uint8x8_t  p8_56  = vmovn_u16(vcombine_u16(p16_5,p16_6));
-	uint8x8_t  p8_78  = vmovn_u16(vcombine_u16(p16_7,p16_8));
-	uint8x16_t p8_a   = vcombine_u8(p8_12, p8_34);
-	uint8x16_t p8_b   = vcombine_u8(p8_56, p8_78);
-	vst1q_u8(&out[i   ], p8_a);
-	vst1q_u8(&out[i+16], p8_b);
+        // out[i+z+?] = S[?]
+        uint16x4_t p16_1 = vmovn_u32(Sv1);
+        uint16x4_t p16_2 = vmovn_u32(Sv2);
+        uint16x4_t p16_3 = vmovn_u32(Sv3);
+        uint16x4_t p16_4 = vmovn_u32(Sv4);
+        uint16x4_t p16_5 = vmovn_u32(Sv5);
+        uint16x4_t p16_6 = vmovn_u32(Sv6);
+        uint16x4_t p16_7 = vmovn_u32(Sv7);
+        uint16x4_t p16_8 = vmovn_u32(Sv8);
+        uint8x8_t  p8_12  = vmovn_u16(vcombine_u16(p16_1,p16_2));
+        uint8x8_t  p8_34  = vmovn_u16(vcombine_u16(p16_3,p16_4));
+        uint8x8_t  p8_56  = vmovn_u16(vcombine_u16(p16_5,p16_6));
+        uint8x8_t  p8_78  = vmovn_u16(vcombine_u16(p16_7,p16_8));
+        uint8x16_t p8_a   = vcombine_u8(p8_12, p8_34);
+        uint8x16_t p8_b   = vcombine_u8(p8_56, p8_78);
+        vst1q_u8(&out[i   ], p8_a);
+        vst1q_u8(&out[i+16], p8_b);
     }
 
     for (z = out_sz & (NX-1); z-- > 0; )
@@ -908,40 +908,40 @@ unsigned char *rans_uncompress_O0_32x16_neon(unsigned char *in,
 //-----------------------------------------------------------------------------
 
 unsigned char *rans_compress_O1_32x16_neon(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size) {
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size) {
     unsigned char *cp, *out_end, *out_free = NULL;
     unsigned int tab_size;
     int bound = rans_compress_bound_4x16(in_size,1)-20, z;
     RansState ransN[NX];
 
     if (in_size < NX) // force O0 instead
-	return NULL;
+        return NULL;
 
     if (!out) {
-	*out_size = bound;
-	out_free = out = malloc(*out_size);
+        *out_size = bound;
+        out_free = out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     out_end = out + bound;
 
     RansEncSymbol (*syms)[256] = htscodecs_tls_alloc(256 * (sizeof(*syms)));
     if (!syms) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     cp = out;
     int shift = encode_freq1(in, in_size, 32, syms, &cp); 
     if (shift < 0) {
-	free(out_free);
-	htscodecs_tls_free(syms);
-	return NULL;
+        free(out_free);
+        htscodecs_tls_free(syms);
+        return NULL;
     }
     tab_size = cp - out;
 
@@ -952,256 +952,256 @@ unsigned char *rans_compress_O1_32x16_neon(unsigned char *in,
 
     int iN[NX], isz4 = in_size/NX;
     for (z = 0; z < NX; z++)
-	iN[z] = (z+1)*isz4-2;
+        iN[z] = (z+1)*isz4-2;
 
     unsigned char lN[NX];
     for (z = 0; z < NX; z++)
-	lN[z] = in[iN[z]+1];
+        lN[z] = in[iN[z]+1];
 
     // Deal with the remainder
     z = NX-1;
     lN[z] = in[in_size-1];
     for (iN[z] = in_size-2; iN[z] > NX*isz4-2; iN[z]--) {
-	unsigned char c = in[iN[z]];
-	RansEncPutSymbol(&ransN[z], &ptr, &syms[c][lN[z]]);
-	lN[z] = c;
+        unsigned char c = in[iN[z]];
+        RansEncPutSymbol(&ransN[z], &ptr, &syms[c][lN[z]]);
+        lN[z] = c;
     }
 
 #if 0
     // Scalar code equivalent
     for (; iN[0] >= 0; ) {
-	for (z = NX-1; z >= 0; z-=4) {
-	    unsigned char c0;
-	    unsigned char c1;
-	    unsigned char c2;
-	    unsigned char c3;
+        for (z = NX-1; z >= 0; z-=4) {
+            unsigned char c0;
+            unsigned char c1;
+            unsigned char c2;
+            unsigned char c3;
 
-	    RansEncSymbol *s0 = &syms[c0=in[iN[z-0]--]][lN[z-0]]; lN[z-0] = c0;
-	    RansEncSymbol *s1 = &syms[c1=in[iN[z-1]--]][lN[z-1]]; lN[z-1] = c1;
-	    RansEncSymbol *s2 = &syms[c2=in[iN[z-2]--]][lN[z-2]]; lN[z-2] = c2;
-	    RansEncSymbol *s3 = &syms[c3=in[iN[z-3]--]][lN[z-3]]; lN[z-3] = c3;
+            RansEncSymbol *s0 = &syms[c0=in[iN[z-0]--]][lN[z-0]]; lN[z-0] = c0;
+            RansEncSymbol *s1 = &syms[c1=in[iN[z-1]--]][lN[z-1]]; lN[z-1] = c1;
+            RansEncSymbol *s2 = &syms[c2=in[iN[z-2]--]][lN[z-2]]; lN[z-2] = c2;
+            RansEncSymbol *s3 = &syms[c3=in[iN[z-3]--]][lN[z-3]]; lN[z-3] = c3;
 
-	    RansEncPutSymbol(&ransN[z-0], &ptr, s0);
-	    RansEncPutSymbol(&ransN[z-1], &ptr, s1);
-	    RansEncPutSymbol(&ransN[z-2], &ptr, s2);
-	    RansEncPutSymbol(&ransN[z-3], &ptr, s3);
-	}
+            RansEncPutSymbol(&ransN[z-0], &ptr, s0);
+            RansEncPutSymbol(&ransN[z-1], &ptr, s1);
+            RansEncPutSymbol(&ransN[z-2], &ptr, s2);
+            RansEncPutSymbol(&ransN[z-3], &ptr, s3);
+        }
     }
 #else
     // SIMD code
     for (; iN[0] >= 0; ) {
-	for (z = NX-1; z >= 0; z-=16) {
-	    unsigned char c;
+        for (z = NX-1; z >= 0; z-=16) {
+            unsigned char c;
 
-	    RansEncSymbol *s0 = &syms[c=in[iN[z- 0]--]][lN[z- 0]]; lN[z- 0]=c;
-	    RansEncSymbol *s1 = &syms[c=in[iN[z- 1]--]][lN[z- 1]]; lN[z- 1]=c;
-	    RansEncSymbol *s2 = &syms[c=in[iN[z- 2]--]][lN[z- 2]]; lN[z- 2]=c;
-	    RansEncSymbol *s3 = &syms[c=in[iN[z- 3]--]][lN[z- 3]]; lN[z- 3]=c;
+            RansEncSymbol *s0 = &syms[c=in[iN[z- 0]--]][lN[z- 0]]; lN[z- 0]=c;
+            RansEncSymbol *s1 = &syms[c=in[iN[z- 1]--]][lN[z- 1]]; lN[z- 1]=c;
+            RansEncSymbol *s2 = &syms[c=in[iN[z- 2]--]][lN[z- 2]]; lN[z- 2]=c;
+            RansEncSymbol *s3 = &syms[c=in[iN[z- 3]--]][lN[z- 3]]; lN[z- 3]=c;
 
-	    uint32x4_t Rv1 = vld1q_u32(&ransN[z-3]);
-	    uint32x4_t Rv2 = vld1q_u32(&ransN[z-7]);
-	    uint32x4_t Rv3 = vld1q_u32(&ransN[z-11]);
-	    uint32x4_t Rv4 = vld1q_u32(&ransN[z-15]);
-	
-	    RansEncSymbol *s4 = &syms[c=in[iN[z- 4]--]][lN[z- 4]]; lN[z- 4]=c;
-	    RansEncSymbol *s5 = &syms[c=in[iN[z- 5]--]][lN[z- 5]]; lN[z- 5]=c;
-	    RansEncSymbol *s6 = &syms[c=in[iN[z- 6]--]][lN[z- 6]]; lN[z- 6]=c;
-	    RansEncSymbol *s7 = &syms[c=in[iN[z- 7]--]][lN[z- 7]]; lN[z- 7]=c;
+            uint32x4_t Rv1 = vld1q_u32(&ransN[z-3]);
+            uint32x4_t Rv2 = vld1q_u32(&ransN[z-7]);
+            uint32x4_t Rv3 = vld1q_u32(&ransN[z-11]);
+            uint32x4_t Rv4 = vld1q_u32(&ransN[z-15]);
+        
+            RansEncSymbol *s4 = &syms[c=in[iN[z- 4]--]][lN[z- 4]]; lN[z- 4]=c;
+            RansEncSymbol *s5 = &syms[c=in[iN[z- 5]--]][lN[z- 5]]; lN[z- 5]=c;
+            RansEncSymbol *s6 = &syms[c=in[iN[z- 6]--]][lN[z- 6]]; lN[z- 6]=c;
+            RansEncSymbol *s7 = &syms[c=in[iN[z- 7]--]][lN[z- 7]]; lN[z- 7]=c;
 
-	    uint32x4_t A_1 = vld1q_u32((void *)s3);
-	    uint32x4_t B_1 = vld1q_u32((void *)s2);
-	    uint32x4_t C_1 = vld1q_u32((void *)s1);
-	    uint32x4_t D_1 = vld1q_u32((void *)s0);
+            uint32x4_t A_1 = vld1q_u32((void *)s3);
+            uint32x4_t B_1 = vld1q_u32((void *)s2);
+            uint32x4_t C_1 = vld1q_u32((void *)s1);
+            uint32x4_t D_1 = vld1q_u32((void *)s0);
 
-	    uint32x4_t A1_1 = vtrn1q_u32(A_1, B_1);
-	    uint32x4_t C1_1 = vtrn1q_u32(C_1, D_1);
-	    uint32x4_t A2_1 = vtrn2q_u32(A_1, B_1);
-	    uint32x4_t C2_1 = vtrn2q_u32(C_1, D_1);
+            uint32x4_t A1_1 = vtrn1q_u32(A_1, B_1);
+            uint32x4_t C1_1 = vtrn1q_u32(C_1, D_1);
+            uint32x4_t A2_1 = vtrn2q_u32(A_1, B_1);
+            uint32x4_t C2_1 = vtrn2q_u32(C_1, D_1);
 
-	    uint32x4_t Xmaxv1=u32_u64(vtrn1q_u64(u64_u32(A1_1),u64_u32(C1_1)));
-	    uint32x4_t Biasv1=u32_u64(vtrn2q_u64(u64_u32(A1_1),u64_u32(C1_1)));
-	    uint32x4_t RFv1  =u32_u64(vtrn1q_u64(u64_u32(A2_1),u64_u32(C2_1)));
-	    uint32x4_t FSv1  =u32_u64(vtrn2q_u64(u64_u32(A2_1),u64_u32(C2_1)));
+            uint32x4_t Xmaxv1=u32_u64(vtrn1q_u64(u64_u32(A1_1),u64_u32(C1_1)));
+            uint32x4_t Biasv1=u32_u64(vtrn2q_u64(u64_u32(A1_1),u64_u32(C1_1)));
+            uint32x4_t RFv1  =u32_u64(vtrn1q_u64(u64_u32(A2_1),u64_u32(C2_1)));
+            uint32x4_t FSv1  =u32_u64(vtrn2q_u64(u64_u32(A2_1),u64_u32(C2_1)));
 
-	    uint32x4_t A_2 = vld1q_u32((void *)s7);
-	    uint32x4_t B_2 = vld1q_u32((void *)s6);
-	    uint32x4_t C_2 = vld1q_u32((void *)s5);
-	    uint32x4_t D_2 = vld1q_u32((void *)s4);
-	    uint32x4_t A1_2 = vtrn1q_u32(A_2, B_2);
-	    uint32x4_t C1_2 = vtrn1q_u32(C_2, D_2);
-	    uint32x4_t A2_2 = vtrn2q_u32(A_2, B_2);
-	    uint32x4_t C2_2 = vtrn2q_u32(C_2, D_2);
+            uint32x4_t A_2 = vld1q_u32((void *)s7);
+            uint32x4_t B_2 = vld1q_u32((void *)s6);
+            uint32x4_t C_2 = vld1q_u32((void *)s5);
+            uint32x4_t D_2 = vld1q_u32((void *)s4);
+            uint32x4_t A1_2 = vtrn1q_u32(A_2, B_2);
+            uint32x4_t C1_2 = vtrn1q_u32(C_2, D_2);
+            uint32x4_t A2_2 = vtrn2q_u32(A_2, B_2);
+            uint32x4_t C2_2 = vtrn2q_u32(C_2, D_2);
 
-	    uint32x4_t Xmaxv2=u32_u64(vtrn1q_u64(u64_u32(A1_2),u64_u32(C1_2)));
-	    uint32x4_t Biasv2=u32_u64(vtrn2q_u64(u64_u32(A1_2),u64_u32(C1_2)));
-	    uint32x4_t RFv2  =u32_u64(vtrn1q_u64(u64_u32(A2_2),u64_u32(C2_2)));
-	    uint32x4_t FSv2  =u32_u64(vtrn2q_u64(u64_u32(A2_2),u64_u32(C2_2)));
+            uint32x4_t Xmaxv2=u32_u64(vtrn1q_u64(u64_u32(A1_2),u64_u32(C1_2)));
+            uint32x4_t Biasv2=u32_u64(vtrn2q_u64(u64_u32(A1_2),u64_u32(C1_2)));
+            uint32x4_t RFv2  =u32_u64(vtrn1q_u64(u64_u32(A2_2),u64_u32(C2_2)));
+            uint32x4_t FSv2  =u32_u64(vtrn2q_u64(u64_u32(A2_2),u64_u32(C2_2)));
 
-	    uint32x4_t Cv1 = vcgtq_u32(Rv1, Xmaxv1);
-	    uint32x4_t Cv2 = vcgtq_u32(Rv2, Xmaxv2);
-	    uint32x4_t bit = {8,4,2,1};
-	    uint32_t imask1 = vaddvq_u32(vandq_u32(Cv1, bit));
-	    uint32_t imask2 = vaddvq_u32(vandq_u32(Cv2, bit));
+            uint32x4_t Cv1 = vcgtq_u32(Rv1, Xmaxv1);
+            uint32x4_t Cv2 = vcgtq_u32(Rv2, Xmaxv2);
+            uint32x4_t bit = {8,4,2,1};
+            uint32_t imask1 = vaddvq_u32(vandq_u32(Cv1, bit));
+            uint32_t imask2 = vaddvq_u32(vandq_u32(Cv2, bit));
 
-	    RansEncSymbol *s8 = &syms[c=in[iN[z- 8]--]][lN[z- 8]]; lN[z- 8]=c;
-	    RansEncSymbol *s9 = &syms[c=in[iN[z- 9]--]][lN[z- 9]]; lN[z- 9]=c;
-	    RansEncSymbol *s10= &syms[c=in[iN[z-10]--]][lN[z-10]]; lN[z-10]=c;
-	    RansEncSymbol *s11= &syms[c=in[iN[z-11]--]][lN[z-11]]; lN[z-11]=c;
+            RansEncSymbol *s8 = &syms[c=in[iN[z- 8]--]][lN[z- 8]]; lN[z- 8]=c;
+            RansEncSymbol *s9 = &syms[c=in[iN[z- 9]--]][lN[z- 9]]; lN[z- 9]=c;
+            RansEncSymbol *s10= &syms[c=in[iN[z-10]--]][lN[z-10]]; lN[z-10]=c;
+            RansEncSymbol *s11= &syms[c=in[iN[z-11]--]][lN[z-11]]; lN[z-11]=c;
 
-	    RansEncSymbol *s12= &syms[c=in[iN[z-12]--]][lN[z-12]]; lN[z-12]=c;
-	    RansEncSymbol *s13= &syms[c=in[iN[z-13]--]][lN[z-13]]; lN[z-13]=c;
-	    RansEncSymbol *s14= &syms[c=in[iN[z-14]--]][lN[z-14]]; lN[z-14]=c;
-	    RansEncSymbol *s15= &syms[c=in[iN[z-15]--]][lN[z-15]]; lN[z-15]=c;
+            RansEncSymbol *s12= &syms[c=in[iN[z-12]--]][lN[z-12]]; lN[z-12]=c;
+            RansEncSymbol *s13= &syms[c=in[iN[z-13]--]][lN[z-13]]; lN[z-13]=c;
+            RansEncSymbol *s14= &syms[c=in[iN[z-14]--]][lN[z-14]]; lN[z-14]=c;
+            RansEncSymbol *s15= &syms[c=in[iN[z-15]--]][lN[z-15]]; lN[z-15]=c;
 
-	    uint32x4_t A_3 = vld1q_u32((void *)s11);
-	    uint32x4_t B_3 = vld1q_u32((void *)s10);
-	    uint32x4_t C_3 = vld1q_u32((void *)s9);
-	    uint32x4_t D_3 = vld1q_u32((void *)s8);
+            uint32x4_t A_3 = vld1q_u32((void *)s11);
+            uint32x4_t B_3 = vld1q_u32((void *)s10);
+            uint32x4_t C_3 = vld1q_u32((void *)s9);
+            uint32x4_t D_3 = vld1q_u32((void *)s8);
 
 
-	    uint32x4_t A1_3 = vtrn1q_u32(A_3, B_3);
-	    uint32x4_t C1_3 = vtrn1q_u32(C_3, D_3);
-	    uint32x4_t A2_3 = vtrn2q_u32(A_3, B_3);
-	    uint32x4_t C2_3 = vtrn2q_u32(C_3, D_3);
+            uint32x4_t A1_3 = vtrn1q_u32(A_3, B_3);
+            uint32x4_t C1_3 = vtrn1q_u32(C_3, D_3);
+            uint32x4_t A2_3 = vtrn2q_u32(A_3, B_3);
+            uint32x4_t C2_3 = vtrn2q_u32(C_3, D_3);
 
-	    uint32x4_t Xmaxv3=u32_u64(vtrn1q_u64(u64_u32(A1_3),u64_u32(C1_3)));
-	    uint32x4_t Biasv3=u32_u64(vtrn2q_u64(u64_u32(A1_3),u64_u32(C1_3)));
-	    uint32x4_t RFv3  =u32_u64(vtrn1q_u64(u64_u32(A2_3),u64_u32(C2_3)));
-	    uint32x4_t FSv3  =u32_u64(vtrn2q_u64(u64_u32(A2_3),u64_u32(C2_3)));
+            uint32x4_t Xmaxv3=u32_u64(vtrn1q_u64(u64_u32(A1_3),u64_u32(C1_3)));
+            uint32x4_t Biasv3=u32_u64(vtrn2q_u64(u64_u32(A1_3),u64_u32(C1_3)));
+            uint32x4_t RFv3  =u32_u64(vtrn1q_u64(u64_u32(A2_3),u64_u32(C2_3)));
+            uint32x4_t FSv3  =u32_u64(vtrn2q_u64(u64_u32(A2_3),u64_u32(C2_3)));
 
-	    uint32x4_t A_4 = vld1q_u32((void *)s15);
-	    uint32x4_t B_4 = vld1q_u32((void *)s14);
-	    uint32x4_t C_4 = vld1q_u32((void *)s13);
-	    uint32x4_t D_4 = vld1q_u32((void *)s12);
+            uint32x4_t A_4 = vld1q_u32((void *)s15);
+            uint32x4_t B_4 = vld1q_u32((void *)s14);
+            uint32x4_t C_4 = vld1q_u32((void *)s13);
+            uint32x4_t D_4 = vld1q_u32((void *)s12);
 
-	    uint32x4_t A1_4 = vtrn1q_u32(A_4, B_4);
-	    uint32x4_t C1_4 = vtrn1q_u32(C_4, D_4);
-	    uint32x4_t A2_4 = vtrn2q_u32(A_4, B_4);
-	    uint32x4_t C2_4 = vtrn2q_u32(C_4, D_4);
+            uint32x4_t A1_4 = vtrn1q_u32(A_4, B_4);
+            uint32x4_t C1_4 = vtrn1q_u32(C_4, D_4);
+            uint32x4_t A2_4 = vtrn2q_u32(A_4, B_4);
+            uint32x4_t C2_4 = vtrn2q_u32(C_4, D_4);
 
-	    uint32x4_t Xmaxv4=u32_u64(vtrn1q_u64(u64_u32(A1_4),u64_u32(C1_4)));
-	    uint32x4_t Biasv4=u32_u64(vtrn2q_u64(u64_u32(A1_4),u64_u32(C1_4)));
-	    uint32x4_t RFv4  =u32_u64(vtrn1q_u64(u64_u32(A2_4),u64_u32(C2_4)));
-	    uint32x4_t FSv4  =u32_u64(vtrn2q_u64(u64_u32(A2_4),u64_u32(C2_4)));
+            uint32x4_t Xmaxv4=u32_u64(vtrn1q_u64(u64_u32(A1_4),u64_u32(C1_4)));
+            uint32x4_t Biasv4=u32_u64(vtrn2q_u64(u64_u32(A1_4),u64_u32(C1_4)));
+            uint32x4_t RFv4  =u32_u64(vtrn1q_u64(u64_u32(A2_4),u64_u32(C2_4)));
+            uint32x4_t FSv4  =u32_u64(vtrn2q_u64(u64_u32(A2_4),u64_u32(C2_4)));
 
-	    uint32x4_t Cv3 = vcgtq_u32(Rv3, Xmaxv3);
-	    uint32x4_t Cv4 = vcgtq_u32(Rv4, Xmaxv4);
-	    uint32_t imask3 = vaddvq_u32(vandq_u32(Cv3, bit));
-	    uint32_t imask4 = vaddvq_u32(vandq_u32(Cv4, bit));
+            uint32x4_t Cv3 = vcgtq_u32(Rv3, Xmaxv3);
+            uint32x4_t Cv4 = vcgtq_u32(Rv4, Xmaxv4);
+            uint32_t imask3 = vaddvq_u32(vandq_u32(Cv3, bit));
+            uint32_t imask4 = vaddvq_u32(vandq_u32(Cv4, bit));
 
-	    // Select low 16-bits from Rv based on imask, using tbl
+            // Select low 16-bits from Rv based on imask, using tbl
             uint8x8_t norm1, norm2, norm3, norm4;
-	    static int nbits[16] = { 0,2,2,4, 2,4,4,6, 2,4,4,6, 4,6,6,8 };
-	    norm1 = vqtbl1_u8(vreinterpretq_u8_u32(Rv1),vtab[imask1]);
-	    norm2 = vqtbl1_u8(vreinterpretq_u8_u32(Rv2),vtab[imask2]);
+            static int nbits[16] = { 0,2,2,4, 2,4,4,6, 2,4,4,6, 4,6,6,8 };
+            norm1 = vqtbl1_u8(vreinterpretq_u8_u32(Rv1),vtab[imask1]);
+            norm2 = vqtbl1_u8(vreinterpretq_u8_u32(Rv2),vtab[imask2]);
 
-	    vst1_u8(ptr-8, norm1);   ptr -= nbits[imask1];
-	    vst1_u8(ptr-8, norm2);   ptr -= nbits[imask2];
+            vst1_u8(ptr-8, norm1);   ptr -= nbits[imask1];
+            vst1_u8(ptr-8, norm2);   ptr -= nbits[imask2];
 
-	    norm3 = vqtbl1_u8(vreinterpretq_u8_u32(Rv3),vtab[imask3]);
-	    norm4 = vqtbl1_u8(vreinterpretq_u8_u32(Rv4),vtab[imask4]);
+            norm3 = vqtbl1_u8(vreinterpretq_u8_u32(Rv3),vtab[imask3]);
+            norm4 = vqtbl1_u8(vreinterpretq_u8_u32(Rv4),vtab[imask4]);
 
-	    vst1_u8(ptr-8, norm3);   ptr -= nbits[imask3];
-	    vst1_u8(ptr-8, norm4);   ptr -= nbits[imask4];
+            vst1_u8(ptr-8, norm3);   ptr -= nbits[imask3];
+            vst1_u8(ptr-8, norm4);   ptr -= nbits[imask4];
 
-	    // R' = R>>16
-	    uint32x4_t Rv1_r = vshrq_n_u32(Rv1, 16);
-	    uint32x4_t Rv2_r = vshrq_n_u32(Rv2, 16);
-	    uint32x4_t Rv3_r = vshrq_n_u32(Rv3, 16);
-	    uint32x4_t Rv4_r = vshrq_n_u32(Rv4, 16);
+            // R' = R>>16
+            uint32x4_t Rv1_r = vshrq_n_u32(Rv1, 16);
+            uint32x4_t Rv2_r = vshrq_n_u32(Rv2, 16);
+            uint32x4_t Rv3_r = vshrq_n_u32(Rv3, 16);
+            uint32x4_t Rv4_r = vshrq_n_u32(Rv4, 16);
 
-	    // Blend R and R' based on Cv.
-	    Rv1 = vbslq_u32(Cv1, Rv1_r, Rv1);
-	    Rv2 = vbslq_u32(Cv2, Rv2_r, Rv2);
-	    Rv3 = vbslq_u32(Cv3, Rv3_r, Rv3);
-	    Rv4 = vbslq_u32(Cv4, Rv4_r, Rv4);
+            // Blend R and R' based on Cv.
+            Rv1 = vbslq_u32(Cv1, Rv1_r, Rv1);
+            Rv2 = vbslq_u32(Cv2, Rv2_r, Rv2);
+            Rv3 = vbslq_u32(Cv3, Rv3_r, Rv3);
+            Rv4 = vbslq_u32(Cv4, Rv4_r, Rv4);
 
-	    uint64x2_t qvl1 = vmull_u32(vget_low_u32(Rv1), vget_low_u32(RFv1));
-	    uint64x2_t qvh1 = vmull_high_u32(Rv1, RFv1);
-	    uint64x2_t qvl2 = vmull_u32(vget_low_u32(Rv2), vget_low_u32(RFv2));
-	    uint64x2_t qvh2 = vmull_high_u32(Rv2, RFv2);
+            uint64x2_t qvl1 = vmull_u32(vget_low_u32(Rv1), vget_low_u32(RFv1));
+            uint64x2_t qvh1 = vmull_high_u32(Rv1, RFv1);
+            uint64x2_t qvl2 = vmull_u32(vget_low_u32(Rv2), vget_low_u32(RFv2));
+            uint64x2_t qvh2 = vmull_high_u32(Rv2, RFv2);
 
-	    int32x4_t RSv1 = vnegq_s32(vreinterpretq_s32_u32(
-				           vshrq_n_u32(FSv1, 16)));
-	    int32x4_t RSv2 = vnegq_s32(vreinterpretq_s32_u32(
-				           vshrq_n_u32(FSv2, 16)));
+            int32x4_t RSv1 = vnegq_s32(vreinterpretq_s32_u32(
+                                           vshrq_n_u32(FSv1, 16)));
+            int32x4_t RSv2 = vnegq_s32(vreinterpretq_s32_u32(
+                                           vshrq_n_u32(FSv2, 16)));
 
-	    uint64x2_t qvl3 = vmull_u32(vget_low_u32(Rv3), vget_low_u32(RFv3));
-	    uint64x2_t qvh3 = vmull_high_u32(Rv3, RFv3);
-	    uint64x2_t qvl4 = vmull_u32(vget_low_u32(Rv4), vget_low_u32(RFv4));
-	    uint64x2_t qvh4 = vmull_high_u32(Rv4, RFv4);
+            uint64x2_t qvl3 = vmull_u32(vget_low_u32(Rv3), vget_low_u32(RFv3));
+            uint64x2_t qvh3 = vmull_high_u32(Rv3, RFv3);
+            uint64x2_t qvl4 = vmull_u32(vget_low_u32(Rv4), vget_low_u32(RFv4));
+            uint64x2_t qvh4 = vmull_high_u32(Rv4, RFv4);
 
-	    int32x4_t RSv3 = vnegq_s32(vreinterpretq_s32_u32(
-				           vshrq_n_u32(FSv3, 16)));
-	    int32x4_t RSv4 = vnegq_s32(vreinterpretq_s32_u32(
-				           vshrq_n_u32(FSv4, 16)));
+            int32x4_t RSv3 = vnegq_s32(vreinterpretq_s32_u32(
+                                           vshrq_n_u32(FSv3, 16)));
+            int32x4_t RSv4 = vnegq_s32(vreinterpretq_s32_u32(
+                                           vshrq_n_u32(FSv4, 16)));
 
-	    qvl1 = vreinterpretq_u64_s64(
-		       vshlq_s64(vreinterpretq_s64_u64(qvl1),
-				 vmovl_s32(vget_low_s32(RSv1))));
-	    qvh1 = vreinterpretq_u64_s64(
-		       vshlq_s64(vreinterpretq_s64_u64(qvh1),
-				 vmovl_s32(vget_high_s32(RSv1))));
+            qvl1 = vreinterpretq_u64_s64(
+                       vshlq_s64(vreinterpretq_s64_u64(qvl1),
+                                 vmovl_s32(vget_low_s32(RSv1))));
+            qvh1 = vreinterpretq_u64_s64(
+                       vshlq_s64(vreinterpretq_s64_u64(qvh1),
+                                 vmovl_s32(vget_high_s32(RSv1))));
 
-	    qvl2 = vreinterpretq_u64_s64(
-		       vshlq_s64(vreinterpretq_s64_u64(qvl2),
-				 vmovl_s32(vget_low_s32(RSv2))));
-	    qvh2 = vreinterpretq_u64_s64(
-		       vshlq_s64(vreinterpretq_s64_u64(qvh2),
-				 vmovl_s32(vget_high_s32(RSv2))));
+            qvl2 = vreinterpretq_u64_s64(
+                       vshlq_s64(vreinterpretq_s64_u64(qvl2),
+                                 vmovl_s32(vget_low_s32(RSv2))));
+            qvh2 = vreinterpretq_u64_s64(
+                       vshlq_s64(vreinterpretq_s64_u64(qvh2),
+                                 vmovl_s32(vget_high_s32(RSv2))));
 
-	    uint32x4_t qv1 = vcombine_u32(vmovn_u64(qvl1),
-					  vmovn_u64(qvh1));
-	    uint32x4_t qv2 = vcombine_u32(vmovn_u64(qvl2),
-					  vmovn_u64(qvh2));
+            uint32x4_t qv1 = vcombine_u32(vmovn_u64(qvl1),
+                                          vmovn_u64(qvh1));
+            uint32x4_t qv2 = vcombine_u32(vmovn_u64(qvl2),
+                                          vmovn_u64(qvh2));
 
-	    qvl3 = vreinterpretq_u64_s64(
-		       vshlq_s64(vreinterpretq_s64_u64(qvl3),
-				 vmovl_s32(vget_low_s32(RSv3))));
-	    qvh3 = vreinterpretq_u64_s64(
-		       vshlq_s64(vreinterpretq_s64_u64(qvh3),
-				 vmovl_s32(vget_high_s32(RSv3))));
+            qvl3 = vreinterpretq_u64_s64(
+                       vshlq_s64(vreinterpretq_s64_u64(qvl3),
+                                 vmovl_s32(vget_low_s32(RSv3))));
+            qvh3 = vreinterpretq_u64_s64(
+                       vshlq_s64(vreinterpretq_s64_u64(qvh3),
+                                 vmovl_s32(vget_high_s32(RSv3))));
 
-	    qvl4 = vreinterpretq_u64_s64(
-		       vshlq_s64(vreinterpretq_s64_u64(qvl4),
-				 vmovl_s32(vget_low_s32(RSv4))));
-	    qvh4 = vreinterpretq_u64_s64(
-		       vshlq_s64(vreinterpretq_s64_u64(qvh4),
-				 vmovl_s32(vget_high_s32(RSv4))));
+            qvl4 = vreinterpretq_u64_s64(
+                       vshlq_s64(vreinterpretq_s64_u64(qvl4),
+                                 vmovl_s32(vget_low_s32(RSv4))));
+            qvh4 = vreinterpretq_u64_s64(
+                       vshlq_s64(vreinterpretq_s64_u64(qvh4),
+                                 vmovl_s32(vget_high_s32(RSv4))));
 
-	    uint32x4_t qv3 = vcombine_u32(vmovn_u64(qvl3),
-					  vmovn_u64(qvh3));
-	    uint32x4_t qv4 = vcombine_u32(vmovn_u64(qvl4),
-					  vmovn_u64(qvh4));
+            uint32x4_t qv3 = vcombine_u32(vmovn_u64(qvl3),
+                                          vmovn_u64(qvh3));
+            uint32x4_t qv4 = vcombine_u32(vmovn_u64(qvl4),
+                                          vmovn_u64(qvh4));
 
             FSv1 = vandq_u32(FSv1, vdupq_n_u32(0xffff)); // cmpl_freq
             FSv2 = vandq_u32(FSv2, vdupq_n_u32(0xffff));
             FSv3 = vandq_u32(FSv3, vdupq_n_u32(0xffff));
             FSv4 = vandq_u32(FSv4, vdupq_n_u32(0xffff));
-	
-	    qv1 = vmlaq_u32(Biasv1, qv1, FSv1);
-	    qv2 = vmlaq_u32(Biasv2, qv2, FSv2);
-	    qv3 = vmlaq_u32(Biasv3, qv3, FSv3);
-	    qv4 = vmlaq_u32(Biasv4, qv4, FSv4);
+        
+            qv1 = vmlaq_u32(Biasv1, qv1, FSv1);
+            qv2 = vmlaq_u32(Biasv2, qv2, FSv2);
+            qv3 = vmlaq_u32(Biasv3, qv3, FSv3);
+            qv4 = vmlaq_u32(Biasv4, qv4, FSv4);
 
-	    Rv1 = vaddq_u32(Rv1, qv1);
-	    Rv2 = vaddq_u32(Rv2, qv2);
-	    Rv3 = vaddq_u32(Rv3, qv3);
-	    Rv4 = vaddq_u32(Rv4, qv4);
+            Rv1 = vaddq_u32(Rv1, qv1);
+            Rv2 = vaddq_u32(Rv2, qv2);
+            Rv3 = vaddq_u32(Rv3, qv3);
+            Rv4 = vaddq_u32(Rv4, qv4);
 
-	    vst1q_u32(&ransN[z-3], Rv1);
-	    vst1q_u32(&ransN[z-7], Rv2);
-	    vst1q_u32(&ransN[z-11],Rv3);
-	    vst1q_u32(&ransN[z-15],Rv4);
-	}
+            vst1q_u32(&ransN[z-3], Rv1);
+            vst1q_u32(&ransN[z-7], Rv2);
+            vst1q_u32(&ransN[z-11],Rv3);
+            vst1q_u32(&ransN[z-15],Rv4);
+        }
     }
 #endif
 
     for (z = NX-1; z>=0; z--)
-	RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
+        RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
 
     for (z = NX-1; z>=0; z--)
-	RansEncFlush(&ransN[z], &ptr);
+        RansEncFlush(&ransN[z], &ptr);
 
     *out_size = (out_end - ptr) + tab_size;
 
@@ -1226,184 +1226,184 @@ typedef struct {
 } bf_t;
 
 static inline void transpose_and_copy(uint8_t *out, int iN[32],
-				      uint8_t t[32][32]) {
+                                      uint8_t t[32][32]) {
     int z;
 //  for (z = 0; z < NX; z++) {
 //      int k;
 //      for (k = 0; k < 32; k++)
-//  	out[iN[z]+k] = t[k][z];
+//      out[iN[z]+k] = t[k][z];
 //      iN[z] += 32;
 //  }
 
     for (z = 0; z < NX; z+=4) {
-	*(uint64_t *)&out[iN[z]] =
-	    ((uint64_t)(t[0][z])<< 0) +
-	    ((uint64_t)(t[1][z])<< 8) +
-	    ((uint64_t)(t[2][z])<<16) +
-	    ((uint64_t)(t[3][z])<<24) +
-	    ((uint64_t)(t[4][z])<<32) +
-	    ((uint64_t)(t[5][z])<<40) +
-	    ((uint64_t)(t[6][z])<<48) +
-	    ((uint64_t)(t[7][z])<<56);
-	*(uint64_t *)&out[iN[z+1]] =
-	    ((uint64_t)(t[0][z+1])<< 0) +
-	    ((uint64_t)(t[1][z+1])<< 8) +
-	    ((uint64_t)(t[2][z+1])<<16) +
-	    ((uint64_t)(t[3][z+1])<<24) +
-	    ((uint64_t)(t[4][z+1])<<32) +
-	    ((uint64_t)(t[5][z+1])<<40) +
-	    ((uint64_t)(t[6][z+1])<<48) +
-	    ((uint64_t)(t[7][z+1])<<56);
-	*(uint64_t *)&out[iN[z+2]] =
-	    ((uint64_t)(t[0][z+2])<< 0) +
-	    ((uint64_t)(t[1][z+2])<< 8) +
-	    ((uint64_t)(t[2][z+2])<<16) +
-	    ((uint64_t)(t[3][z+2])<<24) +
-	    ((uint64_t)(t[4][z+2])<<32) +
-	    ((uint64_t)(t[5][z+2])<<40) +
-	    ((uint64_t)(t[6][z+2])<<48) +
-	    ((uint64_t)(t[7][z+2])<<56);
-	*(uint64_t *)&out[iN[z+3]] =
-	    ((uint64_t)(t[0][z+3])<< 0) +
-	    ((uint64_t)(t[1][z+3])<< 8) +
-	    ((uint64_t)(t[2][z+3])<<16) +
-	    ((uint64_t)(t[3][z+3])<<24) +
-	    ((uint64_t)(t[4][z+3])<<32) +
-	    ((uint64_t)(t[5][z+3])<<40) +
-	    ((uint64_t)(t[6][z+3])<<48) +
-	    ((uint64_t)(t[7][z+3])<<56);
+        *(uint64_t *)&out[iN[z]] =
+            ((uint64_t)(t[0][z])<< 0) +
+            ((uint64_t)(t[1][z])<< 8) +
+            ((uint64_t)(t[2][z])<<16) +
+            ((uint64_t)(t[3][z])<<24) +
+            ((uint64_t)(t[4][z])<<32) +
+            ((uint64_t)(t[5][z])<<40) +
+            ((uint64_t)(t[6][z])<<48) +
+            ((uint64_t)(t[7][z])<<56);
+        *(uint64_t *)&out[iN[z+1]] =
+            ((uint64_t)(t[0][z+1])<< 0) +
+            ((uint64_t)(t[1][z+1])<< 8) +
+            ((uint64_t)(t[2][z+1])<<16) +
+            ((uint64_t)(t[3][z+1])<<24) +
+            ((uint64_t)(t[4][z+1])<<32) +
+            ((uint64_t)(t[5][z+1])<<40) +
+            ((uint64_t)(t[6][z+1])<<48) +
+            ((uint64_t)(t[7][z+1])<<56);
+        *(uint64_t *)&out[iN[z+2]] =
+            ((uint64_t)(t[0][z+2])<< 0) +
+            ((uint64_t)(t[1][z+2])<< 8) +
+            ((uint64_t)(t[2][z+2])<<16) +
+            ((uint64_t)(t[3][z+2])<<24) +
+            ((uint64_t)(t[4][z+2])<<32) +
+            ((uint64_t)(t[5][z+2])<<40) +
+            ((uint64_t)(t[6][z+2])<<48) +
+            ((uint64_t)(t[7][z+2])<<56);
+        *(uint64_t *)&out[iN[z+3]] =
+            ((uint64_t)(t[0][z+3])<< 0) +
+            ((uint64_t)(t[1][z+3])<< 8) +
+            ((uint64_t)(t[2][z+3])<<16) +
+            ((uint64_t)(t[3][z+3])<<24) +
+            ((uint64_t)(t[4][z+3])<<32) +
+            ((uint64_t)(t[5][z+3])<<40) +
+            ((uint64_t)(t[6][z+3])<<48) +
+            ((uint64_t)(t[7][z+3])<<56);
 
-	*(uint64_t *)&out[iN[z]+8] =
-	    ((uint64_t)(t[8+0][z])<< 0) +
-	    ((uint64_t)(t[8+1][z])<< 8) +
-	    ((uint64_t)(t[8+2][z])<<16) +
-	    ((uint64_t)(t[8+3][z])<<24) +
-	    ((uint64_t)(t[8+4][z])<<32) +
-	    ((uint64_t)(t[8+5][z])<<40) +
-	    ((uint64_t)(t[8+6][z])<<48) +
-	    ((uint64_t)(t[8+7][z])<<56);
-	*(uint64_t *)&out[iN[z+1]+8] =
-	    ((uint64_t)(t[8+0][z+1])<< 0) +
-	    ((uint64_t)(t[8+1][z+1])<< 8) +
-	    ((uint64_t)(t[8+2][z+1])<<16) +
-	    ((uint64_t)(t[8+3][z+1])<<24) +
-	    ((uint64_t)(t[8+4][z+1])<<32) +
-	    ((uint64_t)(t[8+5][z+1])<<40) +
-	    ((uint64_t)(t[8+6][z+1])<<48) +
-	    ((uint64_t)(t[8+7][z+1])<<56);
-	*(uint64_t *)&out[iN[z+2]+8] =
-	    ((uint64_t)(t[8+0][z+2])<< 0) +
-	    ((uint64_t)(t[8+1][z+2])<< 8) +
-	    ((uint64_t)(t[8+2][z+2])<<16) +
-	    ((uint64_t)(t[8+3][z+2])<<24) +
-	    ((uint64_t)(t[8+4][z+2])<<32) +
-	    ((uint64_t)(t[8+5][z+2])<<40) +
-	    ((uint64_t)(t[8+6][z+2])<<48) +
-	    ((uint64_t)(t[8+7][z+2])<<56);
-	*(uint64_t *)&out[iN[z+3]+8] =
-	    ((uint64_t)(t[8+0][z+3])<< 0) +
-	    ((uint64_t)(t[8+1][z+3])<< 8) +
-	    ((uint64_t)(t[8+2][z+3])<<16) +
-	    ((uint64_t)(t[8+3][z+3])<<24) +
-	    ((uint64_t)(t[8+4][z+3])<<32) +
-	    ((uint64_t)(t[8+5][z+3])<<40) +
-	    ((uint64_t)(t[8+6][z+3])<<48) +
-	    ((uint64_t)(t[8+7][z+3])<<56);
+        *(uint64_t *)&out[iN[z]+8] =
+            ((uint64_t)(t[8+0][z])<< 0) +
+            ((uint64_t)(t[8+1][z])<< 8) +
+            ((uint64_t)(t[8+2][z])<<16) +
+            ((uint64_t)(t[8+3][z])<<24) +
+            ((uint64_t)(t[8+4][z])<<32) +
+            ((uint64_t)(t[8+5][z])<<40) +
+            ((uint64_t)(t[8+6][z])<<48) +
+            ((uint64_t)(t[8+7][z])<<56);
+        *(uint64_t *)&out[iN[z+1]+8] =
+            ((uint64_t)(t[8+0][z+1])<< 0) +
+            ((uint64_t)(t[8+1][z+1])<< 8) +
+            ((uint64_t)(t[8+2][z+1])<<16) +
+            ((uint64_t)(t[8+3][z+1])<<24) +
+            ((uint64_t)(t[8+4][z+1])<<32) +
+            ((uint64_t)(t[8+5][z+1])<<40) +
+            ((uint64_t)(t[8+6][z+1])<<48) +
+            ((uint64_t)(t[8+7][z+1])<<56);
+        *(uint64_t *)&out[iN[z+2]+8] =
+            ((uint64_t)(t[8+0][z+2])<< 0) +
+            ((uint64_t)(t[8+1][z+2])<< 8) +
+            ((uint64_t)(t[8+2][z+2])<<16) +
+            ((uint64_t)(t[8+3][z+2])<<24) +
+            ((uint64_t)(t[8+4][z+2])<<32) +
+            ((uint64_t)(t[8+5][z+2])<<40) +
+            ((uint64_t)(t[8+6][z+2])<<48) +
+            ((uint64_t)(t[8+7][z+2])<<56);
+        *(uint64_t *)&out[iN[z+3]+8] =
+            ((uint64_t)(t[8+0][z+3])<< 0) +
+            ((uint64_t)(t[8+1][z+3])<< 8) +
+            ((uint64_t)(t[8+2][z+3])<<16) +
+            ((uint64_t)(t[8+3][z+3])<<24) +
+            ((uint64_t)(t[8+4][z+3])<<32) +
+            ((uint64_t)(t[8+5][z+3])<<40) +
+            ((uint64_t)(t[8+6][z+3])<<48) +
+            ((uint64_t)(t[8+7][z+3])<<56);
 
-	*(uint64_t *)&out[iN[z]+16] =
-	    ((uint64_t)(t[16+0][z])<< 0) +
-	    ((uint64_t)(t[16+1][z])<< 8) +
-	    ((uint64_t)(t[16+2][z])<<16) +
-	    ((uint64_t)(t[16+3][z])<<24) +
-	    ((uint64_t)(t[16+4][z])<<32) +
-	    ((uint64_t)(t[16+5][z])<<40) +
-	    ((uint64_t)(t[16+6][z])<<48) +
-	    ((uint64_t)(t[16+7][z])<<56);
-	*(uint64_t *)&out[iN[z+1]+16] =
-	    ((uint64_t)(t[16+0][z+1])<< 0) +
-	    ((uint64_t)(t[16+1][z+1])<< 8) +
-	    ((uint64_t)(t[16+2][z+1])<<16) +
-	    ((uint64_t)(t[16+3][z+1])<<24) +
-	    ((uint64_t)(t[16+4][z+1])<<32) +
-	    ((uint64_t)(t[16+5][z+1])<<40) +
-	    ((uint64_t)(t[16+6][z+1])<<48) +
-	    ((uint64_t)(t[16+7][z+1])<<56);
-	*(uint64_t *)&out[iN[z+2]+16] =
-	    ((uint64_t)(t[16+0][z+2])<< 0) +
-	    ((uint64_t)(t[16+1][z+2])<< 8) +
-	    ((uint64_t)(t[16+2][z+2])<<16) +
-	    ((uint64_t)(t[16+3][z+2])<<24) +
-	    ((uint64_t)(t[16+4][z+2])<<32) +
-	    ((uint64_t)(t[16+5][z+2])<<40) +
-	    ((uint64_t)(t[16+6][z+2])<<48) +
-	    ((uint64_t)(t[16+7][z+2])<<56);
-	*(uint64_t *)&out[iN[z+3]+16] =
-	    ((uint64_t)(t[16+0][z+3])<< 0) +
-	    ((uint64_t)(t[16+1][z+3])<< 8) +
-	    ((uint64_t)(t[16+2][z+3])<<16) +
-	    ((uint64_t)(t[16+3][z+3])<<24) +
-	    ((uint64_t)(t[16+4][z+3])<<32) +
-	    ((uint64_t)(t[16+5][z+3])<<40) +
-	    ((uint64_t)(t[16+6][z+3])<<48) +
-	    ((uint64_t)(t[16+7][z+3])<<56);
+        *(uint64_t *)&out[iN[z]+16] =
+            ((uint64_t)(t[16+0][z])<< 0) +
+            ((uint64_t)(t[16+1][z])<< 8) +
+            ((uint64_t)(t[16+2][z])<<16) +
+            ((uint64_t)(t[16+3][z])<<24) +
+            ((uint64_t)(t[16+4][z])<<32) +
+            ((uint64_t)(t[16+5][z])<<40) +
+            ((uint64_t)(t[16+6][z])<<48) +
+            ((uint64_t)(t[16+7][z])<<56);
+        *(uint64_t *)&out[iN[z+1]+16] =
+            ((uint64_t)(t[16+0][z+1])<< 0) +
+            ((uint64_t)(t[16+1][z+1])<< 8) +
+            ((uint64_t)(t[16+2][z+1])<<16) +
+            ((uint64_t)(t[16+3][z+1])<<24) +
+            ((uint64_t)(t[16+4][z+1])<<32) +
+            ((uint64_t)(t[16+5][z+1])<<40) +
+            ((uint64_t)(t[16+6][z+1])<<48) +
+            ((uint64_t)(t[16+7][z+1])<<56);
+        *(uint64_t *)&out[iN[z+2]+16] =
+            ((uint64_t)(t[16+0][z+2])<< 0) +
+            ((uint64_t)(t[16+1][z+2])<< 8) +
+            ((uint64_t)(t[16+2][z+2])<<16) +
+            ((uint64_t)(t[16+3][z+2])<<24) +
+            ((uint64_t)(t[16+4][z+2])<<32) +
+            ((uint64_t)(t[16+5][z+2])<<40) +
+            ((uint64_t)(t[16+6][z+2])<<48) +
+            ((uint64_t)(t[16+7][z+2])<<56);
+        *(uint64_t *)&out[iN[z+3]+16] =
+            ((uint64_t)(t[16+0][z+3])<< 0) +
+            ((uint64_t)(t[16+1][z+3])<< 8) +
+            ((uint64_t)(t[16+2][z+3])<<16) +
+            ((uint64_t)(t[16+3][z+3])<<24) +
+            ((uint64_t)(t[16+4][z+3])<<32) +
+            ((uint64_t)(t[16+5][z+3])<<40) +
+            ((uint64_t)(t[16+6][z+3])<<48) +
+            ((uint64_t)(t[16+7][z+3])<<56);
 
-	*(uint64_t *)&out[iN[z]+24] =
-	    ((uint64_t)(t[24+0][z])<< 0) +
-	    ((uint64_t)(t[24+1][z])<< 8) +
-	    ((uint64_t)(t[24+2][z])<<16) +
-	    ((uint64_t)(t[24+3][z])<<24) +
-	    ((uint64_t)(t[24+4][z])<<32) +
-	    ((uint64_t)(t[24+5][z])<<40) +
-	    ((uint64_t)(t[24+6][z])<<48) +
-	    ((uint64_t)(t[24+7][z])<<56);
-	*(uint64_t *)&out[iN[z+1]+24] =
-	    ((uint64_t)(t[24+0][z+1])<< 0) +
-	    ((uint64_t)(t[24+1][z+1])<< 8) +
-	    ((uint64_t)(t[24+2][z+1])<<16) +
-	    ((uint64_t)(t[24+3][z+1])<<24) +
-	    ((uint64_t)(t[24+4][z+1])<<32) +
-	    ((uint64_t)(t[24+5][z+1])<<40) +
-	    ((uint64_t)(t[24+6][z+1])<<48) +
-	    ((uint64_t)(t[24+7][z+1])<<56);
-	*(uint64_t *)&out[iN[z+2]+24] =
-	    ((uint64_t)(t[24+0][z+2])<< 0) +
-	    ((uint64_t)(t[24+1][z+2])<< 8) +
-	    ((uint64_t)(t[24+2][z+2])<<16) +
-	    ((uint64_t)(t[24+3][z+2])<<24) +
-	    ((uint64_t)(t[24+4][z+2])<<32) +
-	    ((uint64_t)(t[24+5][z+2])<<40) +
-	    ((uint64_t)(t[24+6][z+2])<<48) +
-	    ((uint64_t)(t[24+7][z+2])<<56);
-	*(uint64_t *)&out[iN[z+3]+24] =
-	    ((uint64_t)(t[24+0][z+3])<< 0) +
-	    ((uint64_t)(t[24+1][z+3])<< 8) +
-	    ((uint64_t)(t[24+2][z+3])<<16) +
-	    ((uint64_t)(t[24+3][z+3])<<24) +
-	    ((uint64_t)(t[24+4][z+3])<<32) +
-	    ((uint64_t)(t[24+5][z+3])<<40) +
-	    ((uint64_t)(t[24+6][z+3])<<48) +
-	    ((uint64_t)(t[24+7][z+3])<<56);
+        *(uint64_t *)&out[iN[z]+24] =
+            ((uint64_t)(t[24+0][z])<< 0) +
+            ((uint64_t)(t[24+1][z])<< 8) +
+            ((uint64_t)(t[24+2][z])<<16) +
+            ((uint64_t)(t[24+3][z])<<24) +
+            ((uint64_t)(t[24+4][z])<<32) +
+            ((uint64_t)(t[24+5][z])<<40) +
+            ((uint64_t)(t[24+6][z])<<48) +
+            ((uint64_t)(t[24+7][z])<<56);
+        *(uint64_t *)&out[iN[z+1]+24] =
+            ((uint64_t)(t[24+0][z+1])<< 0) +
+            ((uint64_t)(t[24+1][z+1])<< 8) +
+            ((uint64_t)(t[24+2][z+1])<<16) +
+            ((uint64_t)(t[24+3][z+1])<<24) +
+            ((uint64_t)(t[24+4][z+1])<<32) +
+            ((uint64_t)(t[24+5][z+1])<<40) +
+            ((uint64_t)(t[24+6][z+1])<<48) +
+            ((uint64_t)(t[24+7][z+1])<<56);
+        *(uint64_t *)&out[iN[z+2]+24] =
+            ((uint64_t)(t[24+0][z+2])<< 0) +
+            ((uint64_t)(t[24+1][z+2])<< 8) +
+            ((uint64_t)(t[24+2][z+2])<<16) +
+            ((uint64_t)(t[24+3][z+2])<<24) +
+            ((uint64_t)(t[24+4][z+2])<<32) +
+            ((uint64_t)(t[24+5][z+2])<<40) +
+            ((uint64_t)(t[24+6][z+2])<<48) +
+            ((uint64_t)(t[24+7][z+2])<<56);
+        *(uint64_t *)&out[iN[z+3]+24] =
+            ((uint64_t)(t[24+0][z+3])<< 0) +
+            ((uint64_t)(t[24+1][z+3])<< 8) +
+            ((uint64_t)(t[24+2][z+3])<<16) +
+            ((uint64_t)(t[24+3][z+3])<<24) +
+            ((uint64_t)(t[24+4][z+3])<<32) +
+            ((uint64_t)(t[24+5][z+3])<<40) +
+            ((uint64_t)(t[24+6][z+3])<<48) +
+            ((uint64_t)(t[24+7][z+3])<<56);
 
-	iN[z+0] += 32;
-	iN[z+1] += 32;
-	iN[z+2] += 32;
-	iN[z+3] += 32;
+        iN[z+0] += 32;
+        iN[z+1] += 32;
+        iN[z+2] += 32;
+        iN[z+3] += 32;
     }
 }
 
 unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz) {
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz) {
     if (in_size < NX*4) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -1416,22 +1416,22 @@ unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
     uint32_t s3[256][TOTFREQ_O1_FAST];
 
     if (!sfb_)
-	return NULL;
+        return NULL;
     bf_t fb[256][256];
     uint8_t *sfb[256];
     if ((*cp >> 4) == TF_SHIFT_O1) {
-	for (i = 0; i < 256; i++)
-	    sfb[i]=  sfb_ + i*(TOTFREQ_O1+MAGIC2);
+        for (i = 0; i < 256; i++)
+            sfb[i]=  sfb_ + i*(TOTFREQ_O1+MAGIC2);
     } else {
-	for (i = 0; i < 256; i++)
-	    sfb[i]=  sfb_ + i*(TOTFREQ_O1_FAST+MAGIC2);
+        for (i = 0; i < 256; i++)
+            sfb[i]=  sfb_ + i*(TOTFREQ_O1_FAST+MAGIC2);
     }
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
 
     if (!out)
-	goto err;
+        goto err;
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
@@ -1440,16 +1440,16 @@ unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
     unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
-	uint32_t u_freq_sz, c_freq_sz;
-	cp += var_get_u32(cp, cp_end, &u_freq_sz);
-	cp += var_get_u32(cp, cp_end, &c_freq_sz);
-	if (c_freq_sz >= cp_end - cp - 16)
-	    goto err;
-	tab_end = cp + c_freq_sz;
-	if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL, u_freq_sz)))
-	    goto err;
-	cp = c_freq;
-	c_freq_end = c_freq + u_freq_sz;
+        uint32_t u_freq_sz, c_freq_sz;
+        cp += var_get_u32(cp, cp_end, &u_freq_sz);
+        cp += var_get_u32(cp, cp_end, &c_freq_sz);
+        if (c_freq_sz >= cp_end - cp - 16)
+            goto err;
+        tab_end = cp + c_freq_sz;
+        if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL, u_freq_sz)))
+            goto err;
+        cp = c_freq;
+        c_freq_end = c_freq + u_freq_sz;
     }
 
     // Decode order-0 symbol list; avoids needing in order-1 tables
@@ -1460,116 +1460,116 @@ unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
     uint32_t F0[256] = {0};
     int fsz = decode_alphabet(cp, c_freq_end, F0);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     if (cp >= c_freq_end)
-	goto err;
+        goto err;
 
     for (i = 0; i < 256; i++) {
-	if (F0[i] == 0)
-	    continue;
+        if (F0[i] == 0)
+            continue;
 
-	uint32_t F[256] = {0}, T = 0;
-	fsz = decode_freq_d(cp, c_freq_end, F0, F, &T);
-	if (!fsz)
-	    goto err;
-	cp += fsz;
+        uint32_t F[256] = {0}, T = 0;
+        fsz = decode_freq_d(cp, c_freq_end, F0, F, &T);
+        if (!fsz)
+            goto err;
+        cp += fsz;
 
-	if (!T) {
-	    //fprintf(stderr, "No freq for F_%d\n", i);
-	    continue;
-	}
+        if (!T) {
+            //fprintf(stderr, "No freq for F_%d\n", i);
+            continue;
+        }
 
-	normalise_freq_shift(F, T, 1<<shift);
+        normalise_freq_shift(F, T, 1<<shift);
 
-	// Build symbols; fixme, do as part of decode, see the _d variant
-	for (j = x = 0; j < 256; j++) {
-	    if (F[j]) {
-		if (F[j] > (1<<shift) - x)
-		    goto err;
+        // Build symbols; fixme, do as part of decode, see the _d variant
+        for (j = x = 0; j < 256; j++) {
+            if (F[j]) {
+                if (F[j] > (1<<shift) - x)
+                    goto err;
 
-		if (shift == TF_SHIFT_O1_FAST) {
-		    int y;
-		    for (y = 0; y < F[j]; y++)
-			s3[i][y+x] = (((uint32_t)F[j])<<(shift+8)) |(y<<8) |j;
-		}
-		memset(&sfb[i][x], j, F[j]);
-		fb[i][j].u.s.f = F[j];
-		fb[i][j].u.s.b = x;
+                if (shift == TF_SHIFT_O1_FAST) {
+                    int y;
+                    for (y = 0; y < F[j]; y++)
+                        s3[i][y+x] = (((uint32_t)F[j])<<(shift+8)) |(y<<8) |j;
+                }
+                memset(&sfb[i][x], j, F[j]);
+                fb[i][j].u.s.f = F[j];
+                fb[i][j].u.s.b = x;
 
-		x += F[j];
-	    }
-	}
-	if (x != (1<<shift))
-	    goto err;
+                x += F[j];
+            }
+        }
+        if (x != (1<<shift))
+            goto err;
     }
 #endif
 
     if (tab_end)
-	cp = tab_end;
+        cp = tab_end;
     free(c_freq);
     c_freq = NULL;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     RansState R[NX];
     uint8_t *ptr = cp, *ptr_end = in + in_size;
     int z;
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &ptr);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &ptr);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     int isz4 = out_sz/NX;
     int i4[NX];
     uint8_t l[NX] = {0};
     for (z = 0; z < NX; z++)
-	i4[z] = z*isz4;
+        i4[z] = z*isz4;
 
     // Around 15% faster to specialise for 10/12 than to have one
     // loop with shift as a variable.
     if (shift == TF_SHIFT_O1) {
-	// TF_SHIFT_O1 = 12
-	const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
-	uint32x4_t maskv = vdupq_n_u32((1u << TF_SHIFT_O1)-1);
+        // TF_SHIFT_O1 = 12
+        const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
+        uint32x4_t maskv = vdupq_n_u32((1u << TF_SHIFT_O1)-1);
 
-	// FIXME: plus room for "safe" renorm.
-	// Follow with 2nd copy doing scalar code instead?
-	unsigned char tbuf[32][32] = {0};
-	int tidx = 0;
-	for (; i4[0] < isz4 && ptr+64 < ptr_end;) {
-	    for (z = 0; z < NX; z+=16) {
-	        uint32x4_t Rv1 = vld1q_u32(&R[z+0]);
-		uint32x4_t Rv2 = vld1q_u32(&R[z+4]);
-		uint32x4_t Rv3 = vld1q_u32(&R[z+8]);
-		uint32x4_t Rv4 = vld1q_u32(&R[z+12]);
+        // FIXME: plus room for "safe" renorm.
+        // Follow with 2nd copy doing scalar code instead?
+        unsigned char tbuf[32][32] = {0};
+        int tidx = 0;
+        for (; i4[0] < isz4 && ptr+64 < ptr_end;) {
+            for (z = 0; z < NX; z+=16) {
+                uint32x4_t Rv1 = vld1q_u32(&R[z+0]);
+                uint32x4_t Rv2 = vld1q_u32(&R[z+4]);
+                uint32x4_t Rv3 = vld1q_u32(&R[z+8]);
+                uint32x4_t Rv4 = vld1q_u32(&R[z+12]);
 
-		uint32x4_t Sv1, Sv2, Sv3, Sv4;
-		uint32x4_t Fv1, Fv2, Fv3, Fv4;
-		uint32x4_t Bv1, Bv2, Bv3, Bv4;
+                uint32x4_t Sv1, Sv2, Sv3, Sv4;
+                uint32x4_t Fv1, Fv2, Fv3, Fv4;
+                uint32x4_t Bv1, Bv2, Bv3, Bv4;
 
-		// Use sfb[256][256] + fb[256][256] instead of s3[256][4096].
-		// It's lower memory and thus less cache contention and also
-		// avoids the 12-bit issue of FREQ==0 vs 4096.
-		// However we need an extra step to store m = R&mask.
-		// Overall it's a big win for gcc (no difference to clang, but
-		// that's lagging behind gcc on this code).
-		//
-		// TODO: consider this for AVX2?
-		//
-		// sfb layout is char (sym)
-		// fb layout is 16-bit freq, 16-bit bias.
-		uint8_t *c = &tbuf[tidx][z];
-		uint32_t f32[16];
-		int i;
-		for (i = 0; i < 16; i++) {
-		  c[i] = sfb[l[z+i]][R[z+i] & mask];
-		  f32[i] = *(uint32_t *)&fb[l[z+i]][c[i]];
-		}
-		
+                // Use sfb[256][256] + fb[256][256] instead of s3[256][4096].
+                // It's lower memory and thus less cache contention and also
+                // avoids the 12-bit issue of FREQ==0 vs 4096.
+                // However we need an extra step to store m = R&mask.
+                // Overall it's a big win for gcc (no difference to clang, but
+                // that's lagging behind gcc on this code).
+                //
+                // TODO: consider this for AVX2?
+                //
+                // sfb layout is char (sym)
+                // fb layout is 16-bit freq, 16-bit bias.
+                uint8_t *c = &tbuf[tidx][z];
+                uint32_t f32[16];
+                int i;
+                for (i = 0; i < 16; i++) {
+                  c[i] = sfb[l[z+i]][R[z+i] & mask];
+                  f32[i] = *(uint32_t *)&fb[l[z+i]][c[i]];
+                }
+                
                 // vcreate faster than vld1q_u32(&f32[0])
                 uint32x2_t s1a, s1b, s2a, s2b, s3a, s3b, s4a, s4b;
                 s1a = vcreate_u32((uint64_t)(f32[ 3])<<32 |
@@ -1591,16 +1591,16 @@ unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
 
                 memcpy(l+z, c, 16);
 
-		// vcreate   = INS   = throughput 2, latency 2, pipe V
-		// vcombine  = DUP+INS = thr    2+2, lat   2+2, pipe V+V
-		// vandq     = AND   = throughput 2, latency 1, pipe V
-		// vshrq     = USHR  = throughput 2, latency 1, pipe V
+                // vcreate   = INS   = throughput 2, latency 2, pipe V
+                // vcombine  = DUP+INS = thr    2+2, lat   2+2, pipe V+V
+                // vandq     = AND   = throughput 2, latency 1, pipe V
+                // vshrq     = USHR  = throughput 2, latency 1, pipe V
                 Sv1 = vcombine_u32(s1b, s1a);
                 Sv2 = vcombine_u32(s2b, s2a);
                 Sv3 = vcombine_u32(s3b, s3a);
                 Sv4 = vcombine_u32(s4b, s4a);
 
-		Bv1 = vshrq_n_u32(Sv1, 16);
+                Bv1 = vshrq_n_u32(Sv1, 16);
                 Bv2 = vshrq_n_u32(Sv2, 16);
 
                 Bv3 = vshrq_n_u32(Sv3, 16);
@@ -1611,133 +1611,133 @@ unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
                 Fv3 = vandq_u32(Sv3, vdupq_n_u32(0xffff));
                 Fv4 = vandq_u32(Sv4, vdupq_n_u32(0xffff));
 
-		Bv1 = vsubq_u32(vandq_u32(Rv1, maskv), Bv1);
-		Bv2 = vsubq_u32(vandq_u32(Rv2, maskv), Bv2);
-		Bv3 = vsubq_u32(vandq_u32(Rv3, maskv), Bv3);
-		Bv4 = vsubq_u32(vandq_u32(Rv4, maskv), Bv4);
+                Bv1 = vsubq_u32(vandq_u32(Rv1, maskv), Bv1);
+                Bv2 = vsubq_u32(vandq_u32(Rv2, maskv), Bv2);
+                Bv3 = vsubq_u32(vandq_u32(Rv3, maskv), Bv3);
+                Bv4 = vsubq_u32(vandq_u32(Rv4, maskv), Bv4);
 
-		Rv1 = vshrq_n_u32(Rv1, TF_SHIFT_O1);
-		Rv2 = vshrq_n_u32(Rv2, TF_SHIFT_O1);
-		Rv3 = vshrq_n_u32(Rv3, TF_SHIFT_O1);
-		Rv4 = vshrq_n_u32(Rv4, TF_SHIFT_O1);
+                Rv1 = vshrq_n_u32(Rv1, TF_SHIFT_O1);
+                Rv2 = vshrq_n_u32(Rv2, TF_SHIFT_O1);
+                Rv3 = vshrq_n_u32(Rv3, TF_SHIFT_O1);
+                Rv4 = vshrq_n_u32(Rv4, TF_SHIFT_O1);
 
-		Rv1 = vmlaq_u32(Bv1, Fv1, Rv1);
-		Rv2 = vmlaq_u32(Bv2, Fv2, Rv2);
-		Rv3 = vmlaq_u32(Bv3, Fv3, Rv3);
-		Rv4 = vmlaq_u32(Bv4, Fv4, Rv4);
+                Rv1 = vmlaq_u32(Bv1, Fv1, Rv1);
+                Rv2 = vmlaq_u32(Bv2, Fv2, Rv2);
+                Rv3 = vmlaq_u32(Bv3, Fv3, Rv3);
+                Rv4 = vmlaq_u32(Bv4, Fv4, Rv4);
 
-		// Renorm
-		uint32x4_t Rlt1 = vcltq_u32(Rv1, vdupq_n_u32(RANS_BYTE_L)); // R<L
-		uint32x4_t Rlt2 = vcltq_u32(Rv2, vdupq_n_u32(RANS_BYTE_L));
-		uint32x4_t Rlt3 = vcltq_u32(Rv3, vdupq_n_u32(RANS_BYTE_L));
-		uint32x4_t Rlt4 = vcltq_u32(Rv4, vdupq_n_u32(RANS_BYTE_L));
-		uint32x4_t all2 = {2,2,2,2};
-		// load 8 lanes of renorm data
-		uint16x8_t norm12 =  vld1q_u16((uint16_t *)ptr);
-		// move ptr by no. renorm lanes used
-		ptr += vaddvq_u32(vandq_u32(Rlt1, all2))
-		    +  vaddvq_u32(vandq_u32(Rlt2, all2));
-		uint16x8_t norm34 =  vld1q_u16((uint16_t *)ptr);
-		ptr += vaddvq_u32(vandq_u32(Rlt3, all2))
-		    +  vaddvq_u32(vandq_u32(Rlt4, all2));
+                // Renorm
+                uint32x4_t Rlt1 = vcltq_u32(Rv1, vdupq_n_u32(RANS_BYTE_L)); // R<L
+                uint32x4_t Rlt2 = vcltq_u32(Rv2, vdupq_n_u32(RANS_BYTE_L));
+                uint32x4_t Rlt3 = vcltq_u32(Rv3, vdupq_n_u32(RANS_BYTE_L));
+                uint32x4_t Rlt4 = vcltq_u32(Rv4, vdupq_n_u32(RANS_BYTE_L));
+                uint32x4_t all2 = {2,2,2,2};
+                // load 8 lanes of renorm data
+                uint16x8_t norm12 =  vld1q_u16((uint16_t *)ptr);
+                // move ptr by no. renorm lanes used
+                ptr += vaddvq_u32(vandq_u32(Rlt1, all2))
+                    +  vaddvq_u32(vandq_u32(Rlt2, all2));
+                uint16x8_t norm34 =  vld1q_u16((uint16_t *)ptr);
+                ptr += vaddvq_u32(vandq_u32(Rlt3, all2))
+                    +  vaddvq_u32(vandq_u32(Rlt4, all2));
 
-		// Compute lookup table index
-		uint32x4_t bit = {8,4,2,1};
-		uint32_t imask1 = vaddvq_u32(vandq_u32(Rlt1, bit));
-		uint32_t imask2 = vaddvq_u32(vandq_u32(Rlt2, bit));
-		uint32_t imask3 = vaddvq_u32(vandq_u32(Rlt3, bit));
-		uint32_t imask4 = vaddvq_u32(vandq_u32(Rlt4, bit));
+                // Compute lookup table index
+                uint32x4_t bit = {8,4,2,1};
+                uint32_t imask1 = vaddvq_u32(vandq_u32(Rlt1, bit));
+                uint32_t imask2 = vaddvq_u32(vandq_u32(Rlt2, bit));
+                uint32_t imask3 = vaddvq_u32(vandq_u32(Rlt3, bit));
+                uint32_t imask4 = vaddvq_u32(vandq_u32(Rlt4, bit));
 
-		uint32_t imask12 = (imask1<<4)|imask2;
-		uint32_t imask34 = (imask3<<4)|imask4;
+                uint32_t imask12 = (imask1<<4)|imask2;
+                uint32_t imask34 = (imask3<<4)|imask4;
 
-		// Shuffle norm to the corresponding R lanes, via imask
-		// #define for brevity and formatting
-		uint16x4_t norm1, norm2, norm3, norm4;
-		norm1 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),
-					      idx [imask1]));
-		norm2 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),
-					      idx2[imask12]));
-		norm3 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),
-					      idx [imask3]));
-		norm4 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),
-					      idx2[imask34]));
+                // Shuffle norm to the corresponding R lanes, via imask
+                // #define for brevity and formatting
+                uint16x4_t norm1, norm2, norm3, norm4;
+                norm1 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),
+                                              idx [imask1]));
+                norm2 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),
+                                              idx2[imask12]));
+                norm3 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),
+                                              idx [imask3]));
+                norm4 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),
+                                              idx2[imask34]));
 
-		// Add norm to R<<16 and blend back in with R
-		uint32x4_t Rsl1 = vshlq_n_u32(Rv1, 16); // Rsl = R << 16
-		uint32x4_t Rsl2 = vshlq_n_u32(Rv2, 16);
-		uint32x4_t Rsl3 = vshlq_n_u32(Rv3, 16);
-		uint32x4_t Rsl4 = vshlq_n_u32(Rv4, 16);
+                // Add norm to R<<16 and blend back in with R
+                uint32x4_t Rsl1 = vshlq_n_u32(Rv1, 16); // Rsl = R << 16
+                uint32x4_t Rsl2 = vshlq_n_u32(Rv2, 16);
+                uint32x4_t Rsl3 = vshlq_n_u32(Rv3, 16);
+                uint32x4_t Rsl4 = vshlq_n_u32(Rv4, 16);
 
-		Rsl1 = vaddw_u16(Rsl1, norm1);          // Rsl += norm
-		Rsl2 = vaddw_u16(Rsl2, norm2);
-		Rsl3 = vaddw_u16(Rsl3, norm3);
-		Rsl4 = vaddw_u16(Rsl4, norm4);
-//		Rsl1 = vaddq_u32(Rsl1, vmovl_u16(norm1));
-//		Rsl2 = vaddq_u32(Rsl2, vmovl_u16(norm2));
-//		Rsl3 = vaddq_u32(Rsl3, vmovl_u16(norm3));
-//		Rsl4 = vaddq_u32(Rsl4, vmovl_u16(norm4));
+                Rsl1 = vaddw_u16(Rsl1, norm1);          // Rsl += norm
+                Rsl2 = vaddw_u16(Rsl2, norm2);
+                Rsl3 = vaddw_u16(Rsl3, norm3);
+                Rsl4 = vaddw_u16(Rsl4, norm4);
+//              Rsl1 = vaddq_u32(Rsl1, vmovl_u16(norm1));
+//              Rsl2 = vaddq_u32(Rsl2, vmovl_u16(norm2));
+//              Rsl3 = vaddq_u32(Rsl3, vmovl_u16(norm3));
+//              Rsl4 = vaddq_u32(Rsl4, vmovl_u16(norm4));
 
-		Rv1 = vbslq_u32(Rlt1, Rsl1, Rv1);       // R = R<L ? Rsl : R
-		Rv2 = vbslq_u32(Rlt2, Rsl2, Rv2);
-		Rv3 = vbslq_u32(Rlt3, Rsl3, Rv3);
-		Rv4 = vbslq_u32(Rlt4, Rsl4, Rv4);
+                Rv1 = vbslq_u32(Rlt1, Rsl1, Rv1);       // R = R<L ? Rsl : R
+                Rv2 = vbslq_u32(Rlt2, Rsl2, Rv2);
+                Rv3 = vbslq_u32(Rlt3, Rsl3, Rv3);
+                Rv4 = vbslq_u32(Rlt4, Rsl4, Rv4);
 
-		vst1q_u32(&R[z+ 0], Rv1);
-		vst1q_u32(&R[z+ 4], Rv2);
-		vst1q_u32(&R[z+ 8], Rv3);
-		vst1q_u32(&R[z+12], Rv4);
-	    }
+                vst1q_u32(&R[z+ 0], Rv1);
+                vst1q_u32(&R[z+ 4], Rv2);
+                vst1q_u32(&R[z+ 8], Rv3);
+                vst1q_u32(&R[z+12], Rv4);
+            }
 
-	    i4[0]++;
-	    if (++tidx == 32) {
-		i4[0] -= 32;
+            i4[0]++;
+            if (++tidx == 32) {
+                i4[0] -= 32;
 
-		transpose_and_copy(out, i4, tbuf);
-		tidx = 0;
-	    }
-	}
+                transpose_and_copy(out, i4, tbuf);
+                tidx = 0;
+            }
+        }
 
-	i4[0]-=tidx;
-	int T;
-	for (z = 0; z < NX; z++)
-	    for (T = 0; T < tidx; T++)
-		out[i4[z]++] = tbuf[T][z];
+        i4[0]-=tidx;
+        int T;
+        for (z = 0; z < NX; z++)
+            for (T = 0; T < tidx; T++)
+                out[i4[z]++] = tbuf[T][z];
 
-	// Scalar version for close to end of in[] array so we don't do
-	// SIMD loads beyond the end of the buffer
-	for (; i4[0] < isz4; ) {
-	    for (z = 0; z < NX; z++) {
-	        uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
-		unsigned char c = sfb[l[z]][m];
+        // Scalar version for close to end of in[] array so we don't do
+        // SIMD loads beyond the end of the buffer
+        for (; i4[0] < isz4; ) {
+            for (z = 0; z < NX; z++) {
+                uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
+                unsigned char c = sfb[l[z]][m];
                 out[i4[z]++] = c;
-		R[z] = fb[l[z]][c].u.s.f * (R[z]>>TF_SHIFT_O1) + m - fb[l[z]][c].u.s.b;
-		RansDecRenormSafe(&R[z], &ptr, ptr_end);
-		l[z] = c;
-	    }
-	}
+                R[z] = fb[l[z]][c].u.s.f * (R[z]>>TF_SHIFT_O1) + m - fb[l[z]][c].u.s.b;
+                RansDecRenormSafe(&R[z], &ptr, ptr_end);
+                l[z] = c;
+            }
+        }
 
 
-	// Remainder
-	for (; i4[NX-1] < out_sz; i4[NX-1]++) {
-	    uint32_t m = R[NX-1] & ((1u<<TF_SHIFT_O1)-1);
-	    unsigned char c = sfb[l[NX-1]][m];
-	    out[i4[NX-1]] = c;
-	    R[NX-1] = fb[l[NX-1]][c].u.s.f * (R[NX-1]>>TF_SHIFT_O1) + m - fb[l[NX-1]][c].u.s.b;
-	    RansDecRenormSafe(&R[NX-1], &ptr, ptr_end);
-	    l[NX-1] = c;
-	}
+        // Remainder
+        for (; i4[NX-1] < out_sz; i4[NX-1]++) {
+            uint32_t m = R[NX-1] & ((1u<<TF_SHIFT_O1)-1);
+            unsigned char c = sfb[l[NX-1]][m];
+            out[i4[NX-1]] = c;
+            R[NX-1] = fb[l[NX-1]][c].u.s.f * (R[NX-1]>>TF_SHIFT_O1) + m - fb[l[NX-1]][c].u.s.b;
+            RansDecRenormSafe(&R[NX-1], &ptr, ptr_end);
+            l[NX-1] = c;
+        }
     } else {
-	// TF_SHIFT_O1 = 10
-	const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
-	uint32x4_t maskv = vdupq_n_u32((1u << TF_SHIFT_O1_FAST)-1);
+        // TF_SHIFT_O1 = 10
+        const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
+        uint32x4_t maskv = vdupq_n_u32((1u << TF_SHIFT_O1_FAST)-1);
 
-	// FIXME: plus room for "safe" renorm.
-	// Follow with 2nd copy doing scalar code instead?
-	unsigned char tbuf[32][32];
-	int tidx = 0;
+        // FIXME: plus room for "safe" renorm.
+        // Follow with 2nd copy doing scalar code instead?
+        unsigned char tbuf[32][32];
+        int tidx = 0;
 
-	uint32x4_t RV[8] = {
+        uint32x4_t RV[8] = {
             vld1q_u32(&R[0]),
             vld1q_u32(&R[4]),
             vld1q_u32(&R[8]),
@@ -1746,9 +1746,9 @@ unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
             vld1q_u32(&R[20]),
             vld1q_u32(&R[24]),
             vld1q_u32(&R[28]),
-	};
+        };
 
-//	uint32x4_t MV[8] = {
+//      uint32x4_t MV[8] = {
 //            vandq_u32(RV[0], maskv),
 //            vandq_u32(RV[1], maskv),
 //            vandq_u32(RV[2], maskv),
@@ -1757,188 +1757,188 @@ unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
 //            vandq_u32(RV[5], maskv),
 //            vandq_u32(RV[6], maskv),
 //            vandq_u32(RV[7], maskv),
-//	};
+//      };
 
-	uint32_t m[NX];
-	for (z = 0; z < NX; z++)
-	    m[z] = l[z]*TOTFREQ_O1_FAST + (R[z] & mask);
+        uint32_t m[NX];
+        for (z = 0; z < NX; z++)
+            m[z] = l[z]*TOTFREQ_O1_FAST + (R[z] & mask);
 
-	uint32_t *S3 = (uint32_t *)s3;
-	
-	for (; i4[0] < isz4 && ptr+64 < ptr_end;) {
-	    int Z = 0;
-	    for (z = 0; z < NX; z+=16, Z+=4) {
-		// streamline these.  Could swap between two banks and pre-load
-		uint32x4_t Sv1, Sv2, Sv3, Sv4;
-		uint32x4_t Fv1, Fv2, Fv3, Fv4;
-		uint32x4_t Bv1, Bv2, Bv3, Bv4;
-		uint32x2_t s1a, s1b, s2a, s2b, s3a, s3b, s4a, s4b;
+        uint32_t *S3 = (uint32_t *)s3;
+        
+        for (; i4[0] < isz4 && ptr+64 < ptr_end;) {
+            int Z = 0;
+            for (z = 0; z < NX; z+=16, Z+=4) {
+                // streamline these.  Could swap between two banks and pre-load
+                uint32x4_t Sv1, Sv2, Sv3, Sv4;
+                uint32x4_t Fv1, Fv2, Fv3, Fv4;
+                uint32x4_t Bv1, Bv2, Bv3, Bv4;
+                uint32x2_t s1a, s1b, s2a, s2b, s3a, s3b, s4a, s4b;
 
-		s1a = vcreate_u32((uint64_t)(S3[m[z+1]])<<32  | (S3[m[z+0]]));
-		s1b = vcreate_u32((uint64_t)(S3[m[z+3]])<<32  | (S3[m[z+2]]));
-		s2a = vcreate_u32((uint64_t)(S3[m[z+5]])<<32  | (S3[m[z+4]]));
-		s2b = vcreate_u32((uint64_t)(S3[m[z+7]])<<32  | (S3[m[z+6]]));
-		s3a = vcreate_u32((uint64_t)(S3[m[z+9]])<<32  | (S3[m[z+8]]));
-		s3b = vcreate_u32((uint64_t)(S3[m[z+11]])<<32 | (S3[m[z+10]]));
-		s4a = vcreate_u32((uint64_t)(S3[m[z+13]])<<32 | (S3[m[z+12]]));
-		s4b = vcreate_u32((uint64_t)(S3[m[z+15]])<<32 | (S3[m[z+14]]));
+                s1a = vcreate_u32((uint64_t)(S3[m[z+1]])<<32  | (S3[m[z+0]]));
+                s1b = vcreate_u32((uint64_t)(S3[m[z+3]])<<32  | (S3[m[z+2]]));
+                s2a = vcreate_u32((uint64_t)(S3[m[z+5]])<<32  | (S3[m[z+4]]));
+                s2b = vcreate_u32((uint64_t)(S3[m[z+7]])<<32  | (S3[m[z+6]]));
+                s3a = vcreate_u32((uint64_t)(S3[m[z+9]])<<32  | (S3[m[z+8]]));
+                s3b = vcreate_u32((uint64_t)(S3[m[z+11]])<<32 | (S3[m[z+10]]));
+                s4a = vcreate_u32((uint64_t)(S3[m[z+13]])<<32 | (S3[m[z+12]]));
+                s4b = vcreate_u32((uint64_t)(S3[m[z+15]])<<32 | (S3[m[z+14]]));
 
-		Sv1 = vcombine_u32(s1a, s1b);
-		Sv2 = vcombine_u32(s2a, s2b);
-		Sv3 = vcombine_u32(s3a, s3b);
-		Sv4 = vcombine_u32(s4a, s4b);
-		
-		uint16x4_t p16_1 = vmovn_u32(Sv1);
-		uint16x4_t p16_2 = vmovn_u32(Sv2);
-		uint16x4_t p16_3 = vmovn_u32(Sv3);
-		uint16x4_t p16_4 = vmovn_u32(Sv4);
+                Sv1 = vcombine_u32(s1a, s1b);
+                Sv2 = vcombine_u32(s2a, s2b);
+                Sv3 = vcombine_u32(s3a, s3b);
+                Sv4 = vcombine_u32(s4a, s4b);
+                
+                uint16x4_t p16_1 = vmovn_u32(Sv1);
+                uint16x4_t p16_2 = vmovn_u32(Sv2);
+                uint16x4_t p16_3 = vmovn_u32(Sv3);
+                uint16x4_t p16_4 = vmovn_u32(Sv4);
 
-		uint8x8_t  p8_12  = vmovn_u16(vcombine_u16(p16_1,p16_2));
-		uint8x8_t  p8_34  = vmovn_u16(vcombine_u16(p16_3,p16_4));
-		uint8x16_t p8_a   = vcombine_u8(p8_12, p8_34);
-		vst1q_u8(l+z, p8_a);
+                uint8x8_t  p8_12  = vmovn_u16(vcombine_u16(p16_1,p16_2));
+                uint8x8_t  p8_34  = vmovn_u16(vcombine_u16(p16_3,p16_4));
+                uint8x16_t p8_a   = vcombine_u8(p8_12, p8_34);
+                vst1q_u8(l+z, p8_a);
 
-		Fv1 = vshrq_n_u32(Sv1, TF_SHIFT_O1_FAST+8);
-		Fv2 = vshrq_n_u32(Sv2, TF_SHIFT_O1_FAST+8);
-		Fv3 = vshrq_n_u32(Sv3, TF_SHIFT_O1_FAST+8);
-		Fv4 = vshrq_n_u32(Sv4, TF_SHIFT_O1_FAST+8);
+                Fv1 = vshrq_n_u32(Sv1, TF_SHIFT_O1_FAST+8);
+                Fv2 = vshrq_n_u32(Sv2, TF_SHIFT_O1_FAST+8);
+                Fv3 = vshrq_n_u32(Sv3, TF_SHIFT_O1_FAST+8);
+                Fv4 = vshrq_n_u32(Sv4, TF_SHIFT_O1_FAST+8);
 
-		Bv1 = vandq_u32(vshrq_n_u32(Sv1, 8), maskv);
-		Bv2 = vandq_u32(vshrq_n_u32(Sv2, 8), maskv);
-		Bv3 = vandq_u32(vshrq_n_u32(Sv3, 8), maskv);
-		Bv4 = vandq_u32(vshrq_n_u32(Sv4, 8), maskv);
+                Bv1 = vandq_u32(vshrq_n_u32(Sv1, 8), maskv);
+                Bv2 = vandq_u32(vshrq_n_u32(Sv2, 8), maskv);
+                Bv3 = vandq_u32(vshrq_n_u32(Sv3, 8), maskv);
+                Bv4 = vandq_u32(vshrq_n_u32(Sv4, 8), maskv);
 
-		// Add in transpose here.
-		memcpy(&tbuf[tidx][z], &l[z], 16);
-		
-		RV[Z+0] = vshrq_n_u32(RV[Z+0], TF_SHIFT_O1_FAST);
-		RV[Z+1] = vshrq_n_u32(RV[Z+1], TF_SHIFT_O1_FAST);
-		RV[Z+2] = vshrq_n_u32(RV[Z+2], TF_SHIFT_O1_FAST);
-		RV[Z+3] = vshrq_n_u32(RV[Z+3], TF_SHIFT_O1_FAST);
+                // Add in transpose here.
+                memcpy(&tbuf[tidx][z], &l[z], 16);
+                
+                RV[Z+0] = vshrq_n_u32(RV[Z+0], TF_SHIFT_O1_FAST);
+                RV[Z+1] = vshrq_n_u32(RV[Z+1], TF_SHIFT_O1_FAST);
+                RV[Z+2] = vshrq_n_u32(RV[Z+2], TF_SHIFT_O1_FAST);
+                RV[Z+3] = vshrq_n_u32(RV[Z+3], TF_SHIFT_O1_FAST);
 
-		// Ready for use in S3[] offset
-		Sv1 = vshlq_n_u32(vandq_u32(Sv1, vdupq_n_u32(0xff)), TF_SHIFT_O1_FAST);
-		Sv2 = vshlq_n_u32(vandq_u32(Sv2, vdupq_n_u32(0xff)), TF_SHIFT_O1_FAST);
-		Sv3 = vshlq_n_u32(vandq_u32(Sv3, vdupq_n_u32(0xff)), TF_SHIFT_O1_FAST);
-		Sv4 = vshlq_n_u32(vandq_u32(Sv4, vdupq_n_u32(0xff)), TF_SHIFT_O1_FAST);
+                // Ready for use in S3[] offset
+                Sv1 = vshlq_n_u32(vandq_u32(Sv1, vdupq_n_u32(0xff)), TF_SHIFT_O1_FAST);
+                Sv2 = vshlq_n_u32(vandq_u32(Sv2, vdupq_n_u32(0xff)), TF_SHIFT_O1_FAST);
+                Sv3 = vshlq_n_u32(vandq_u32(Sv3, vdupq_n_u32(0xff)), TF_SHIFT_O1_FAST);
+                Sv4 = vshlq_n_u32(vandq_u32(Sv4, vdupq_n_u32(0xff)), TF_SHIFT_O1_FAST);
 
-		RV[Z+0] = vmlaq_u32(Bv1, Fv1, RV[Z+0]);
-		RV[Z+1] = vmlaq_u32(Bv2, Fv2, RV[Z+1]);
-		RV[Z+2] = vmlaq_u32(Bv3, Fv3, RV[Z+2]);
-		RV[Z+3] = vmlaq_u32(Bv4, Fv4, RV[Z+3]);
+                RV[Z+0] = vmlaq_u32(Bv1, Fv1, RV[Z+0]);
+                RV[Z+1] = vmlaq_u32(Bv2, Fv2, RV[Z+1]);
+                RV[Z+2] = vmlaq_u32(Bv3, Fv3, RV[Z+2]);
+                RV[Z+3] = vmlaq_u32(Bv4, Fv4, RV[Z+3]);
 
-		// Renorm
-		uint32x4_t Rlt1 = vcltq_u32(RV[Z+0], vdupq_n_u32(RANS_BYTE_L));
-		uint32x4_t Rlt2 = vcltq_u32(RV[Z+1], vdupq_n_u32(RANS_BYTE_L));
-		uint32x4_t Rlt3 = vcltq_u32(RV[Z+2], vdupq_n_u32(RANS_BYTE_L));
-		uint32x4_t Rlt4 = vcltq_u32(RV[Z+3], vdupq_n_u32(RANS_BYTE_L));
+                // Renorm
+                uint32x4_t Rlt1 = vcltq_u32(RV[Z+0], vdupq_n_u32(RANS_BYTE_L));
+                uint32x4_t Rlt2 = vcltq_u32(RV[Z+1], vdupq_n_u32(RANS_BYTE_L));
+                uint32x4_t Rlt3 = vcltq_u32(RV[Z+2], vdupq_n_u32(RANS_BYTE_L));
+                uint32x4_t Rlt4 = vcltq_u32(RV[Z+3], vdupq_n_u32(RANS_BYTE_L));
 
-		// Compute lookup table index
-		static int nbits[16] = { 0,2,2,4, 2,4,4,6, 2,4,4,6, 4,6,6,8 };
-		uint32x4_t bit = {8,4,2,1};
-		uint32_t imask1 = vaddvq_u32(vandq_u32(Rlt1, bit));
-		uint32_t imask2 = vaddvq_u32(vandq_u32(Rlt2, bit));
-		uint32_t imask3 = vaddvq_u32(vandq_u32(Rlt3, bit));
-		uint32_t imask4 = vaddvq_u32(vandq_u32(Rlt4, bit));
+                // Compute lookup table index
+                static int nbits[16] = { 0,2,2,4, 2,4,4,6, 2,4,4,6, 4,6,6,8 };
+                uint32x4_t bit = {8,4,2,1};
+                uint32_t imask1 = vaddvq_u32(vandq_u32(Rlt1, bit));
+                uint32_t imask2 = vaddvq_u32(vandq_u32(Rlt2, bit));
+                uint32_t imask3 = vaddvq_u32(vandq_u32(Rlt3, bit));
+                uint32_t imask4 = vaddvq_u32(vandq_u32(Rlt4, bit));
 
-		// load 8 lanes of renorm data
-		uint16x8_t norm12 =  vld1q_u16((uint16_t *)ptr);
-		// move ptr by no. renorm lanes used
-		ptr += nbits[imask1] + nbits[imask2];
-		uint16x8_t norm34 =  vld1q_u16((uint16_t *)ptr);
-		ptr += nbits[imask3] + nbits[imask4];
+                // load 8 lanes of renorm data
+                uint16x8_t norm12 =  vld1q_u16((uint16_t *)ptr);
+                // move ptr by no. renorm lanes used
+                ptr += nbits[imask1] + nbits[imask2];
+                uint16x8_t norm34 =  vld1q_u16((uint16_t *)ptr);
+                ptr += nbits[imask3] + nbits[imask4];
 
-		uint32_t imask12 = (imask1<<4)|imask2;
-		uint32_t imask34 = (imask3<<4)|imask4;
+                uint32_t imask12 = (imask1<<4)|imask2;
+                uint32_t imask34 = (imask3<<4)|imask4;
 
-		// Shuffle norm to the corresponding R lanes, via imask
-		// #define for brevity and formatting
-		uint16x4_t norm1, norm2, norm3, norm4;
-		norm1 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),idx [imask1]));
-		norm2 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),idx2[imask12]));
-		norm3 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),idx [imask3]));
-		norm4 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),idx2[imask34]));
+                // Shuffle norm to the corresponding R lanes, via imask
+                // #define for brevity and formatting
+                uint16x4_t norm1, norm2, norm3, norm4;
+                norm1 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),idx [imask1]));
+                norm2 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm12),idx2[imask12]));
+                norm3 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),idx [imask3]));
+                norm4 = cast_u16_u8(vqtbl1_u8(cast_u8_u16(norm34),idx2[imask34]));
 
-		// Add norm to R<<16 and blend back in with R
-		uint32x4_t Rsl1 = vshlq_n_u32(RV[Z+0], 16); // Rsl = R << 16
-		uint32x4_t Rsl2 = vshlq_n_u32(RV[Z+1], 16);
-		uint32x4_t Rsl3 = vshlq_n_u32(RV[Z+2], 16);
-		uint32x4_t Rsl4 = vshlq_n_u32(RV[Z+3], 16);
+                // Add norm to R<<16 and blend back in with R
+                uint32x4_t Rsl1 = vshlq_n_u32(RV[Z+0], 16); // Rsl = R << 16
+                uint32x4_t Rsl2 = vshlq_n_u32(RV[Z+1], 16);
+                uint32x4_t Rsl3 = vshlq_n_u32(RV[Z+2], 16);
+                uint32x4_t Rsl4 = vshlq_n_u32(RV[Z+3], 16);
 
-		Rsl1 = vaddw_u16(Rsl1, norm1);          // Rsl += norm
-		Rsl2 = vaddw_u16(Rsl2, norm2);
-		Rsl3 = vaddw_u16(Rsl3, norm3);
-		Rsl4 = vaddw_u16(Rsl4, norm4);
+                Rsl1 = vaddw_u16(Rsl1, norm1);          // Rsl += norm
+                Rsl2 = vaddw_u16(Rsl2, norm2);
+                Rsl3 = vaddw_u16(Rsl3, norm3);
+                Rsl4 = vaddw_u16(Rsl4, norm4);
 
-		RV[Z+0] = vbslq_u32(Rlt1, Rsl1, RV[Z+0]);       // R = R<L ? Rsl : R
-		RV[Z+1] = vbslq_u32(Rlt2, Rsl2, RV[Z+1]);
-		RV[Z+2] = vbslq_u32(Rlt3, Rsl3, RV[Z+2]);
-		RV[Z+3] = vbslq_u32(Rlt4, Rsl4, RV[Z+3]);
+                RV[Z+0] = vbslq_u32(Rlt1, Rsl1, RV[Z+0]);       // R = R<L ? Rsl : R
+                RV[Z+1] = vbslq_u32(Rlt2, Rsl2, RV[Z+1]);
+                RV[Z+2] = vbslq_u32(Rlt3, Rsl3, RV[Z+2]);
+                RV[Z+3] = vbslq_u32(Rlt4, Rsl4, RV[Z+3]);
 
-		// Offset into s3[l][c] => s3 + l*TOTFREQ_O1_FAST + c.
-		uint32x4_t off1 = vandq_u32(RV[Z+0], maskv);
-		uint32x4_t off2 = vandq_u32(RV[Z+1], maskv);
-		uint32x4_t off3 = vandq_u32(RV[Z+2], maskv);
-		uint32x4_t off4 = vandq_u32(RV[Z+3], maskv);
+                // Offset into s3[l][c] => s3 + l*TOTFREQ_O1_FAST + c.
+                uint32x4_t off1 = vandq_u32(RV[Z+0], maskv);
+                uint32x4_t off2 = vandq_u32(RV[Z+1], maskv);
+                uint32x4_t off3 = vandq_u32(RV[Z+2], maskv);
+                uint32x4_t off4 = vandq_u32(RV[Z+3], maskv);
 
-		off1 = vaddq_u32(off1, Sv1);
-		off2 = vaddq_u32(off2, Sv2);
-		off3 = vaddq_u32(off3, Sv3);
-		off4 = vaddq_u32(off4, Sv4);
-		
-		vst1q_u32(&m[z+ 0], off1);
-		vst1q_u32(&m[z+ 4], off2);
-		vst1q_u32(&m[z+ 8], off3);
-		vst1q_u32(&m[z+12], off4);
-	    }
+                off1 = vaddq_u32(off1, Sv1);
+                off2 = vaddq_u32(off2, Sv2);
+                off3 = vaddq_u32(off3, Sv3);
+                off4 = vaddq_u32(off4, Sv4);
+                
+                vst1q_u32(&m[z+ 0], off1);
+                vst1q_u32(&m[z+ 4], off2);
+                vst1q_u32(&m[z+ 8], off3);
+                vst1q_u32(&m[z+12], off4);
+            }
 
-	    i4[0]++;
-	    if (++tidx == 32) {
-		i4[0] -= 32;
+            i4[0]++;
+            if (++tidx == 32) {
+                i4[0] -= 32;
 
-		transpose_and_copy(out, i4, tbuf);
-		tidx = 0;
-	    }
-	}
+                transpose_and_copy(out, i4, tbuf);
+                tidx = 0;
+            }
+        }
 
-	vst1q_u32(&R[ 0], RV[0]);
-	vst1q_u32(&R[ 4], RV[1]);
-	vst1q_u32(&R[ 8], RV[2]);
-	vst1q_u32(&R[12], RV[3]);
-	vst1q_u32(&R[16], RV[4]);
-	vst1q_u32(&R[20], RV[5]);
-	vst1q_u32(&R[24], RV[6]);
-	vst1q_u32(&R[28], RV[7]);
+        vst1q_u32(&R[ 0], RV[0]);
+        vst1q_u32(&R[ 4], RV[1]);
+        vst1q_u32(&R[ 8], RV[2]);
+        vst1q_u32(&R[12], RV[3]);
+        vst1q_u32(&R[16], RV[4]);
+        vst1q_u32(&R[20], RV[5]);
+        vst1q_u32(&R[24], RV[6]);
+        vst1q_u32(&R[28], RV[7]);
 
-	i4[0]-=tidx;
-	int T;
-	for (z = 0; z < NX; z++)
-	    for (T = 0; T < tidx; T++)
-		out[i4[z]++] = tbuf[T][z];
+        i4[0]-=tidx;
+        int T;
+        for (z = 0; z < NX; z++)
+            for (T = 0; T < tidx; T++)
+                out[i4[z]++] = tbuf[T][z];
 
-	// Scalar version for close to end of in[] array so we don't do
-	// SIMD loads beyond the end of the buffer
-	for (; i4[0] < isz4; ) {
-	    for (z = 0; z < NX; z++) {
-		uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
-		uint32_t S = s3[l[z]][m];
+        // Scalar version for close to end of in[] array so we don't do
+        // SIMD loads beyond the end of the buffer
+        for (; i4[0] < isz4; ) {
+            for (z = 0; z < NX; z++) {
+                uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
+                uint32_t S = s3[l[z]][m];
                 unsigned char c = S & 0xff;
                 out[i4[z]++] = c;
                 R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
                     ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
                 RansDecRenormSafe(&R[z], &ptr, ptr_end);
                 l[z] = c;
-	    }
-	}
+            }
+        }
 
-	// Remainder
-	for (; i4[NX-1] < out_sz; i4[NX-1]++) {
-	    uint32_t S = s3[l[NX-1]][R[NX-1] & ((1u<<TF_SHIFT_O1_FAST)-1)];
-	    out[i4[NX-1]] = l[NX-1] = S&0xff;
-	    R[NX-1] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[NX-1]>>TF_SHIFT_O1_FAST)
-		+ ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-	    RansDecRenormSafe(&R[NX-1], &ptr, ptr_end);
-	}
+        // Remainder
+        for (; i4[NX-1] < out_sz; i4[NX-1]++) {
+            uint32_t S = s3[l[NX-1]][R[NX-1] & ((1u<<TF_SHIFT_O1_FAST)-1)];
+            out[i4[NX-1]] = l[NX-1] = S&0xff;
+            R[NX-1] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[NX-1]>>TF_SHIFT_O1_FAST)
+                + ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+            RansDecRenormSafe(&R[NX-1], &ptr, ptr_end);
+        }
     }
     //fprintf(stderr, "    1 Decoded %d bytes\n", (int)(ptr-in)); //c-size
 

--- a/htscodecs/rANS_static32x16pr_sse4.c
+++ b/htscodecs/rANS_static32x16pr_sse4.c
@@ -87,24 +87,24 @@ POPCNT:
 
 #define NX 32
 
-#define LOAD128(a,b)					\
-    __m128i a##1 = _mm_load_si128((__m128i *)&b[0]);	\
-    __m128i a##2 = _mm_load_si128((__m128i *)&b[4]);	\
-    __m128i a##3 = _mm_load_si128((__m128i *)&b[8]);	\
-    __m128i a##4 = _mm_load_si128((__m128i *)&b[12]);	\
-    __m128i a##5 = _mm_load_si128((__m128i *)&b[16]);	\
-    __m128i a##6 = _mm_load_si128((__m128i *)&b[20]);	\
-    __m128i a##7 = _mm_load_si128((__m128i *)&b[24]);	\
+#define LOAD128(a,b)                                    \
+    __m128i a##1 = _mm_load_si128((__m128i *)&b[0]);    \
+    __m128i a##2 = _mm_load_si128((__m128i *)&b[4]);    \
+    __m128i a##3 = _mm_load_si128((__m128i *)&b[8]);    \
+    __m128i a##4 = _mm_load_si128((__m128i *)&b[12]);   \
+    __m128i a##5 = _mm_load_si128((__m128i *)&b[16]);   \
+    __m128i a##6 = _mm_load_si128((__m128i *)&b[20]);   \
+    __m128i a##7 = _mm_load_si128((__m128i *)&b[24]);   \
     __m128i a##8 = _mm_load_si128((__m128i *)&b[28]);
 
-#define STORE128(a,b)					\
-    _mm_store_si128((__m128i *)&b[ 0], a##1);		\
-    _mm_store_si128((__m128i *)&b[ 4], a##2);		\
-    _mm_store_si128((__m128i *)&b[ 8], a##3);		\
-    _mm_store_si128((__m128i *)&b[12], a##4);		\
-    _mm_store_si128((__m128i *)&b[16], a##5);		\
-    _mm_store_si128((__m128i *)&b[20], a##6);		\
-    _mm_store_si128((__m128i *)&b[24], a##7);		\
+#define STORE128(a,b)                                   \
+    _mm_store_si128((__m128i *)&b[ 0], a##1);           \
+    _mm_store_si128((__m128i *)&b[ 4], a##2);           \
+    _mm_store_si128((__m128i *)&b[ 8], a##3);           \
+    _mm_store_si128((__m128i *)&b[12], a##4);           \
+    _mm_store_si128((__m128i *)&b[16], a##5);           \
+    _mm_store_si128((__m128i *)&b[20], a##6);           \
+    _mm_store_si128((__m128i *)&b[24], a##7);           \
     _mm_store_si128((__m128i *)&b[28], a##8);
 
 static inline __m128i _mm_i32gather_epi32x(int *b, __m128i idx, int size) {
@@ -116,25 +116,25 @@ static inline __m128i _mm_i32gather_epi32x(int *b, __m128i idx, int size) {
 // SSE4 implementation of the Order-0 encoder is poorly performing.
 // Disabled for now.
 #if 0
-#define LOAD128v(a,b)					\
-    __m128i a[8];					\
-    a[0] = _mm_load_si128((__m128i *)&b[0]);		\
-    a[1] = _mm_load_si128((__m128i *)&b[4]);		\
-    a[2] = _mm_load_si128((__m128i *)&b[8]);		\
-    a[3] = _mm_load_si128((__m128i *)&b[12]);		\
-    a[4] = _mm_load_si128((__m128i *)&b[16]);		\
-    a[5] = _mm_load_si128((__m128i *)&b[20]);		\
-    a[6] = _mm_load_si128((__m128i *)&b[24]);		\
+#define LOAD128v(a,b)                                   \
+    __m128i a[8];                                       \
+    a[0] = _mm_load_si128((__m128i *)&b[0]);            \
+    a[1] = _mm_load_si128((__m128i *)&b[4]);            \
+    a[2] = _mm_load_si128((__m128i *)&b[8]);            \
+    a[3] = _mm_load_si128((__m128i *)&b[12]);           \
+    a[4] = _mm_load_si128((__m128i *)&b[16]);           \
+    a[5] = _mm_load_si128((__m128i *)&b[20]);           \
+    a[6] = _mm_load_si128((__m128i *)&b[24]);           \
     a[7] = _mm_load_si128((__m128i *)&b[28]);
 
-#define STORE128v(a,b)					\
-    _mm_store_si128((__m128i *)&b[ 0], a[0]);		\
-    _mm_store_si128((__m128i *)&b[ 4], a[1]);		\
-    _mm_store_si128((__m128i *)&b[ 8], a[2]);		\
-    _mm_store_si128((__m128i *)&b[12], a[3]);		\
-    _mm_store_si128((__m128i *)&b[16], a[4]);		\
-    _mm_store_si128((__m128i *)&b[20], a[5]);		\
-    _mm_store_si128((__m128i *)&b[24], a[6]);		\
+#define STORE128v(a,b)                                  \
+    _mm_store_si128((__m128i *)&b[ 0], a[0]);           \
+    _mm_store_si128((__m128i *)&b[ 4], a[1]);           \
+    _mm_store_si128((__m128i *)&b[ 8], a[2]);           \
+    _mm_store_si128((__m128i *)&b[12], a[3]);           \
+    _mm_store_si128((__m128i *)&b[16], a[4]);           \
+    _mm_store_si128((__m128i *)&b[20], a[5]);           \
+    _mm_store_si128((__m128i *)&b[24], a[6]);           \
     _mm_store_si128((__m128i *)&b[28], a[7]);
 
 static inline __m128i _mm_mulhi_epu32(__m128i a, __m128i b) {
@@ -156,40 +156,40 @@ static inline __m128i _mm_mulhi_epu32(__m128i a, __m128i b) {
 static inline __m128i _mm_srlv_epi32x(__m128i a, __m128i b) {
 // Extract and inline shift.  Slowest clang, joint fastest gcc
 //    return _mm_set_epi32(_mm_extract_epi32(a,3)>>_mm_extract_epi32(b,3),
-//			 _mm_extract_epi32(a,2)>>_mm_extract_epi32(b,2),
-//			 _mm_extract_epi32(a,1)>>_mm_extract_epi32(b,1),
-//			 _mm_extract_epi32(a,0)>>_mm_extract_epi32(b,0));
+//                       _mm_extract_epi32(a,2)>>_mm_extract_epi32(b,2),
+//                       _mm_extract_epi32(a,1)>>_mm_extract_epi32(b,1),
+//                       _mm_extract_epi32(a,0)>>_mm_extract_epi32(b,0));
 
 // Half store and inline shift; Fastest gcc, comparable to others below clang
 //    uint32_t A[4];
 //    _mm_storeu_si128((__m128i *)&A, a);
 //
 //    return _mm_set_epi32(A[3]>>_mm_extract_epi32(b,3),
-//			 A[2]>>_mm_extract_epi32(b,2),
-//			 A[1]>>_mm_extract_epi32(b,1),
-//			 A[0]>>_mm_extract_epi32(b,0));
+//                       A[2]>>_mm_extract_epi32(b,2),
+//                       A[1]>>_mm_extract_epi32(b,1),
+//                       A[0]>>_mm_extract_epi32(b,0));
 
 // Other half
     uint32_t B[4];
     _mm_storeu_si128((__m128i *)&B, b);
     return _mm_set_epi32(_mm_extract_epi32(a,3)>>B[3],
-			 _mm_extract_epi32(a,2)>>B[2],
-			 _mm_extract_epi32(a,1)>>B[1],
-			 _mm_extract_epi32(a,0)>>B[0]);
+                         _mm_extract_epi32(a,2)>>B[2],
+                         _mm_extract_epi32(a,1)>>B[1],
+                         _mm_extract_epi32(a,0)>>B[0]);
 
 // Check if all b[] match, and constant shift if so.
 // Too costly, even on q4 where it's common for all shift to be identical.
 //    __m128i cmp = _mm_cmpeq_epi32(b, _mm_shuffle_epi32(b, 0x39));
 //    if (_mm_movemask_ps((__m128)cmp) == 15) {
-//	return _mm_srl_epi32(a, _mm_set1_epi64x(_mm_extract_epi32(b,0)));
-//	//_mm_storeu_si128((__m128i *)&B,_mm_set1_epi32(_mm_extract_epi32(b,0)));
+//      return _mm_srl_epi32(a, _mm_set1_epi64x(_mm_extract_epi32(b,0)));
+//      //_mm_storeu_si128((__m128i *)&B,_mm_set1_epi32(_mm_extract_epi32(b,0)));
 //    } else {
-//	uint32_t B[4];
-//	_mm_storeu_si128((__m128i *)&B, b);
-//	return _mm_set_epi32(_mm_extract_epi32(a,3)>>B[3],
-//			     _mm_extract_epi32(a,2)>>B[2],
-//			     _mm_extract_epi32(a,1)>>B[1],
-//			     _mm_extract_epi32(a,0)>>B[0]);
+//      uint32_t B[4];
+//      _mm_storeu_si128((__m128i *)&B, b);
+//      return _mm_set_epi32(_mm_extract_epi32(a,3)>>B[3],
+//                           _mm_extract_epi32(a,2)>>B[2],
+//                           _mm_extract_epi32(a,1)>>B[1],
+//                           _mm_extract_epi32(a,0)>>B[0]);
 //    }
 
 
@@ -212,9 +212,9 @@ static inline __m128i _mm_srlv_epi32x(__m128i a, __m128i b) {
 }
 
 unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
-					   unsigned int in_size,
-					   unsigned char *out,
-					   unsigned int *out_size) {
+                                           unsigned int in_size,
+                                           unsigned char *out,
+                                           unsigned int *out_size) {
     unsigned char *cp, *out_end;
     RansEncSymbol syms[256];
     RansState ransN[NX];
@@ -224,20 +224,20 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
     int bound = rans_compress_bound_4x16(in_size,0)-20; // -20 for order/size/meta
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     // If "out" isn't word aligned, tweak out_end/ptr to ensure it is.
     // We already added more round in bound to allow for this.
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     ptr = out_end = out + bound;
 
     if (in_size == 0)
-	goto empty;
+        goto empty;
 
     // Compute statistics
     hist8(in, in_size, F);
@@ -247,10 +247,10 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
     uint32_t fsum = in_size;
     uint32_t max_val = round2(fsum);
     if (max_val > TOTFREQ)
-	max_val = TOTFREQ;
+        max_val = TOTFREQ;
 
     if (normalise_freq(F, fsum, max_val) < 0)
-	return NULL;
+        return NULL;
     fsum=max_val;
 
     cp = out;
@@ -259,14 +259,14 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
     //write(2, out+4, cp-(out+4));
 
     if (normalise_freq(F, fsum, TOTFREQ) < 0)
-	return NULL;
+        return NULL;
 
     // Encode statistics.
     for (x = rle = j = 0; j < 256; j++) {
-	if (F[j]) {
-	    RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
-	    x += F[j];
-	}
+        if (F[j]) {
+            RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
+            x += F[j];
+        }
     }
 
     for (z = 0; z < NX; z++)
@@ -290,9 +290,9 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
     LOAD128v(Rv, ransN);
 
     const __m128i shuf = _mm_set_epi8(0x80, 0x80, 0x80, 0x80,
-				      0x80, 0x80, 0x80, 0x80,
-				      0x0d, 0x0c, 0x09, 0x08,
-				      0x05, 0x04, 0x01, 0x00);
+                                      0x80, 0x80, 0x80, 0x80,
+                                      0x0d, 0x0c, 0x09, 0x08,
+                                      0x05, 0x04, 0x01, 0x00);
 
     // FIXME: slower!
     // q40:  340 (scalar) vs 300 (this)
@@ -305,141 +305,141 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
       // but the reverse with gcc.
       //for (h=24; h >= 0; h -= 8) {
       for (h=16; h >= 0; h -= 16) {
-	int H = h/4; // rans index
-	uint8_t *C = &in[i-NX+h];
+        int H = h/4; // rans index
+        uint8_t *C = &in[i-NX+h];
 
 #define SET(i,a) _mm_set_epi32(a[C[i+3]],a[C[i+2]],a[C[i+1]],a[C[i+0]])
-	__m128i xmax8 = SET(12, SB);
-	__m128i xmax7 = SET( 8, SB);
-	__m128i xmax6 = SET( 4, SB);
-	__m128i xmax5 = SET( 0, SB);
+        __m128i xmax8 = SET(12, SB);
+        __m128i xmax7 = SET( 8, SB);
+        __m128i xmax6 = SET( 4, SB);
+        __m128i xmax5 = SET( 0, SB);
 
-	__m128i cv8 = _mm_cmpgt_epi32(Rv[H+3], xmax8);
-	__m128i cv7 = _mm_cmpgt_epi32(Rv[H+2], xmax7);
-	__m128i cv6 = _mm_cmpgt_epi32(Rv[H+1], xmax6);
-	__m128i cv5 = _mm_cmpgt_epi32(Rv[H+0], xmax5);
+        __m128i cv8 = _mm_cmpgt_epi32(Rv[H+3], xmax8);
+        __m128i cv7 = _mm_cmpgt_epi32(Rv[H+2], xmax7);
+        __m128i cv6 = _mm_cmpgt_epi32(Rv[H+1], xmax6);
+        __m128i cv5 = _mm_cmpgt_epi32(Rv[H+0], xmax5);
 
-	// Store bottom 16-bits at ptr16
-	unsigned int imask8 = _mm_movemask_ps((__m128)cv8);
-	unsigned int imask7 = _mm_movemask_ps((__m128)cv7);
-	unsigned int imask6 = _mm_movemask_ps((__m128)cv6);
-	unsigned int imask5 = _mm_movemask_ps((__m128)cv5);
+        // Store bottom 16-bits at ptr16
+        unsigned int imask8 = _mm_movemask_ps((__m128)cv8);
+        unsigned int imask7 = _mm_movemask_ps((__m128)cv7);
+        unsigned int imask6 = _mm_movemask_ps((__m128)cv6);
+        unsigned int imask5 = _mm_movemask_ps((__m128)cv5);
 
 #define X(A) 4*A,4*A+1,0x80,0x80
 #define _ 0x80,0x80,0x80,0x80
- 	uint8_t permutec[16][16] __attribute__((aligned(16))) = {
-	    {  _ ,  _ ,  _ ,  _ },
-	    {  _ ,  _ ,  _ ,X(0)},
-	    {  _ ,  _ ,  _ ,X(1)},
-	    {  _ ,  _ ,X(0),X(1)},
+        uint8_t permutec[16][16] __attribute__((aligned(16))) = {
+            {  _ ,  _ ,  _ ,  _ },
+            {  _ ,  _ ,  _ ,X(0)},
+            {  _ ,  _ ,  _ ,X(1)},
+            {  _ ,  _ ,X(0),X(1)},
 
-	    {  _ ,  _ ,  _ ,X(2)},
-	    {  _ ,  _ ,X(0),X(2)},
-	    {  _ ,  _ ,X(1),X(2)},
-	    {  _ ,X(0),X(1),X(2)},
+            {  _ ,  _ ,  _ ,X(2)},
+            {  _ ,  _ ,X(0),X(2)},
+            {  _ ,  _ ,X(1),X(2)},
+            {  _ ,X(0),X(1),X(2)},
 
-	    {  _ ,  _ ,  _ ,X(3)},
-	    {  _ ,  _ ,X(0),X(3)},
-	    {  _ ,  _ ,X(1),X(3)},
-	    {  _ ,X(0),X(1),X(3)},
+            {  _ ,  _ ,  _ ,X(3)},
+            {  _ ,  _ ,X(0),X(3)},
+            {  _ ,  _ ,X(1),X(3)},
+            {  _ ,X(0),X(1),X(3)},
 
-	    {  _ ,  _ ,X(2),X(3)},
-	    {  _ ,X(0),X(2),X(3)},
-	    {  _ ,X(1),X(2),X(3)},
-	    {X(0),X(1),X(2),X(3)},
-	};
+            {  _ ,  _ ,X(2),X(3)},
+            {  _ ,X(0),X(2),X(3)},
+            {  _ ,X(1),X(2),X(3)},
+            {X(0),X(1),X(2),X(3)},
+        };
 #undef X
 #undef _
 
-	__m128i idx8 = _mm_load_si128((__m128i *)permutec[imask8]);
-	__m128i idx7 = _mm_load_si128((__m128i *)permutec[imask7]);
-	__m128i idx6 = _mm_load_si128((__m128i *)permutec[imask6]);
-	__m128i idx5 = _mm_load_si128((__m128i *)permutec[imask5]);
+        __m128i idx8 = _mm_load_si128((__m128i *)permutec[imask8]);
+        __m128i idx7 = _mm_load_si128((__m128i *)permutec[imask7]);
+        __m128i idx6 = _mm_load_si128((__m128i *)permutec[imask6]);
+        __m128i idx5 = _mm_load_si128((__m128i *)permutec[imask5]);
 
-	// Permute; to gather together the rans states that need flushing
-	__m128i V1, V2, V3, V4, V5, V6, V7, V8;
-	V8 = _mm_shuffle_epi8(_mm_and_si128(Rv[H+3], cv8), idx8);
-	V7 = _mm_shuffle_epi8(_mm_and_si128(Rv[H+2], cv7), idx7);
-	V6 = _mm_shuffle_epi8(_mm_and_si128(Rv[H+1], cv6), idx6);
-	V5 = _mm_shuffle_epi8(_mm_and_si128(Rv[H+0], cv5), idx5);
+        // Permute; to gather together the rans states that need flushing
+        __m128i V1, V2, V3, V4, V5, V6, V7, V8;
+        V8 = _mm_shuffle_epi8(_mm_and_si128(Rv[H+3], cv8), idx8);
+        V7 = _mm_shuffle_epi8(_mm_and_si128(Rv[H+2], cv7), idx7);
+        V6 = _mm_shuffle_epi8(_mm_and_si128(Rv[H+1], cv6), idx6);
+        V5 = _mm_shuffle_epi8(_mm_and_si128(Rv[H+0], cv5), idx5);
 
-	// Shuffle alternating shorts together to collect low 16-bit
-	// elements together.  ... 9 8 5 4 1 0.
-	// Or as with avx2 code use packus instead.
+        // Shuffle alternating shorts together to collect low 16-bit
+        // elements together.  ... 9 8 5 4 1 0.
+        // Or as with avx2 code use packus instead.
         V8 = _mm_shuffle_epi8(V8, shuf);
         V7 = _mm_shuffle_epi8(V7, shuf);
-	V6 = _mm_shuffle_epi8(V6, shuf);
-	V5 = _mm_shuffle_epi8(V5, shuf);
+        V6 = _mm_shuffle_epi8(V6, shuf);
+        V5 = _mm_shuffle_epi8(V5, shuf);
 
-	_mm_storeu_si64(ptr16-4, V8); ptr16 -= _mm_popcnt_u32(imask8);
-	_mm_storeu_si64(ptr16-4, V7); ptr16 -= _mm_popcnt_u32(imask7);
-	_mm_storeu_si64(ptr16-4, V6); ptr16 -= _mm_popcnt_u32(imask6);
-	_mm_storeu_si64(ptr16-4, V5); ptr16 -= _mm_popcnt_u32(imask5);
+        _mm_storeu_si64(ptr16-4, V8); ptr16 -= _mm_popcnt_u32(imask8);
+        _mm_storeu_si64(ptr16-4, V7); ptr16 -= _mm_popcnt_u32(imask7);
+        _mm_storeu_si64(ptr16-4, V6); ptr16 -= _mm_popcnt_u32(imask6);
+        _mm_storeu_si64(ptr16-4, V5); ptr16 -= _mm_popcnt_u32(imask5);
 
-	Rv[H+3] = _mm_blendv_epi8(Rv[H+3], _mm_srli_epi32(Rv[H+3], 16), cv8);
-	Rv[H+2] = _mm_blendv_epi8(Rv[H+2], _mm_srli_epi32(Rv[H+2], 16), cv7);
-	Rv[H+1] = _mm_blendv_epi8(Rv[H+1], _mm_srli_epi32(Rv[H+1], 16), cv6);
-	Rv[H+0] = _mm_blendv_epi8(Rv[H+0], _mm_srli_epi32(Rv[H+0], 16), cv5);
+        Rv[H+3] = _mm_blendv_epi8(Rv[H+3], _mm_srli_epi32(Rv[H+3], 16), cv8);
+        Rv[H+2] = _mm_blendv_epi8(Rv[H+2], _mm_srli_epi32(Rv[H+2], 16), cv7);
+        Rv[H+1] = _mm_blendv_epi8(Rv[H+1], _mm_srli_epi32(Rv[H+1], 16), cv6);
+        Rv[H+0] = _mm_blendv_epi8(Rv[H+0], _mm_srli_epi32(Rv[H+0], 16), cv5);
 
-	// Cannot trivially replace the multiply as mulhi_epu32 doesn't
-	// exist (only mullo).
-	// However we can use _mm_mul_epu32 twice to get 64bit results
-	// (h our lanes) and shift/or to get the answer.
-	//
-	// (AVX512 allows us to hold it all in 64-bit lanes and use mullo_epi64
-	// plus a shift.  KNC has mulhi_epi32, but not sure if this is
-	// available.)
-	__m128i rfv8 = SET(12, SA);
-	__m128i rfv7 = SET( 8, SA);
-	__m128i rfv6 = SET( 4, SA);
-	__m128i rfv5 = SET( 0, SA);
+        // Cannot trivially replace the multiply as mulhi_epu32 doesn't
+        // exist (only mullo).
+        // However we can use _mm_mul_epu32 twice to get 64bit results
+        // (h our lanes) and shift/or to get the answer.
+        //
+        // (AVX512 allows us to hold it all in 64-bit lanes and use mullo_epi64
+        // plus a shift.  KNC has mulhi_epi32, but not sure if this is
+        // available.)
+        __m128i rfv8 = SET(12, SA);
+        __m128i rfv7 = SET( 8, SA);
+        __m128i rfv6 = SET( 4, SA);
+        __m128i rfv5 = SET( 0, SA);
 
-	rfv8 = _mm_mulhi_epu32(Rv[H+3], rfv8);
-	rfv7 = _mm_mulhi_epu32(Rv[H+2], rfv7);
-	rfv6 = _mm_mulhi_epu32(Rv[H+1], rfv6);
-	rfv5 = _mm_mulhi_epu32(Rv[H+0], rfv5);
+        rfv8 = _mm_mulhi_epu32(Rv[H+3], rfv8);
+        rfv7 = _mm_mulhi_epu32(Rv[H+2], rfv7);
+        rfv6 = _mm_mulhi_epu32(Rv[H+1], rfv6);
+        rfv5 = _mm_mulhi_epu32(Rv[H+0], rfv5);
 
-	__m128i SDv8 = SET(12, SD);
-	__m128i SDv7 = SET( 8, SD);
-	__m128i SDv6 = SET( 4, SD);
-	__m128i SDv5 = SET( 0, SD);
+        __m128i SDv8 = SET(12, SD);
+        __m128i SDv7 = SET( 8, SD);
+        __m128i SDv6 = SET( 4, SD);
+        __m128i SDv5 = SET( 0, SD);
 
-	__m128i shiftv8 = _mm_srli_epi32(SDv8, 16);
-	__m128i shiftv7 = _mm_srli_epi32(SDv7, 16);
-	__m128i shiftv6 = _mm_srli_epi32(SDv6, 16);
-	__m128i shiftv5 = _mm_srli_epi32(SDv5, 16);
+        __m128i shiftv8 = _mm_srli_epi32(SDv8, 16);
+        __m128i shiftv7 = _mm_srli_epi32(SDv7, 16);
+        __m128i shiftv6 = _mm_srli_epi32(SDv6, 16);
+        __m128i shiftv5 = _mm_srli_epi32(SDv5, 16);
 
-	__m128i freqv8 = _mm_and_si128(SDv8, _mm_set1_epi32(0xffff));
-	__m128i freqv7 = _mm_and_si128(SDv7, _mm_set1_epi32(0xffff));
-	__m128i freqv6 = _mm_and_si128(SDv6, _mm_set1_epi32(0xffff));
-	__m128i freqv5 = _mm_and_si128(SDv5, _mm_set1_epi32(0xffff));
+        __m128i freqv8 = _mm_and_si128(SDv8, _mm_set1_epi32(0xffff));
+        __m128i freqv7 = _mm_and_si128(SDv7, _mm_set1_epi32(0xffff));
+        __m128i freqv6 = _mm_and_si128(SDv6, _mm_set1_epi32(0xffff));
+        __m128i freqv5 = _mm_and_si128(SDv5, _mm_set1_epi32(0xffff));
 
-	// Bake this into the tabel to start with?
-	shiftv8 = _mm_sub_epi32(shiftv8, _mm_set1_epi32(32));
-	shiftv7 = _mm_sub_epi32(shiftv7, _mm_set1_epi32(32));
-	shiftv6 = _mm_sub_epi32(shiftv6, _mm_set1_epi32(32));
-	shiftv5 = _mm_sub_epi32(shiftv5, _mm_set1_epi32(32));
+        // Bake this into the tabel to start with?
+        shiftv8 = _mm_sub_epi32(shiftv8, _mm_set1_epi32(32));
+        shiftv7 = _mm_sub_epi32(shiftv7, _mm_set1_epi32(32));
+        shiftv6 = _mm_sub_epi32(shiftv6, _mm_set1_epi32(32));
+        shiftv5 = _mm_sub_epi32(shiftv5, _mm_set1_epi32(32));
 
-	// No way to shift by varying amounts.  Store, shift, load? Simulated
-	__m128i qv8 = _mm_srlv_epi32x(rfv8, shiftv8);
-	__m128i qv7 = _mm_srlv_epi32x(rfv7, shiftv7);
-	__m128i qv6 = _mm_srlv_epi32x(rfv6, shiftv6);
-	__m128i qv5 = _mm_srlv_epi32x(rfv5, shiftv5);
+        // No way to shift by varying amounts.  Store, shift, load? Simulated
+        __m128i qv8 = _mm_srlv_epi32x(rfv8, shiftv8);
+        __m128i qv7 = _mm_srlv_epi32x(rfv7, shiftv7);
+        __m128i qv6 = _mm_srlv_epi32x(rfv6, shiftv6);
+        __m128i qv5 = _mm_srlv_epi32x(rfv5, shiftv5);
 
-	qv8 = _mm_mullo_epi32(qv8, freqv8);
-	qv7 = _mm_mullo_epi32(qv7, freqv7);
-	qv6 = _mm_mullo_epi32(qv6, freqv6);
-	qv5 = _mm_mullo_epi32(qv5, freqv5);
+        qv8 = _mm_mullo_epi32(qv8, freqv8);
+        qv7 = _mm_mullo_epi32(qv7, freqv7);
+        qv6 = _mm_mullo_epi32(qv6, freqv6);
+        qv5 = _mm_mullo_epi32(qv5, freqv5);
 
-	qv8 = _mm_add_epi32(qv8, SET(12, SC));
-	qv7 = _mm_add_epi32(qv7, SET( 8, SC));
-	qv6 = _mm_add_epi32(qv6, SET( 4, SC));
-	qv5 = _mm_add_epi32(qv5, SET( 0, SC));
+        qv8 = _mm_add_epi32(qv8, SET(12, SC));
+        qv7 = _mm_add_epi32(qv7, SET( 8, SC));
+        qv6 = _mm_add_epi32(qv6, SET( 4, SC));
+        qv5 = _mm_add_epi32(qv5, SET( 0, SC));
 
-	Rv[H+3] = _mm_add_epi32(Rv[H+3], qv8);
-	Rv[H+2] = _mm_add_epi32(Rv[H+2], qv7);
-	Rv[H+1] = _mm_add_epi32(Rv[H+1], qv6);
-	Rv[H+0] = _mm_add_epi32(Rv[H+0], qv5);
+        Rv[H+3] = _mm_add_epi32(Rv[H+3], qv8);
+        Rv[H+2] = _mm_add_epi32(Rv[H+2], qv7);
+        Rv[H+1] = _mm_add_epi32(Rv[H+1], qv6);
+        Rv[H+0] = _mm_add_epi32(Rv[H+0], qv5);
       }
     }
 
@@ -467,18 +467,18 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
 #endif // disable SSE4 encoder
 
 unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz) {
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz) {
     if (in_size < 16) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -488,32 +488,32 @@ unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
     uint32_t s3[TOTFREQ] __attribute__((aligned(32))); // For TF_SHIFT <= 12
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     // Precompute reverse lookup of frequency.
     uint32_t F[256] = {0}, fsum;
     int fsz = decode_freq(cp, cp_end, F, &fsum);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     normalise_freq_shift(F, fsum, TOTFREQ);
 
     // Build symbols; fixme, do as part of decode, see the _d variant
     if (rans_F_to_s3(F, TF_SHIFT, s3))
-	goto err;
+        goto err;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     int z;
     RansState R[NX] __attribute__((aligned(32)));
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &cp);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &cp);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     uint16_t *sp = (uint16_t *)cp;
@@ -526,263 +526,263 @@ unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
 
     uint8_t overflow[72+64] = {0};
     for (i=0; i < out_end; i+=NX) {
-	//for (z = 0; z < NX; z++)
-	//  m[z] = R[z] & mask;
-	__m128i masked1 = _mm_and_si128(Rv1, maskv);
-	__m128i masked2 = _mm_and_si128(Rv2, maskv);
-	__m128i masked3 = _mm_and_si128(Rv3, maskv);
-	__m128i masked4 = _mm_and_si128(Rv4, maskv);
+        //for (z = 0; z < NX; z++)
+        //  m[z] = R[z] & mask;
+        __m128i masked1 = _mm_and_si128(Rv1, maskv);
+        __m128i masked2 = _mm_and_si128(Rv2, maskv);
+        __m128i masked3 = _mm_and_si128(Rv3, maskv);
+        __m128i masked4 = _mm_and_si128(Rv4, maskv);
 
-	//  S[z] = s3[m[z]];
-	__m128i Sv1 = _mm_i32gather_epi32x((int *)s3, masked1, sizeof(*s3));
-	__m128i Sv2 = _mm_i32gather_epi32x((int *)s3, masked2, sizeof(*s3));
-	__m128i Sv3 = _mm_i32gather_epi32x((int *)s3, masked3, sizeof(*s3));
-	__m128i Sv4 = _mm_i32gather_epi32x((int *)s3, masked4, sizeof(*s3));
+        //  S[z] = s3[m[z]];
+        __m128i Sv1 = _mm_i32gather_epi32x((int *)s3, masked1, sizeof(*s3));
+        __m128i Sv2 = _mm_i32gather_epi32x((int *)s3, masked2, sizeof(*s3));
+        __m128i Sv3 = _mm_i32gather_epi32x((int *)s3, masked3, sizeof(*s3));
+        __m128i Sv4 = _mm_i32gather_epi32x((int *)s3, masked4, sizeof(*s3));
 
-	//  f[z] = S[z]>>(TF_SHIFT+8);
-	__m128i fv1 = _mm_srli_epi32(Sv1, TF_SHIFT+8);
-	__m128i fv2 = _mm_srli_epi32(Sv2, TF_SHIFT+8);
-	__m128i fv3 = _mm_srli_epi32(Sv3, TF_SHIFT+8);
-	__m128i fv4 = _mm_srli_epi32(Sv4, TF_SHIFT+8);
+        //  f[z] = S[z]>>(TF_SHIFT+8);
+        __m128i fv1 = _mm_srli_epi32(Sv1, TF_SHIFT+8);
+        __m128i fv2 = _mm_srli_epi32(Sv2, TF_SHIFT+8);
+        __m128i fv3 = _mm_srli_epi32(Sv3, TF_SHIFT+8);
+        __m128i fv4 = _mm_srli_epi32(Sv4, TF_SHIFT+8);
 
-	//  b[z] = (S[z]>>8) & mask;
-	__m128i bv1 = _mm_and_si128(_mm_srli_epi32(Sv1, 8), maskv);
-	__m128i bv2 = _mm_and_si128(_mm_srli_epi32(Sv2, 8), maskv);
-	__m128i bv3 = _mm_and_si128(_mm_srli_epi32(Sv3, 8), maskv);
-	__m128i bv4 = _mm_and_si128(_mm_srli_epi32(Sv4, 8), maskv);
+        //  b[z] = (S[z]>>8) & mask;
+        __m128i bv1 = _mm_and_si128(_mm_srli_epi32(Sv1, 8), maskv);
+        __m128i bv2 = _mm_and_si128(_mm_srli_epi32(Sv2, 8), maskv);
+        __m128i bv3 = _mm_and_si128(_mm_srli_epi32(Sv3, 8), maskv);
+        __m128i bv4 = _mm_and_si128(_mm_srli_epi32(Sv4, 8), maskv);
 
-	//  s[z] = S[z] & 0xff;
-	__m128i sv1 = _mm_and_si128(Sv1, _mm_set1_epi32(0xff));
-	__m128i sv2 = _mm_and_si128(Sv2, _mm_set1_epi32(0xff));
-	__m128i sv3 = _mm_and_si128(Sv3, _mm_set1_epi32(0xff));
-	__m128i sv4 = _mm_and_si128(Sv4, _mm_set1_epi32(0xff));
+        //  s[z] = S[z] & 0xff;
+        __m128i sv1 = _mm_and_si128(Sv1, _mm_set1_epi32(0xff));
+        __m128i sv2 = _mm_and_si128(Sv2, _mm_set1_epi32(0xff));
+        __m128i sv3 = _mm_and_si128(Sv3, _mm_set1_epi32(0xff));
+        __m128i sv4 = _mm_and_si128(Sv4, _mm_set1_epi32(0xff));
 
-	//  R[z] = f[z] * (R[z] >> TF_SHIFT) + b[z];
-	Rv1 = _mm_add_epi32(
-	          _mm_mullo_epi32(
-		      _mm_srli_epi32(Rv1,TF_SHIFT), fv1), bv1);
-	Rv2 = _mm_add_epi32(
-		  _mm_mullo_epi32(
-		      _mm_srli_epi32(Rv2,TF_SHIFT), fv2), bv2);
-	Rv3 = _mm_add_epi32(
-	          _mm_mullo_epi32(
-		      _mm_srli_epi32(Rv3,TF_SHIFT), fv3), bv3);
-	Rv4 = _mm_add_epi32(
-		  _mm_mullo_epi32(
-		      _mm_srli_epi32(Rv4,TF_SHIFT), fv4), bv4);
+        //  R[z] = f[z] * (R[z] >> TF_SHIFT) + b[z];
+        Rv1 = _mm_add_epi32(
+                  _mm_mullo_epi32(
+                      _mm_srli_epi32(Rv1,TF_SHIFT), fv1), bv1);
+        Rv2 = _mm_add_epi32(
+                  _mm_mullo_epi32(
+                      _mm_srli_epi32(Rv2,TF_SHIFT), fv2), bv2);
+        Rv3 = _mm_add_epi32(
+                  _mm_mullo_epi32(
+                      _mm_srli_epi32(Rv3,TF_SHIFT), fv3), bv3);
+        Rv4 = _mm_add_epi32(
+                  _mm_mullo_epi32(
+                      _mm_srli_epi32(Rv4,TF_SHIFT), fv4), bv4);
 
-	// Tricky one:  out[i+z] = s[z];
-	//             ---d---c ---b---a  sv1
-	//             ---h---g ---f---e  sv2
-	// packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
-	// packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
-	sv1 = _mm_packus_epi32(sv1, sv2);
-	sv3 = _mm_packus_epi32(sv3, sv4);
-	sv1 = _mm_packus_epi16(sv1, sv3);
+        // Tricky one:  out[i+z] = s[z];
+        //             ---d---c ---b---a  sv1
+        //             ---h---g ---f---e  sv2
+        // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
+        // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
+        sv1 = _mm_packus_epi32(sv1, sv2);
+        sv3 = _mm_packus_epi32(sv3, sv4);
+        sv1 = _mm_packus_epi16(sv1, sv3);
 
-	// c =  R[z] < RANS_BYTE_L;
-	// A little tricky as we only have signed comparisons.
-	// See https://stackoverflow.com/questions/32945410/sse2-intrinsics-comparing-unsigned-integers
+        // c =  R[z] < RANS_BYTE_L;
+        // A little tricky as we only have signed comparisons.
+        // See https://stackoverflow.com/questions/32945410/sse2-intrinsics-comparing-unsigned-integers
 
 #define _mm_cmplt_epu32_imm(a,b) _mm_andnot_si128(_mm_cmpeq_epi32(_mm_max_epu32((a),_mm_set1_epi32(b)), (a)), _mm_set1_epi32(-1));
 
 //#define _mm_cmplt_epu32_imm(a,b) _mm_cmpgt_epi32(_mm_set1_epi32((b)-0x80000000), _mm_xor_si128((a), _mm_set1_epi32(0x80000000)))
 
-	__m128i renorm_mask1, renorm_mask2, renorm_mask3, renorm_mask4;
-	renorm_mask1 = _mm_cmplt_epu32_imm(Rv1, RANS_BYTE_L);
-	renorm_mask2 = _mm_cmplt_epu32_imm(Rv2, RANS_BYTE_L);
-	renorm_mask3 = _mm_cmplt_epu32_imm(Rv3, RANS_BYTE_L);
-	renorm_mask4 = _mm_cmplt_epu32_imm(Rv4, RANS_BYTE_L);
+        __m128i renorm_mask1, renorm_mask2, renorm_mask3, renorm_mask4;
+        renorm_mask1 = _mm_cmplt_epu32_imm(Rv1, RANS_BYTE_L);
+        renorm_mask2 = _mm_cmplt_epu32_imm(Rv2, RANS_BYTE_L);
+        renorm_mask3 = _mm_cmplt_epu32_imm(Rv3, RANS_BYTE_L);
+        renorm_mask4 = _mm_cmplt_epu32_imm(Rv4, RANS_BYTE_L);
 
 //#define P(A,B,C,D) ((A)+((B)<<2) + ((C)<<4) + ((D)<<6))
-#define P(A,B,C,D) 				\
-	{ A+0,A+1,A+2,A+3,			\
-          B+0,B+1,B+2,B+3,			\
-	  C+0,C+1,C+2,C+3,			\
-	  D+0,D+1,D+2,D+3}
+#define P(A,B,C,D)                              \
+        { A+0,A+1,A+2,A+3,                      \
+          B+0,B+1,B+2,B+3,                      \
+          C+0,C+1,C+2,C+3,                      \
+          D+0,D+1,D+2,D+3}
 #ifdef _
 #undef _
 #endif
 #define _ 0x80
-	uint8_t pidx[16][16] = {
-	    P(_,_,_,_),
-	    P(0,_,_,_),
-	    P(_,0,_,_),
-	    P(0,4,_,_),
+        uint8_t pidx[16][16] = {
+            P(_,_,_,_),
+            P(0,_,_,_),
+            P(_,0,_,_),
+            P(0,4,_,_),
 
-	    P(_,_,0,_),
-	    P(0,_,4,_),
-	    P(_,0,4,_),
-	    P(0,4,8,_),
+            P(_,_,0,_),
+            P(0,_,4,_),
+            P(_,0,4,_),
+            P(0,4,8,_),
 
-	    P(_,_,_,0),
-	    P(0,_,_,4),
-	    P(_,0,_,4),
-	    P(0,4,_,8),
+            P(_,_,_,0),
+            P(0,_,_,4),
+            P(_,0,_,4),
+            P(0,4,_,8),
 
-	    P(_,_,0,4),
-	    P(0,_,4,8),
-	    P(_,0,4,8),
-	    P(0,4,8,12),
-	};
+            P(_,_,0,4),
+            P(0,_,4,8),
+            P(_,0,4,8),
+            P(0,4,8,12),
+        };
 #undef _
 
-	// Protect against running off the end of in buffer.
-	// We copy it to a worst-case local buffer when near the end.
-	// 72 = 7*8(imask1..7) + 16;  worse case for 8th _mm_loadu_si128 call.
-	// An extra 64 bytes is to avoid triggering this multiple times
-	// after we swap sp/cp_end over.
-	if ((uint8_t *)sp+72 > cp_end) {
-	    memmove(overflow, sp, cp_end - (uint8_t *)sp);
-	    sp = (uint16_t *)overflow;
-	    cp_end = (uint8_t *)overflow + sizeof(overflow);
-	}
+        // Protect against running off the end of in buffer.
+        // We copy it to a worst-case local buffer when near the end.
+        // 72 = 7*8(imask1..7) + 16;  worse case for 8th _mm_loadu_si128 call.
+        // An extra 64 bytes is to avoid triggering this multiple times
+        // after we swap sp/cp_end over.
+        if ((uint8_t *)sp+72 > cp_end) {
+            memmove(overflow, sp, cp_end - (uint8_t *)sp);
+            sp = (uint16_t *)overflow;
+            cp_end = (uint8_t *)overflow + sizeof(overflow);
+        }
 
-	// Shuffle the renorm values to correct lanes and incr sp pointer
-	__m128i Vv1 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	unsigned int imask1 = _mm_movemask_ps((__m128)renorm_mask1);
-	Vv1 = _mm_shuffle_epi8(Vv1, _mm_load_si128((__m128i*)pidx[imask1]));
-	sp += _mm_popcnt_u32(imask1);
+        // Shuffle the renorm values to correct lanes and incr sp pointer
+        __m128i Vv1 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        unsigned int imask1 = _mm_movemask_ps((__m128)renorm_mask1);
+        Vv1 = _mm_shuffle_epi8(Vv1, _mm_load_si128((__m128i*)pidx[imask1]));
+        sp += _mm_popcnt_u32(imask1);
 
-	__m128i Vv2 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	unsigned int imask2 = _mm_movemask_ps((__m128)renorm_mask2);
-	sp += _mm_popcnt_u32(imask2);
-	Vv2 = _mm_shuffle_epi8(Vv2, _mm_load_si128((__m128i*)pidx[imask2]));
+        __m128i Vv2 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        unsigned int imask2 = _mm_movemask_ps((__m128)renorm_mask2);
+        sp += _mm_popcnt_u32(imask2);
+        Vv2 = _mm_shuffle_epi8(Vv2, _mm_load_si128((__m128i*)pidx[imask2]));
 
-	__m128i Vv3 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	unsigned int imask3 = _mm_movemask_ps((__m128)renorm_mask3);
-	Vv3 = _mm_shuffle_epi8(Vv3, _mm_load_si128((__m128i*)pidx[imask3]));
-	sp += _mm_popcnt_u32(imask3);
+        __m128i Vv3 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        unsigned int imask3 = _mm_movemask_ps((__m128)renorm_mask3);
+        Vv3 = _mm_shuffle_epi8(Vv3, _mm_load_si128((__m128i*)pidx[imask3]));
+        sp += _mm_popcnt_u32(imask3);
 
-	__m128i Vv4 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	unsigned int imask4 = _mm_movemask_ps((__m128)renorm_mask4);
-	sp += _mm_popcnt_u32(imask4);
-	Vv4 = _mm_shuffle_epi8(Vv4, _mm_load_si128((__m128i*)pidx[imask4]));
+        __m128i Vv4 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        unsigned int imask4 = _mm_movemask_ps((__m128)renorm_mask4);
+        sp += _mm_popcnt_u32(imask4);
+        Vv4 = _mm_shuffle_epi8(Vv4, _mm_load_si128((__m128i*)pidx[imask4]));
 
-	__m128i Yv1 = _mm_slli_epi32(Rv1, 16);
-	__m128i Yv2 = _mm_slli_epi32(Rv2, 16);
-	__m128i Yv3 = _mm_slli_epi32(Rv3, 16);
-	__m128i Yv4 = _mm_slli_epi32(Rv4, 16);
+        __m128i Yv1 = _mm_slli_epi32(Rv1, 16);
+        __m128i Yv2 = _mm_slli_epi32(Rv2, 16);
+        __m128i Yv3 = _mm_slli_epi32(Rv3, 16);
+        __m128i Yv4 = _mm_slli_epi32(Rv4, 16);
 
-	// y = (R[z] << 16) | V[z];
-	Yv1 = _mm_or_si128(Yv1, Vv1);
-	Yv2 = _mm_or_si128(Yv2, Vv2);
-	Yv3 = _mm_or_si128(Yv3, Vv3);
-	Yv4 = _mm_or_si128(Yv4, Vv4);
+        // y = (R[z] << 16) | V[z];
+        Yv1 = _mm_or_si128(Yv1, Vv1);
+        Yv2 = _mm_or_si128(Yv2, Vv2);
+        Yv3 = _mm_or_si128(Yv3, Vv3);
+        Yv4 = _mm_or_si128(Yv4, Vv4);
 
-	// R[z] = c ? Y[z] : R[z];
-	Rv1 = _mm_blendv_epi8(Rv1, Yv1, renorm_mask1);
-	Rv2 = _mm_blendv_epi8(Rv2, Yv2, renorm_mask2);
-	Rv3 = _mm_blendv_epi8(Rv3, Yv3, renorm_mask3);
-	Rv4 = _mm_blendv_epi8(Rv4, Yv4, renorm_mask4);
+        // R[z] = c ? Y[z] : R[z];
+        Rv1 = _mm_blendv_epi8(Rv1, Yv1, renorm_mask1);
+        Rv2 = _mm_blendv_epi8(Rv2, Yv2, renorm_mask2);
+        Rv3 = _mm_blendv_epi8(Rv3, Yv3, renorm_mask3);
+        Rv4 = _mm_blendv_epi8(Rv4, Yv4, renorm_mask4);
 
-	// ------------------------------------------------------------
+        // ------------------------------------------------------------
 
-	//  m[z] = R[z] & mask;
-	__m128i masked5 = _mm_and_si128(Rv5, maskv);
-	__m128i masked6 = _mm_and_si128(Rv6, maskv);
-	__m128i masked7 = _mm_and_si128(Rv7, maskv);
-	__m128i masked8 = _mm_and_si128(Rv8, maskv);
+        //  m[z] = R[z] & mask;
+        __m128i masked5 = _mm_and_si128(Rv5, maskv);
+        __m128i masked6 = _mm_and_si128(Rv6, maskv);
+        __m128i masked7 = _mm_and_si128(Rv7, maskv);
+        __m128i masked8 = _mm_and_si128(Rv8, maskv);
 
-	//  S[z] = s3[m[z]];
-	__m128i Sv5 = _mm_i32gather_epi32x((int *)s3, masked5, sizeof(*s3));
-	__m128i Sv6 = _mm_i32gather_epi32x((int *)s3, masked6, sizeof(*s3));
-	__m128i Sv7 = _mm_i32gather_epi32x((int *)s3, masked7, sizeof(*s3));
-	__m128i Sv8 = _mm_i32gather_epi32x((int *)s3, masked8, sizeof(*s3));
+        //  S[z] = s3[m[z]];
+        __m128i Sv5 = _mm_i32gather_epi32x((int *)s3, masked5, sizeof(*s3));
+        __m128i Sv6 = _mm_i32gather_epi32x((int *)s3, masked6, sizeof(*s3));
+        __m128i Sv7 = _mm_i32gather_epi32x((int *)s3, masked7, sizeof(*s3));
+        __m128i Sv8 = _mm_i32gather_epi32x((int *)s3, masked8, sizeof(*s3));
 
-	//  f[z] = S[z]>>(TF_SHIFT+8);
-	__m128i fv5 = _mm_srli_epi32(Sv5, TF_SHIFT+8);
-	__m128i fv6 = _mm_srli_epi32(Sv6, TF_SHIFT+8);
-	__m128i fv7 = _mm_srli_epi32(Sv7, TF_SHIFT+8);
-	__m128i fv8 = _mm_srli_epi32(Sv8, TF_SHIFT+8);
+        //  f[z] = S[z]>>(TF_SHIFT+8);
+        __m128i fv5 = _mm_srli_epi32(Sv5, TF_SHIFT+8);
+        __m128i fv6 = _mm_srli_epi32(Sv6, TF_SHIFT+8);
+        __m128i fv7 = _mm_srli_epi32(Sv7, TF_SHIFT+8);
+        __m128i fv8 = _mm_srli_epi32(Sv8, TF_SHIFT+8);
 
-	//  b[z] = (S[z]>>8) & mask;
-	__m128i bv5 = _mm_and_si128(_mm_srli_epi32(Sv5, 8), maskv);
-	__m128i bv6 = _mm_and_si128(_mm_srli_epi32(Sv6, 8), maskv);
-	__m128i bv7 = _mm_and_si128(_mm_srli_epi32(Sv7, 8), maskv);
-	__m128i bv8 = _mm_and_si128(_mm_srli_epi32(Sv8, 8), maskv);
+        //  b[z] = (S[z]>>8) & mask;
+        __m128i bv5 = _mm_and_si128(_mm_srli_epi32(Sv5, 8), maskv);
+        __m128i bv6 = _mm_and_si128(_mm_srli_epi32(Sv6, 8), maskv);
+        __m128i bv7 = _mm_and_si128(_mm_srli_epi32(Sv7, 8), maskv);
+        __m128i bv8 = _mm_and_si128(_mm_srli_epi32(Sv8, 8), maskv);
 
-	//  s[z] = S[z] & 0xff;
-	__m128i sv5 = _mm_and_si128(Sv5, _mm_set1_epi32(0xff));
-	__m128i sv6 = _mm_and_si128(Sv6, _mm_set1_epi32(0xff));
-	__m128i sv7 = _mm_and_si128(Sv7, _mm_set1_epi32(0xff));
-	__m128i sv8 = _mm_and_si128(Sv8, _mm_set1_epi32(0xff));
+        //  s[z] = S[z] & 0xff;
+        __m128i sv5 = _mm_and_si128(Sv5, _mm_set1_epi32(0xff));
+        __m128i sv6 = _mm_and_si128(Sv6, _mm_set1_epi32(0xff));
+        __m128i sv7 = _mm_and_si128(Sv7, _mm_set1_epi32(0xff));
+        __m128i sv8 = _mm_and_si128(Sv8, _mm_set1_epi32(0xff));
 
-	//  R[z] = f[z] * (R[z] >> TF_SHIFT) + b[z];
-	Rv5 = _mm_add_epi32(
-	          _mm_mullo_epi32(
-		      _mm_srli_epi32(Rv5,TF_SHIFT), fv5), bv5);
-	Rv6 = _mm_add_epi32(
-		  _mm_mullo_epi32(
-		      _mm_srli_epi32(Rv6,TF_SHIFT), fv6), bv6);
-	Rv7 = _mm_add_epi32(
-	          _mm_mullo_epi32(
-		      _mm_srli_epi32(Rv7,TF_SHIFT), fv7), bv7);
-	Rv8 = _mm_add_epi32(
-		  _mm_mullo_epi32(
-		      _mm_srli_epi32(Rv8,TF_SHIFT), fv8), bv8);
+        //  R[z] = f[z] * (R[z] >> TF_SHIFT) + b[z];
+        Rv5 = _mm_add_epi32(
+                  _mm_mullo_epi32(
+                      _mm_srli_epi32(Rv5,TF_SHIFT), fv5), bv5);
+        Rv6 = _mm_add_epi32(
+                  _mm_mullo_epi32(
+                      _mm_srli_epi32(Rv6,TF_SHIFT), fv6), bv6);
+        Rv7 = _mm_add_epi32(
+                  _mm_mullo_epi32(
+                      _mm_srli_epi32(Rv7,TF_SHIFT), fv7), bv7);
+        Rv8 = _mm_add_epi32(
+                  _mm_mullo_epi32(
+                      _mm_srli_epi32(Rv8,TF_SHIFT), fv8), bv8);
 
-	// Tricky one:  out[i+z] = s[z];
-	//             ---d---c ---b---a  sv1
-	//             ---h---g ---f---e  sv2
-	// packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
-	// packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
-	sv5 = _mm_packus_epi32(sv5, sv6);
-	sv7 = _mm_packus_epi32(sv7, sv8);
-	sv5 = _mm_packus_epi16(sv5, sv7);
+        // Tricky one:  out[i+z] = s[z];
+        //             ---d---c ---b---a  sv1
+        //             ---h---g ---f---e  sv2
+        // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
+        // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
+        sv5 = _mm_packus_epi32(sv5, sv6);
+        sv7 = _mm_packus_epi32(sv7, sv8);
+        sv5 = _mm_packus_epi16(sv5, sv7);
 
-	// c =  R[z] < RANS_BYTE_L;
-	__m128i renorm_mask5, renorm_mask6, renorm_mask7, renorm_mask8;
-	renorm_mask5 = _mm_cmplt_epu32_imm(Rv5, RANS_BYTE_L);
-	renorm_mask6 = _mm_cmplt_epu32_imm(Rv6, RANS_BYTE_L);
-	renorm_mask7 = _mm_cmplt_epu32_imm(Rv7, RANS_BYTE_L);
-	renorm_mask8 = _mm_cmplt_epu32_imm(Rv8, RANS_BYTE_L);
-	
-	// Shuffle the renorm values to correct lanes and incr sp pointer
-	__m128i Vv5 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	unsigned int imask5 = _mm_movemask_ps((__m128)renorm_mask5);
-	Vv5 = _mm_shuffle_epi8(Vv5, _mm_load_si128((__m128i*)pidx[imask5]));
-	sp += _mm_popcnt_u32(imask5);
+        // c =  R[z] < RANS_BYTE_L;
+        __m128i renorm_mask5, renorm_mask6, renorm_mask7, renorm_mask8;
+        renorm_mask5 = _mm_cmplt_epu32_imm(Rv5, RANS_BYTE_L);
+        renorm_mask6 = _mm_cmplt_epu32_imm(Rv6, RANS_BYTE_L);
+        renorm_mask7 = _mm_cmplt_epu32_imm(Rv7, RANS_BYTE_L);
+        renorm_mask8 = _mm_cmplt_epu32_imm(Rv8, RANS_BYTE_L);
+        
+        // Shuffle the renorm values to correct lanes and incr sp pointer
+        __m128i Vv5 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        unsigned int imask5 = _mm_movemask_ps((__m128)renorm_mask5);
+        Vv5 = _mm_shuffle_epi8(Vv5, _mm_load_si128((__m128i*)pidx[imask5]));
+        sp += _mm_popcnt_u32(imask5);
 
-	__m128i Vv6 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	unsigned int imask6 = _mm_movemask_ps((__m128)renorm_mask6);
-	sp += _mm_popcnt_u32(imask6);
-	Vv6 = _mm_shuffle_epi8(Vv6, _mm_load_si128((__m128i*)pidx[imask6]));
+        __m128i Vv6 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        unsigned int imask6 = _mm_movemask_ps((__m128)renorm_mask6);
+        sp += _mm_popcnt_u32(imask6);
+        Vv6 = _mm_shuffle_epi8(Vv6, _mm_load_si128((__m128i*)pidx[imask6]));
 
-	__m128i Vv7 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	unsigned int imask7 = _mm_movemask_ps((__m128)renorm_mask7);
-	Vv7 = _mm_shuffle_epi8(Vv7, _mm_load_si128((__m128i*)pidx[imask7]));
-	sp += _mm_popcnt_u32(imask7);
+        __m128i Vv7 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        unsigned int imask7 = _mm_movemask_ps((__m128)renorm_mask7);
+        Vv7 = _mm_shuffle_epi8(Vv7, _mm_load_si128((__m128i*)pidx[imask7]));
+        sp += _mm_popcnt_u32(imask7);
 
-	__m128i Vv8 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	unsigned int imask8 = _mm_movemask_ps((__m128)renorm_mask8);
-	sp += _mm_popcnt_u32(imask8);
-	Vv8 = _mm_shuffle_epi8(Vv8, _mm_load_si128((__m128i*)pidx[imask8]));
+        __m128i Vv8 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+        unsigned int imask8 = _mm_movemask_ps((__m128)renorm_mask8);
+        sp += _mm_popcnt_u32(imask8);
+        Vv8 = _mm_shuffle_epi8(Vv8, _mm_load_si128((__m128i*)pidx[imask8]));
 
-	__m128i Yv5 = _mm_slli_epi32(Rv5, 16);
-	__m128i Yv6 = _mm_slli_epi32(Rv6, 16);
-	__m128i Yv7 = _mm_slli_epi32(Rv7, 16);
-	__m128i Yv8 = _mm_slli_epi32(Rv8, 16);
+        __m128i Yv5 = _mm_slli_epi32(Rv5, 16);
+        __m128i Yv6 = _mm_slli_epi32(Rv6, 16);
+        __m128i Yv7 = _mm_slli_epi32(Rv7, 16);
+        __m128i Yv8 = _mm_slli_epi32(Rv8, 16);
 
-	// y = (R[z] << 16) | V[z];
-	Yv5 = _mm_or_si128(Yv5, Vv5);
-	Yv6 = _mm_or_si128(Yv6, Vv6);
-	Yv7 = _mm_or_si128(Yv7, Vv7);
-	Yv8 = _mm_or_si128(Yv8, Vv8);
+        // y = (R[z] << 16) | V[z];
+        Yv5 = _mm_or_si128(Yv5, Vv5);
+        Yv6 = _mm_or_si128(Yv6, Vv6);
+        Yv7 = _mm_or_si128(Yv7, Vv7);
+        Yv8 = _mm_or_si128(Yv8, Vv8);
 
-	// R[z] = c ? Y[z] : R[z];
-	Rv5 = _mm_blendv_epi8(Rv5, Yv5, renorm_mask5);
-	Rv6 = _mm_blendv_epi8(Rv6, Yv6, renorm_mask6);
-	Rv7 = _mm_blendv_epi8(Rv7, Yv7, renorm_mask7);
-	Rv8 = _mm_blendv_epi8(Rv8, Yv8, renorm_mask8);
+        // R[z] = c ? Y[z] : R[z];
+        Rv5 = _mm_blendv_epi8(Rv5, Yv5, renorm_mask5);
+        Rv6 = _mm_blendv_epi8(Rv6, Yv6, renorm_mask6);
+        Rv7 = _mm_blendv_epi8(Rv7, Yv7, renorm_mask7);
+        Rv8 = _mm_blendv_epi8(Rv8, Yv8, renorm_mask8);
 
-	// Maybe just a store128 instead?
-	_mm_storeu_si128((__m128i *)&out[i+ 0], sv1);
-	_mm_storeu_si128((__m128i *)&out[i+16], sv5);
-//	*(uint64_t *)&out[i+ 0] = _mm_extract_epi64(sv1, 0);
-//	*(uint64_t *)&out[i+ 8] = _mm_extract_epi64(sv1, 1);
-//	*(uint64_t *)&out[i+16] = _mm_extract_epi64(sv5, 0);
-//	*(uint64_t *)&out[i+24] = _mm_extract_epi64(sv5, 1);
+        // Maybe just a store128 instead?
+        _mm_storeu_si128((__m128i *)&out[i+ 0], sv1);
+        _mm_storeu_si128((__m128i *)&out[i+16], sv5);
+//      *(uint64_t *)&out[i+ 0] = _mm_extract_epi64(sv1, 0);
+//      *(uint64_t *)&out[i+ 8] = _mm_extract_epi64(sv1, 1);
+//      *(uint64_t *)&out[i+16] = _mm_extract_epi64(sv5, 0);
+//      *(uint64_t *)&out[i+24] = _mm_extract_epi64(sv5, 1);
     }
 
     STORE128(Rv, R);
@@ -809,189 +809,189 @@ unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
  * can then flush to out in 1KB blocks.
  */
 static inline void transpose_and_copy(uint8_t *out, int iN[32],
-				      uint8_t t[32][32]) {
+                                      uint8_t t[32][32]) {
     int z;
 #ifdef UBSAN
     // Simplified version to avoid undefined behaviour sanitiser warnings.
     for (z = 0; z < NX; z++) {
-	int k;
-	for (k = 0; k < 32; k++)
-	    out[iN[z]+k] = t[k][z];
-	iN[z] += 32;
+        int k;
+        for (k = 0; k < 32; k++)
+            out[iN[z]+k] = t[k][z];
+        iN[z] += 32;
     }
 #else
     // Unaligned access.  We know we can get away with this as this
     // code is only ever executed on x86 platforms which permit this.
     for (z = 0; z < NX; z+=4) {
-	*(uint64_t *)&out[iN[z]] =
-	    ((uint64_t)(t[0][z])<< 0) +
-	    ((uint64_t)(t[1][z])<< 8) +
-	    ((uint64_t)(t[2][z])<<16) +
-	    ((uint64_t)(t[3][z])<<24) +
-	    ((uint64_t)(t[4][z])<<32) +
-	    ((uint64_t)(t[5][z])<<40) +
-	    ((uint64_t)(t[6][z])<<48) +
-	    ((uint64_t)(t[7][z])<<56);
-	*(uint64_t *)&out[iN[z+1]] =
-	    ((uint64_t)(t[0][z+1])<< 0) +
-	    ((uint64_t)(t[1][z+1])<< 8) +
-	    ((uint64_t)(t[2][z+1])<<16) +
-	    ((uint64_t)(t[3][z+1])<<24) +
-	    ((uint64_t)(t[4][z+1])<<32) +
-	    ((uint64_t)(t[5][z+1])<<40) +
-	    ((uint64_t)(t[6][z+1])<<48) +
-	    ((uint64_t)(t[7][z+1])<<56);
-	*(uint64_t *)&out[iN[z+2]] =
-	    ((uint64_t)(t[0][z+2])<< 0) +
-	    ((uint64_t)(t[1][z+2])<< 8) +
-	    ((uint64_t)(t[2][z+2])<<16) +
-	    ((uint64_t)(t[3][z+2])<<24) +
-	    ((uint64_t)(t[4][z+2])<<32) +
-	    ((uint64_t)(t[5][z+2])<<40) +
-	    ((uint64_t)(t[6][z+2])<<48) +
-	    ((uint64_t)(t[7][z+2])<<56);
-	*(uint64_t *)&out[iN[z+3]] =
-	    ((uint64_t)(t[0][z+3])<< 0) +
-	    ((uint64_t)(t[1][z+3])<< 8) +
-	    ((uint64_t)(t[2][z+3])<<16) +
-	    ((uint64_t)(t[3][z+3])<<24) +
-	    ((uint64_t)(t[4][z+3])<<32) +
-	    ((uint64_t)(t[5][z+3])<<40) +
-	    ((uint64_t)(t[6][z+3])<<48) +
-	    ((uint64_t)(t[7][z+3])<<56);
+        *(uint64_t *)&out[iN[z]] =
+            ((uint64_t)(t[0][z])<< 0) +
+            ((uint64_t)(t[1][z])<< 8) +
+            ((uint64_t)(t[2][z])<<16) +
+            ((uint64_t)(t[3][z])<<24) +
+            ((uint64_t)(t[4][z])<<32) +
+            ((uint64_t)(t[5][z])<<40) +
+            ((uint64_t)(t[6][z])<<48) +
+            ((uint64_t)(t[7][z])<<56);
+        *(uint64_t *)&out[iN[z+1]] =
+            ((uint64_t)(t[0][z+1])<< 0) +
+            ((uint64_t)(t[1][z+1])<< 8) +
+            ((uint64_t)(t[2][z+1])<<16) +
+            ((uint64_t)(t[3][z+1])<<24) +
+            ((uint64_t)(t[4][z+1])<<32) +
+            ((uint64_t)(t[5][z+1])<<40) +
+            ((uint64_t)(t[6][z+1])<<48) +
+            ((uint64_t)(t[7][z+1])<<56);
+        *(uint64_t *)&out[iN[z+2]] =
+            ((uint64_t)(t[0][z+2])<< 0) +
+            ((uint64_t)(t[1][z+2])<< 8) +
+            ((uint64_t)(t[2][z+2])<<16) +
+            ((uint64_t)(t[3][z+2])<<24) +
+            ((uint64_t)(t[4][z+2])<<32) +
+            ((uint64_t)(t[5][z+2])<<40) +
+            ((uint64_t)(t[6][z+2])<<48) +
+            ((uint64_t)(t[7][z+2])<<56);
+        *(uint64_t *)&out[iN[z+3]] =
+            ((uint64_t)(t[0][z+3])<< 0) +
+            ((uint64_t)(t[1][z+3])<< 8) +
+            ((uint64_t)(t[2][z+3])<<16) +
+            ((uint64_t)(t[3][z+3])<<24) +
+            ((uint64_t)(t[4][z+3])<<32) +
+            ((uint64_t)(t[5][z+3])<<40) +
+            ((uint64_t)(t[6][z+3])<<48) +
+            ((uint64_t)(t[7][z+3])<<56);
 
-	*(uint64_t *)&out[iN[z]+8] =
-	    ((uint64_t)(t[8+0][z])<< 0) +
-	    ((uint64_t)(t[8+1][z])<< 8) +
-	    ((uint64_t)(t[8+2][z])<<16) +
-	    ((uint64_t)(t[8+3][z])<<24) +
-	    ((uint64_t)(t[8+4][z])<<32) +
-	    ((uint64_t)(t[8+5][z])<<40) +
-	    ((uint64_t)(t[8+6][z])<<48) +
-	    ((uint64_t)(t[8+7][z])<<56);
-	*(uint64_t *)&out[iN[z+1]+8] =
-	    ((uint64_t)(t[8+0][z+1])<< 0) +
-	    ((uint64_t)(t[8+1][z+1])<< 8) +
-	    ((uint64_t)(t[8+2][z+1])<<16) +
-	    ((uint64_t)(t[8+3][z+1])<<24) +
-	    ((uint64_t)(t[8+4][z+1])<<32) +
-	    ((uint64_t)(t[8+5][z+1])<<40) +
-	    ((uint64_t)(t[8+6][z+1])<<48) +
-	    ((uint64_t)(t[8+7][z+1])<<56);
-	*(uint64_t *)&out[iN[z+2]+8] =
-	    ((uint64_t)(t[8+0][z+2])<< 0) +
-	    ((uint64_t)(t[8+1][z+2])<< 8) +
-	    ((uint64_t)(t[8+2][z+2])<<16) +
-	    ((uint64_t)(t[8+3][z+2])<<24) +
-	    ((uint64_t)(t[8+4][z+2])<<32) +
-	    ((uint64_t)(t[8+5][z+2])<<40) +
-	    ((uint64_t)(t[8+6][z+2])<<48) +
-	    ((uint64_t)(t[8+7][z+2])<<56);
-	*(uint64_t *)&out[iN[z+3]+8] =
-	    ((uint64_t)(t[8+0][z+3])<< 0) +
-	    ((uint64_t)(t[8+1][z+3])<< 8) +
-	    ((uint64_t)(t[8+2][z+3])<<16) +
-	    ((uint64_t)(t[8+3][z+3])<<24) +
-	    ((uint64_t)(t[8+4][z+3])<<32) +
-	    ((uint64_t)(t[8+5][z+3])<<40) +
-	    ((uint64_t)(t[8+6][z+3])<<48) +
-	    ((uint64_t)(t[8+7][z+3])<<56);
+        *(uint64_t *)&out[iN[z]+8] =
+            ((uint64_t)(t[8+0][z])<< 0) +
+            ((uint64_t)(t[8+1][z])<< 8) +
+            ((uint64_t)(t[8+2][z])<<16) +
+            ((uint64_t)(t[8+3][z])<<24) +
+            ((uint64_t)(t[8+4][z])<<32) +
+            ((uint64_t)(t[8+5][z])<<40) +
+            ((uint64_t)(t[8+6][z])<<48) +
+            ((uint64_t)(t[8+7][z])<<56);
+        *(uint64_t *)&out[iN[z+1]+8] =
+            ((uint64_t)(t[8+0][z+1])<< 0) +
+            ((uint64_t)(t[8+1][z+1])<< 8) +
+            ((uint64_t)(t[8+2][z+1])<<16) +
+            ((uint64_t)(t[8+3][z+1])<<24) +
+            ((uint64_t)(t[8+4][z+1])<<32) +
+            ((uint64_t)(t[8+5][z+1])<<40) +
+            ((uint64_t)(t[8+6][z+1])<<48) +
+            ((uint64_t)(t[8+7][z+1])<<56);
+        *(uint64_t *)&out[iN[z+2]+8] =
+            ((uint64_t)(t[8+0][z+2])<< 0) +
+            ((uint64_t)(t[8+1][z+2])<< 8) +
+            ((uint64_t)(t[8+2][z+2])<<16) +
+            ((uint64_t)(t[8+3][z+2])<<24) +
+            ((uint64_t)(t[8+4][z+2])<<32) +
+            ((uint64_t)(t[8+5][z+2])<<40) +
+            ((uint64_t)(t[8+6][z+2])<<48) +
+            ((uint64_t)(t[8+7][z+2])<<56);
+        *(uint64_t *)&out[iN[z+3]+8] =
+            ((uint64_t)(t[8+0][z+3])<< 0) +
+            ((uint64_t)(t[8+1][z+3])<< 8) +
+            ((uint64_t)(t[8+2][z+3])<<16) +
+            ((uint64_t)(t[8+3][z+3])<<24) +
+            ((uint64_t)(t[8+4][z+3])<<32) +
+            ((uint64_t)(t[8+5][z+3])<<40) +
+            ((uint64_t)(t[8+6][z+3])<<48) +
+            ((uint64_t)(t[8+7][z+3])<<56);
 
-	*(uint64_t *)&out[iN[z]+16] =
-	    ((uint64_t)(t[16+0][z])<< 0) +
-	    ((uint64_t)(t[16+1][z])<< 8) +
-	    ((uint64_t)(t[16+2][z])<<16) +
-	    ((uint64_t)(t[16+3][z])<<24) +
-	    ((uint64_t)(t[16+4][z])<<32) +
-	    ((uint64_t)(t[16+5][z])<<40) +
-	    ((uint64_t)(t[16+6][z])<<48) +
-	    ((uint64_t)(t[16+7][z])<<56);
-	*(uint64_t *)&out[iN[z+1]+16] =
-	    ((uint64_t)(t[16+0][z+1])<< 0) +
-	    ((uint64_t)(t[16+1][z+1])<< 8) +
-	    ((uint64_t)(t[16+2][z+1])<<16) +
-	    ((uint64_t)(t[16+3][z+1])<<24) +
-	    ((uint64_t)(t[16+4][z+1])<<32) +
-	    ((uint64_t)(t[16+5][z+1])<<40) +
-	    ((uint64_t)(t[16+6][z+1])<<48) +
-	    ((uint64_t)(t[16+7][z+1])<<56);
-	*(uint64_t *)&out[iN[z+2]+16] =
-	    ((uint64_t)(t[16+0][z+2])<< 0) +
-	    ((uint64_t)(t[16+1][z+2])<< 8) +
-	    ((uint64_t)(t[16+2][z+2])<<16) +
-	    ((uint64_t)(t[16+3][z+2])<<24) +
-	    ((uint64_t)(t[16+4][z+2])<<32) +
-	    ((uint64_t)(t[16+5][z+2])<<40) +
-	    ((uint64_t)(t[16+6][z+2])<<48) +
-	    ((uint64_t)(t[16+7][z+2])<<56);
-	*(uint64_t *)&out[iN[z+3]+16] =
-	    ((uint64_t)(t[16+0][z+3])<< 0) +
-	    ((uint64_t)(t[16+1][z+3])<< 8) +
-	    ((uint64_t)(t[16+2][z+3])<<16) +
-	    ((uint64_t)(t[16+3][z+3])<<24) +
-	    ((uint64_t)(t[16+4][z+3])<<32) +
-	    ((uint64_t)(t[16+5][z+3])<<40) +
-	    ((uint64_t)(t[16+6][z+3])<<48) +
-	    ((uint64_t)(t[16+7][z+3])<<56);
+        *(uint64_t *)&out[iN[z]+16] =
+            ((uint64_t)(t[16+0][z])<< 0) +
+            ((uint64_t)(t[16+1][z])<< 8) +
+            ((uint64_t)(t[16+2][z])<<16) +
+            ((uint64_t)(t[16+3][z])<<24) +
+            ((uint64_t)(t[16+4][z])<<32) +
+            ((uint64_t)(t[16+5][z])<<40) +
+            ((uint64_t)(t[16+6][z])<<48) +
+            ((uint64_t)(t[16+7][z])<<56);
+        *(uint64_t *)&out[iN[z+1]+16] =
+            ((uint64_t)(t[16+0][z+1])<< 0) +
+            ((uint64_t)(t[16+1][z+1])<< 8) +
+            ((uint64_t)(t[16+2][z+1])<<16) +
+            ((uint64_t)(t[16+3][z+1])<<24) +
+            ((uint64_t)(t[16+4][z+1])<<32) +
+            ((uint64_t)(t[16+5][z+1])<<40) +
+            ((uint64_t)(t[16+6][z+1])<<48) +
+            ((uint64_t)(t[16+7][z+1])<<56);
+        *(uint64_t *)&out[iN[z+2]+16] =
+            ((uint64_t)(t[16+0][z+2])<< 0) +
+            ((uint64_t)(t[16+1][z+2])<< 8) +
+            ((uint64_t)(t[16+2][z+2])<<16) +
+            ((uint64_t)(t[16+3][z+2])<<24) +
+            ((uint64_t)(t[16+4][z+2])<<32) +
+            ((uint64_t)(t[16+5][z+2])<<40) +
+            ((uint64_t)(t[16+6][z+2])<<48) +
+            ((uint64_t)(t[16+7][z+2])<<56);
+        *(uint64_t *)&out[iN[z+3]+16] =
+            ((uint64_t)(t[16+0][z+3])<< 0) +
+            ((uint64_t)(t[16+1][z+3])<< 8) +
+            ((uint64_t)(t[16+2][z+3])<<16) +
+            ((uint64_t)(t[16+3][z+3])<<24) +
+            ((uint64_t)(t[16+4][z+3])<<32) +
+            ((uint64_t)(t[16+5][z+3])<<40) +
+            ((uint64_t)(t[16+6][z+3])<<48) +
+            ((uint64_t)(t[16+7][z+3])<<56);
 
-	*(uint64_t *)&out[iN[z]+24] =
-	    ((uint64_t)(t[24+0][z])<< 0) +
-	    ((uint64_t)(t[24+1][z])<< 8) +
-	    ((uint64_t)(t[24+2][z])<<16) +
-	    ((uint64_t)(t[24+3][z])<<24) +
-	    ((uint64_t)(t[24+4][z])<<32) +
-	    ((uint64_t)(t[24+5][z])<<40) +
-	    ((uint64_t)(t[24+6][z])<<48) +
-	    ((uint64_t)(t[24+7][z])<<56);
-	*(uint64_t *)&out[iN[z+1]+24] =
-	    ((uint64_t)(t[24+0][z+1])<< 0) +
-	    ((uint64_t)(t[24+1][z+1])<< 8) +
-	    ((uint64_t)(t[24+2][z+1])<<16) +
-	    ((uint64_t)(t[24+3][z+1])<<24) +
-	    ((uint64_t)(t[24+4][z+1])<<32) +
-	    ((uint64_t)(t[24+5][z+1])<<40) +
-	    ((uint64_t)(t[24+6][z+1])<<48) +
-	    ((uint64_t)(t[24+7][z+1])<<56);
-	*(uint64_t *)&out[iN[z+2]+24] =
-	    ((uint64_t)(t[24+0][z+2])<< 0) +
-	    ((uint64_t)(t[24+1][z+2])<< 8) +
-	    ((uint64_t)(t[24+2][z+2])<<16) +
-	    ((uint64_t)(t[24+3][z+2])<<24) +
-	    ((uint64_t)(t[24+4][z+2])<<32) +
-	    ((uint64_t)(t[24+5][z+2])<<40) +
-	    ((uint64_t)(t[24+6][z+2])<<48) +
-	    ((uint64_t)(t[24+7][z+2])<<56);
-	*(uint64_t *)&out[iN[z+3]+24] =
-	    ((uint64_t)(t[24+0][z+3])<< 0) +
-	    ((uint64_t)(t[24+1][z+3])<< 8) +
-	    ((uint64_t)(t[24+2][z+3])<<16) +
-	    ((uint64_t)(t[24+3][z+3])<<24) +
-	    ((uint64_t)(t[24+4][z+3])<<32) +
-	    ((uint64_t)(t[24+5][z+3])<<40) +
-	    ((uint64_t)(t[24+6][z+3])<<48) +
-	    ((uint64_t)(t[24+7][z+3])<<56);
+        *(uint64_t *)&out[iN[z]+24] =
+            ((uint64_t)(t[24+0][z])<< 0) +
+            ((uint64_t)(t[24+1][z])<< 8) +
+            ((uint64_t)(t[24+2][z])<<16) +
+            ((uint64_t)(t[24+3][z])<<24) +
+            ((uint64_t)(t[24+4][z])<<32) +
+            ((uint64_t)(t[24+5][z])<<40) +
+            ((uint64_t)(t[24+6][z])<<48) +
+            ((uint64_t)(t[24+7][z])<<56);
+        *(uint64_t *)&out[iN[z+1]+24] =
+            ((uint64_t)(t[24+0][z+1])<< 0) +
+            ((uint64_t)(t[24+1][z+1])<< 8) +
+            ((uint64_t)(t[24+2][z+1])<<16) +
+            ((uint64_t)(t[24+3][z+1])<<24) +
+            ((uint64_t)(t[24+4][z+1])<<32) +
+            ((uint64_t)(t[24+5][z+1])<<40) +
+            ((uint64_t)(t[24+6][z+1])<<48) +
+            ((uint64_t)(t[24+7][z+1])<<56);
+        *(uint64_t *)&out[iN[z+2]+24] =
+            ((uint64_t)(t[24+0][z+2])<< 0) +
+            ((uint64_t)(t[24+1][z+2])<< 8) +
+            ((uint64_t)(t[24+2][z+2])<<16) +
+            ((uint64_t)(t[24+3][z+2])<<24) +
+            ((uint64_t)(t[24+4][z+2])<<32) +
+            ((uint64_t)(t[24+5][z+2])<<40) +
+            ((uint64_t)(t[24+6][z+2])<<48) +
+            ((uint64_t)(t[24+7][z+2])<<56);
+        *(uint64_t *)&out[iN[z+3]+24] =
+            ((uint64_t)(t[24+0][z+3])<< 0) +
+            ((uint64_t)(t[24+1][z+3])<< 8) +
+            ((uint64_t)(t[24+2][z+3])<<16) +
+            ((uint64_t)(t[24+3][z+3])<<24) +
+            ((uint64_t)(t[24+4][z+3])<<32) +
+            ((uint64_t)(t[24+5][z+3])<<40) +
+            ((uint64_t)(t[24+6][z+3])<<48) +
+            ((uint64_t)(t[24+7][z+3])<<56);
 
-	iN[z+0] += 32;
-	iN[z+1] += 32;
-	iN[z+2] += 32;
-	iN[z+3] += 32;
+        iN[z+0] += 32;
+        iN[z+1] += 32;
+        iN[z+2] += 32;
+        iN[z+3] += 32;
     }
 #endif
 }
 
 unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
-					     unsigned int in_size,
-					     unsigned char *out,
-					     unsigned int out_sz) {
+                                             unsigned int in_size,
+                                             unsigned char *out,
+                                             unsigned int out_sz) {
     if (in_size < NX*4) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -1000,14 +1000,14 @@ unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
 
     uint32_t (*s3)[TOTFREQ_O1] = htscodecs_tls_alloc(256*TOTFREQ_O1*4);
     if (!s3)
-	return NULL;
+        return NULL;
     uint32_t (*s3F)[TOTFREQ_O1_FAST] = (uint32_t (*)[TOTFREQ_O1_FAST])s3;
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
 
     if (!out)
-	goto err;
+        goto err;
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
@@ -1016,749 +1016,749 @@ unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
     unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
-	uint32_t u_freq_sz, c_freq_sz;
-	cp += var_get_u32(cp, cp_end, &u_freq_sz);
-	cp += var_get_u32(cp, cp_end, &c_freq_sz);
-	if (c_freq_sz >= cp_end - cp - 16)
-	    goto err;
-	tab_end = cp + c_freq_sz;
-	if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL,u_freq_sz)))
-	    goto err;
-	cp = c_freq;
-	c_freq_end = c_freq + u_freq_sz;
+        uint32_t u_freq_sz, c_freq_sz;
+        cp += var_get_u32(cp, cp_end, &u_freq_sz);
+        cp += var_get_u32(cp, cp_end, &c_freq_sz);
+        if (c_freq_sz >= cp_end - cp - 16)
+            goto err;
+        tab_end = cp + c_freq_sz;
+        if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL,u_freq_sz)))
+            goto err;
+        cp = c_freq;
+        c_freq_end = c_freq + u_freq_sz;
     }
 
     // Decode order-0 symbol list; avoids needing in order-1 tables
     cp += decode_freq1(cp, c_freq_end, shift, s3, s3F, NULL, NULL);
 
     if (tab_end)
-	cp = tab_end;
+        cp = tab_end;
     free(c_freq);
     c_freq = NULL;
 
     if (cp_end - cp < NX * 4)
-	goto err;
+        goto err;
 
     RansState R[NX];
     uint8_t *ptr = cp, *ptr_end = in + in_size;
     int z;
     for (z = 0; z < NX; z++) {
-	RansDecInit(&R[z], &ptr);
-	if (R[z] < RANS_BYTE_L)
-	    goto err;
+        RansDecInit(&R[z], &ptr);
+        if (R[z] < RANS_BYTE_L)
+            goto err;
     }
 
     int isz4 = out_sz/NX;
     int i4[NX], l[NX] = {0};
     for (z = 0; z < NX; z++)
-	i4[z] = z*isz4;
+        i4[z] = z*isz4;
 
     // Around 15% faster to specialise for 10/12 than to have one
     // loop with shift as a variable.
     if (shift == TF_SHIFT_O1) {
-	// TF_SHIFT_O1 = 12
+        // TF_SHIFT_O1 = 12
         uint16_t *sp = (uint16_t *)ptr;
-	const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
-	__m128i maskv  = _mm_set1_epi32(mask); // set mask in all lanes
-	uint8_t tbuf[32][32];
-	int tidx = 0;
-	LOAD128(Rv, R);
-	LOAD128(Lv, l);
+        const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
+        __m128i maskv  = _mm_set1_epi32(mask); // set mask in all lanes
+        uint8_t tbuf[32][32];
+        int tidx = 0;
+        LOAD128(Rv, R);
+        LOAD128(Lv, l);
 
-	isz4 -= 64;
-	for (; i4[0] < isz4 && (uint8_t *)sp+72 < ptr_end; ) {
-	    //for (z = 0; z < NX; z++)
-	    //  m[z] = R[z] & mask;
-	    __m128i masked1 = _mm_and_si128(Rv1, maskv);
-	    __m128i masked2 = _mm_and_si128(Rv2, maskv);
-	    __m128i masked3 = _mm_and_si128(Rv3, maskv);
-	    __m128i masked4 = _mm_and_si128(Rv4, maskv);
+        isz4 -= 64;
+        for (; i4[0] < isz4 && (uint8_t *)sp+72 < ptr_end; ) {
+            //for (z = 0; z < NX; z++)
+            //  m[z] = R[z] & mask;
+            __m128i masked1 = _mm_and_si128(Rv1, maskv);
+            __m128i masked2 = _mm_and_si128(Rv2, maskv);
+            __m128i masked3 = _mm_and_si128(Rv3, maskv);
+            __m128i masked4 = _mm_and_si128(Rv4, maskv);
 
-	    Lv1 = _mm_slli_epi32(Lv1, TF_SHIFT_O1);
-	    Lv2 = _mm_slli_epi32(Lv2, TF_SHIFT_O1);
-	    Lv3 = _mm_slli_epi32(Lv3, TF_SHIFT_O1);
-	    Lv4 = _mm_slli_epi32(Lv4, TF_SHIFT_O1);
-	    masked1 = _mm_add_epi32(masked1, Lv1);
-	    masked2 = _mm_add_epi32(masked2, Lv2);
-	    masked3 = _mm_add_epi32(masked3, Lv3);
-	    masked4 = _mm_add_epi32(masked4, Lv4);
+            Lv1 = _mm_slli_epi32(Lv1, TF_SHIFT_O1);
+            Lv2 = _mm_slli_epi32(Lv2, TF_SHIFT_O1);
+            Lv3 = _mm_slli_epi32(Lv3, TF_SHIFT_O1);
+            Lv4 = _mm_slli_epi32(Lv4, TF_SHIFT_O1);
+            masked1 = _mm_add_epi32(masked1, Lv1);
+            masked2 = _mm_add_epi32(masked2, Lv2);
+            masked3 = _mm_add_epi32(masked3, Lv3);
+            masked4 = _mm_add_epi32(masked4, Lv4);
 
-	    //  S[z] = s3[l[z]][m[z]];
-	    __m128i Sv1 = _mm_i32gather_epi32x((int *)s3, masked1, sizeof(*s3));
-	    __m128i Sv2 = _mm_i32gather_epi32x((int *)s3, masked2, sizeof(*s3));
-	    __m128i Sv3 = _mm_i32gather_epi32x((int *)s3, masked3, sizeof(*s3));
-	    __m128i Sv4 = _mm_i32gather_epi32x((int *)s3, masked4, sizeof(*s3));
+            //  S[z] = s3[l[z]][m[z]];
+            __m128i Sv1 = _mm_i32gather_epi32x((int *)s3, masked1, sizeof(*s3));
+            __m128i Sv2 = _mm_i32gather_epi32x((int *)s3, masked2, sizeof(*s3));
+            __m128i Sv3 = _mm_i32gather_epi32x((int *)s3, masked3, sizeof(*s3));
+            __m128i Sv4 = _mm_i32gather_epi32x((int *)s3, masked4, sizeof(*s3));
 
-	    //  f[z] = S[z]>>(TF_SHIFT+8);
-	    __m128i fv1 = _mm_srli_epi32(Sv1, TF_SHIFT_O1+8);
-	    __m128i fv2 = _mm_srli_epi32(Sv2, TF_SHIFT_O1+8);
-	    __m128i fv3 = _mm_srli_epi32(Sv3, TF_SHIFT_O1+8);
-	    __m128i fv4 = _mm_srli_epi32(Sv4, TF_SHIFT_O1+8);
+            //  f[z] = S[z]>>(TF_SHIFT+8);
+            __m128i fv1 = _mm_srli_epi32(Sv1, TF_SHIFT_O1+8);
+            __m128i fv2 = _mm_srli_epi32(Sv2, TF_SHIFT_O1+8);
+            __m128i fv3 = _mm_srli_epi32(Sv3, TF_SHIFT_O1+8);
+            __m128i fv4 = _mm_srli_epi32(Sv4, TF_SHIFT_O1+8);
 
-	    //  b[z] = (S[z]>>8) & mask;
-	    __m128i bv1 = _mm_and_si128(_mm_srli_epi32(Sv1, 8), maskv);
-	    __m128i bv2 = _mm_and_si128(_mm_srli_epi32(Sv2, 8), maskv);
-	    __m128i bv3 = _mm_and_si128(_mm_srli_epi32(Sv3, 8), maskv);
-	    __m128i bv4 = _mm_and_si128(_mm_srli_epi32(Sv4, 8), maskv);
+            //  b[z] = (S[z]>>8) & mask;
+            __m128i bv1 = _mm_and_si128(_mm_srli_epi32(Sv1, 8), maskv);
+            __m128i bv2 = _mm_and_si128(_mm_srli_epi32(Sv2, 8), maskv);
+            __m128i bv3 = _mm_and_si128(_mm_srli_epi32(Sv3, 8), maskv);
+            __m128i bv4 = _mm_and_si128(_mm_srli_epi32(Sv4, 8), maskv);
 
-	    //  s[z] = S[z] & 0xff;
-	    __m128i sv1 = _mm_and_si128(Sv1, _mm_set1_epi32(0xff));
-	    __m128i sv2 = _mm_and_si128(Sv2, _mm_set1_epi32(0xff));
-	    __m128i sv3 = _mm_and_si128(Sv3, _mm_set1_epi32(0xff));
-	    __m128i sv4 = _mm_and_si128(Sv4, _mm_set1_epi32(0xff));
+            //  s[z] = S[z] & 0xff;
+            __m128i sv1 = _mm_and_si128(Sv1, _mm_set1_epi32(0xff));
+            __m128i sv2 = _mm_and_si128(Sv2, _mm_set1_epi32(0xff));
+            __m128i sv3 = _mm_and_si128(Sv3, _mm_set1_epi32(0xff));
+            __m128i sv4 = _mm_and_si128(Sv4, _mm_set1_epi32(0xff));
 
-	    // A maximum frequency of 4096 doesn't fit in our s3 array.
-	    // as it's 12 bit + 12 bit + 8 bit.  It wraps around to zero.
-	    // (We don't have this issue for TOTFREQ_O1_FAST.)
-	    //
-	    // Solution 1 is to change to spec to forbid freq of 4096.
-	    // Easy hack is to add an extra symbol so it sums correctly.
-	    //
-	    // Solution 2 implemented here is to look for the wrap around
-	    // and fix it.
-	    __m128i max_freq = _mm_set1_epi32(TOTFREQ_O1);
-	    __m128i zero = _mm_set1_epi32(0);
-	    __m128i cmp1 = _mm_cmpeq_epi32(fv1, zero);
-	    fv1 = _mm_blendv_epi8(fv1, max_freq, cmp1);
-	    __m128i cmp2 = _mm_cmpeq_epi32(fv2, zero);
-	    fv2 = _mm_blendv_epi8(fv2, max_freq, cmp2);
-	    __m128i cmp3 = _mm_cmpeq_epi32(fv3, zero);
-	    fv3 = _mm_blendv_epi8(fv3, max_freq, cmp3);
-	    __m128i cmp4 = _mm_cmpeq_epi32(fv4, zero);
-	    fv4 = _mm_blendv_epi8(fv4, max_freq, cmp4);
+            // A maximum frequency of 4096 doesn't fit in our s3 array.
+            // as it's 12 bit + 12 bit + 8 bit.  It wraps around to zero.
+            // (We don't have this issue for TOTFREQ_O1_FAST.)
+            //
+            // Solution 1 is to change to spec to forbid freq of 4096.
+            // Easy hack is to add an extra symbol so it sums correctly.
+            //
+            // Solution 2 implemented here is to look for the wrap around
+            // and fix it.
+            __m128i max_freq = _mm_set1_epi32(TOTFREQ_O1);
+            __m128i zero = _mm_set1_epi32(0);
+            __m128i cmp1 = _mm_cmpeq_epi32(fv1, zero);
+            fv1 = _mm_blendv_epi8(fv1, max_freq, cmp1);
+            __m128i cmp2 = _mm_cmpeq_epi32(fv2, zero);
+            fv2 = _mm_blendv_epi8(fv2, max_freq, cmp2);
+            __m128i cmp3 = _mm_cmpeq_epi32(fv3, zero);
+            fv3 = _mm_blendv_epi8(fv3, max_freq, cmp3);
+            __m128i cmp4 = _mm_cmpeq_epi32(fv4, zero);
+            fv4 = _mm_blendv_epi8(fv4, max_freq, cmp4);
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
-	    Rv1 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-		          _mm_srli_epi32(Rv1,TF_SHIFT_O1), fv1), bv1);
-	    Rv2 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv2,TF_SHIFT_O1), fv2), bv2);
-	    Rv3 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv3,TF_SHIFT_O1), fv3), bv3);
-	    Rv4 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv4,TF_SHIFT_O1), fv4), bv4);
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
+            Rv1 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv1,TF_SHIFT_O1), fv1), bv1);
+            Rv2 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv2,TF_SHIFT_O1), fv2), bv2);
+            Rv3 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv3,TF_SHIFT_O1), fv3), bv3);
+            Rv4 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv4,TF_SHIFT_O1), fv4), bv4);
 
-	    Lv1 = sv1;
-	    Lv2 = sv2;
-	    Lv3 = sv3;
-	    Lv4 = sv4;
+            Lv1 = sv1;
+            Lv2 = sv2;
+            Lv3 = sv3;
+            Lv4 = sv4;
 
-	    // Tricky one:  out[i+z] = s[z];
-	    //             ---d---c ---b---a  sv1
-	    //             ---h---g ---f---e  sv2
-	    // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
-	    // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
-	    sv1 = _mm_packus_epi32(sv1, sv2);
-	    sv3 = _mm_packus_epi32(sv3, sv4);
-	    sv1 = _mm_packus_epi16(sv1, sv3);
+            // Tricky one:  out[i+z] = s[z];
+            //             ---d---c ---b---a  sv1
+            //             ---h---g ---f---e  sv2
+            // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
+            // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
+            sv1 = _mm_packus_epi32(sv1, sv2);
+            sv3 = _mm_packus_epi32(sv3, sv4);
+            sv1 = _mm_packus_epi16(sv1, sv3);
 
-	    // c =  R[z] < RANS_BYTE_L;
-	    // A little tricky as we only have signed comparisons.
-	    // See https://stackoverflow.com/questions/32945410/sse2-intrinsics-comparing-unsigned-integers
+            // c =  R[z] < RANS_BYTE_L;
+            // A little tricky as we only have signed comparisons.
+            // See https://stackoverflow.com/questions/32945410/sse2-intrinsics-comparing-unsigned-integers
 
 //#define _mm_cmplt_epu32_imm(a,b) _mm_andnot_si128(_mm_cmpeq_epi32(_mm_max_epu32((a),_mm_set1_epi32(b)), (a)), _mm_set1_epi32(-1));
 
-	    //#define _mm_cmplt_epu32_imm(a,b) _mm_cmpgt_epi32(_mm_set1_epi32((b)-0x80000000), _mm_xor_si128((a), _mm_set1_epi32(0x80000000)))
+            //#define _mm_cmplt_epu32_imm(a,b) _mm_cmpgt_epi32(_mm_set1_epi32((b)-0x80000000), _mm_xor_si128((a), _mm_set1_epi32(0x80000000)))
 
-	    __m128i renorm_mask1, renorm_mask2, renorm_mask3, renorm_mask4;
-	    renorm_mask1 = _mm_cmplt_epu32_imm(Rv1, RANS_BYTE_L);
-	    renorm_mask2 = _mm_cmplt_epu32_imm(Rv2, RANS_BYTE_L);
-	    renorm_mask3 = _mm_cmplt_epu32_imm(Rv3, RANS_BYTE_L);
-	    renorm_mask4 = _mm_cmplt_epu32_imm(Rv4, RANS_BYTE_L);
+            __m128i renorm_mask1, renorm_mask2, renorm_mask3, renorm_mask4;
+            renorm_mask1 = _mm_cmplt_epu32_imm(Rv1, RANS_BYTE_L);
+            renorm_mask2 = _mm_cmplt_epu32_imm(Rv2, RANS_BYTE_L);
+            renorm_mask3 = _mm_cmplt_epu32_imm(Rv3, RANS_BYTE_L);
+            renorm_mask4 = _mm_cmplt_epu32_imm(Rv4, RANS_BYTE_L);
 
-	    //#define P(A,B,C,D) ((A)+((B)<<2) + ((C)<<4) + ((D)<<6))
-#define P(A,B,C,D) 				\
-	    { A+0,A+1,A+2,A+3,			\
-  	      B+0,B+1,B+2,B+3,			\
-	      C+0,C+1,C+2,C+3,			\
-	      D+0,D+1,D+2,D+3}
+            //#define P(A,B,C,D) ((A)+((B)<<2) + ((C)<<4) + ((D)<<6))
+#define P(A,B,C,D)                              \
+            { A+0,A+1,A+2,A+3,                  \
+              B+0,B+1,B+2,B+3,                  \
+              C+0,C+1,C+2,C+3,                  \
+              D+0,D+1,D+2,D+3}
 #ifdef _
 #undef _
 #endif
 #define _ 0x80
-	    uint8_t pidx[16][16] = {
-		P(_,_,_,_),
-		P(0,_,_,_),
-		P(_,0,_,_),
-		P(0,4,_,_),
+            uint8_t pidx[16][16] = {
+                P(_,_,_,_),
+                P(0,_,_,_),
+                P(_,0,_,_),
+                P(0,4,_,_),
 
-		P(_,_,0,_),
-		P(0,_,4,_),
-		P(_,0,4,_),
-		P(0,4,8,_),
+                P(_,_,0,_),
+                P(0,_,4,_),
+                P(_,0,4,_),
+                P(0,4,8,_),
 
-		P(_,_,_,0),
-		P(0,_,_,4),
-		P(_,0,_,4),
-		P(0,4,_,8),
+                P(_,_,_,0),
+                P(0,_,_,4),
+                P(_,0,_,4),
+                P(0,4,_,8),
 
-		P(_,_,0,4),
-		P(0,_,4,8),
-		P(_,0,4,8),
-		P(0,4,8,12),
-	    };
+                P(_,_,0,4),
+                P(0,_,4,8),
+                P(_,0,4,8),
+                P(0,4,8,12),
+            };
 #undef _
 
-	    // Shuffle the renorm values to correct lanes and incr sp pointer
-	    __m128i Vv1 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask1 = _mm_movemask_ps((__m128)renorm_mask1);
-	    Vv1 = _mm_shuffle_epi8(Vv1, _mm_load_si128((__m128i*)pidx[imask1]));
-	    sp += _mm_popcnt_u32(imask1);
+            // Shuffle the renorm values to correct lanes and incr sp pointer
+            __m128i Vv1 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask1 = _mm_movemask_ps((__m128)renorm_mask1);
+            Vv1 = _mm_shuffle_epi8(Vv1, _mm_load_si128((__m128i*)pidx[imask1]));
+            sp += _mm_popcnt_u32(imask1);
 
-	    __m128i Vv2 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask2 = _mm_movemask_ps((__m128)renorm_mask2);
-	    sp += _mm_popcnt_u32(imask2);
-	    Vv2 = _mm_shuffle_epi8(Vv2, _mm_load_si128((__m128i*)pidx[imask2]));
+            __m128i Vv2 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask2 = _mm_movemask_ps((__m128)renorm_mask2);
+            sp += _mm_popcnt_u32(imask2);
+            Vv2 = _mm_shuffle_epi8(Vv2, _mm_load_si128((__m128i*)pidx[imask2]));
 
-	    __m128i Vv3 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask3 = _mm_movemask_ps((__m128)renorm_mask3);
-	    Vv3 = _mm_shuffle_epi8(Vv3, _mm_load_si128((__m128i*)pidx[imask3]));
-	    sp += _mm_popcnt_u32(imask3);
+            __m128i Vv3 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask3 = _mm_movemask_ps((__m128)renorm_mask3);
+            Vv3 = _mm_shuffle_epi8(Vv3, _mm_load_si128((__m128i*)pidx[imask3]));
+            sp += _mm_popcnt_u32(imask3);
 
-	    __m128i Vv4 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask4 = _mm_movemask_ps((__m128)renorm_mask4);
-	    sp += _mm_popcnt_u32(imask4);
-	    Vv4 = _mm_shuffle_epi8(Vv4, _mm_load_si128((__m128i*)pidx[imask4]));
+            __m128i Vv4 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask4 = _mm_movemask_ps((__m128)renorm_mask4);
+            sp += _mm_popcnt_u32(imask4);
+            Vv4 = _mm_shuffle_epi8(Vv4, _mm_load_si128((__m128i*)pidx[imask4]));
 
-	    __m128i Yv1 = _mm_slli_epi32(Rv1, 16);
-	    __m128i Yv2 = _mm_slli_epi32(Rv2, 16);
-	    __m128i Yv3 = _mm_slli_epi32(Rv3, 16);
-	    __m128i Yv4 = _mm_slli_epi32(Rv4, 16);
+            __m128i Yv1 = _mm_slli_epi32(Rv1, 16);
+            __m128i Yv2 = _mm_slli_epi32(Rv2, 16);
+            __m128i Yv3 = _mm_slli_epi32(Rv3, 16);
+            __m128i Yv4 = _mm_slli_epi32(Rv4, 16);
 
-	    // y = (R[z] << 16) | V[z];
-	    Yv1 = _mm_or_si128(Yv1, Vv1);
-	    Yv2 = _mm_or_si128(Yv2, Vv2);
-	    Yv3 = _mm_or_si128(Yv3, Vv3);
-	    Yv4 = _mm_or_si128(Yv4, Vv4);
+            // y = (R[z] << 16) | V[z];
+            Yv1 = _mm_or_si128(Yv1, Vv1);
+            Yv2 = _mm_or_si128(Yv2, Vv2);
+            Yv3 = _mm_or_si128(Yv3, Vv3);
+            Yv4 = _mm_or_si128(Yv4, Vv4);
 
-	    // R[z] = c ? Y[z] : R[z];
-	    Rv1 = _mm_blendv_epi8(Rv1, Yv1, renorm_mask1);
-	    Rv2 = _mm_blendv_epi8(Rv2, Yv2, renorm_mask2);
-	    Rv3 = _mm_blendv_epi8(Rv3, Yv3, renorm_mask3);
-	    Rv4 = _mm_blendv_epi8(Rv4, Yv4, renorm_mask4);
+            // R[z] = c ? Y[z] : R[z];
+            Rv1 = _mm_blendv_epi8(Rv1, Yv1, renorm_mask1);
+            Rv2 = _mm_blendv_epi8(Rv2, Yv2, renorm_mask2);
+            Rv3 = _mm_blendv_epi8(Rv3, Yv3, renorm_mask3);
+            Rv4 = _mm_blendv_epi8(Rv4, Yv4, renorm_mask4);
 
-	    // ------------------------------------------------------------
+            // ------------------------------------------------------------
 
-	    //  m[z] = R[z] & mask;
-	    __m128i masked5 = _mm_and_si128(Rv5, maskv);
-	    __m128i masked6 = _mm_and_si128(Rv6, maskv);
-	    __m128i masked7 = _mm_and_si128(Rv7, maskv);
-	    __m128i masked8 = _mm_and_si128(Rv8, maskv);
+            //  m[z] = R[z] & mask;
+            __m128i masked5 = _mm_and_si128(Rv5, maskv);
+            __m128i masked6 = _mm_and_si128(Rv6, maskv);
+            __m128i masked7 = _mm_and_si128(Rv7, maskv);
+            __m128i masked8 = _mm_and_si128(Rv8, maskv);
 
 
-	    Lv5 = _mm_slli_epi32(Lv5, TF_SHIFT_O1);
-	    Lv6 = _mm_slli_epi32(Lv6, TF_SHIFT_O1);
-	    Lv7 = _mm_slli_epi32(Lv7, TF_SHIFT_O1);
-	    Lv8 = _mm_slli_epi32(Lv8, TF_SHIFT_O1);
-	    masked5 = _mm_add_epi32(masked5, Lv5);
-	    masked6 = _mm_add_epi32(masked6, Lv6);
-	    masked7 = _mm_add_epi32(masked7, Lv7);
-	    masked8 = _mm_add_epi32(masked8, Lv8);
+            Lv5 = _mm_slli_epi32(Lv5, TF_SHIFT_O1);
+            Lv6 = _mm_slli_epi32(Lv6, TF_SHIFT_O1);
+            Lv7 = _mm_slli_epi32(Lv7, TF_SHIFT_O1);
+            Lv8 = _mm_slli_epi32(Lv8, TF_SHIFT_O1);
+            masked5 = _mm_add_epi32(masked5, Lv5);
+            masked6 = _mm_add_epi32(masked6, Lv6);
+            masked7 = _mm_add_epi32(masked7, Lv7);
+            masked8 = _mm_add_epi32(masked8, Lv8);
 
-	    //  S[z] = s3[m[z]];
-	    __m128i Sv5 = _mm_i32gather_epi32x((int *)s3, masked5, sizeof(*s3));
-	    __m128i Sv6 = _mm_i32gather_epi32x((int *)s3, masked6, sizeof(*s3));
-	    __m128i Sv7 = _mm_i32gather_epi32x((int *)s3, masked7, sizeof(*s3));
-	    __m128i Sv8 = _mm_i32gather_epi32x((int *)s3, masked8, sizeof(*s3));
+            //  S[z] = s3[m[z]];
+            __m128i Sv5 = _mm_i32gather_epi32x((int *)s3, masked5, sizeof(*s3));
+            __m128i Sv6 = _mm_i32gather_epi32x((int *)s3, masked6, sizeof(*s3));
+            __m128i Sv7 = _mm_i32gather_epi32x((int *)s3, masked7, sizeof(*s3));
+            __m128i Sv8 = _mm_i32gather_epi32x((int *)s3, masked8, sizeof(*s3));
 
-	    //  f[z] = S[z]>>(TF_SHIFT_O1+8);
-	    __m128i fv5 = _mm_srli_epi32(Sv5, TF_SHIFT_O1+8);
-	    __m128i fv6 = _mm_srli_epi32(Sv6, TF_SHIFT_O1+8);
-	    __m128i fv7 = _mm_srli_epi32(Sv7, TF_SHIFT_O1+8);
-	    __m128i fv8 = _mm_srli_epi32(Sv8, TF_SHIFT_O1+8);
+            //  f[z] = S[z]>>(TF_SHIFT_O1+8);
+            __m128i fv5 = _mm_srli_epi32(Sv5, TF_SHIFT_O1+8);
+            __m128i fv6 = _mm_srli_epi32(Sv6, TF_SHIFT_O1+8);
+            __m128i fv7 = _mm_srli_epi32(Sv7, TF_SHIFT_O1+8);
+            __m128i fv8 = _mm_srli_epi32(Sv8, TF_SHIFT_O1+8);
 
-	    //  b[z] = (S[z]>>8) & mask;
-	    __m128i bv5 = _mm_and_si128(_mm_srli_epi32(Sv5, 8), maskv);
-	    __m128i bv6 = _mm_and_si128(_mm_srli_epi32(Sv6, 8), maskv);
-	    __m128i bv7 = _mm_and_si128(_mm_srli_epi32(Sv7, 8), maskv);
-	    __m128i bv8 = _mm_and_si128(_mm_srli_epi32(Sv8, 8), maskv);
+            //  b[z] = (S[z]>>8) & mask;
+            __m128i bv5 = _mm_and_si128(_mm_srli_epi32(Sv5, 8), maskv);
+            __m128i bv6 = _mm_and_si128(_mm_srli_epi32(Sv6, 8), maskv);
+            __m128i bv7 = _mm_and_si128(_mm_srli_epi32(Sv7, 8), maskv);
+            __m128i bv8 = _mm_and_si128(_mm_srli_epi32(Sv8, 8), maskv);
 
-	    //  s[z] = S[z] & 0xff;
-	    __m128i sv5 = _mm_and_si128(Sv5, _mm_set1_epi32(0xff));
-	    __m128i sv6 = _mm_and_si128(Sv6, _mm_set1_epi32(0xff));
-	    __m128i sv7 = _mm_and_si128(Sv7, _mm_set1_epi32(0xff));
-	    __m128i sv8 = _mm_and_si128(Sv8, _mm_set1_epi32(0xff));
+            //  s[z] = S[z] & 0xff;
+            __m128i sv5 = _mm_and_si128(Sv5, _mm_set1_epi32(0xff));
+            __m128i sv6 = _mm_and_si128(Sv6, _mm_set1_epi32(0xff));
+            __m128i sv7 = _mm_and_si128(Sv7, _mm_set1_epi32(0xff));
+            __m128i sv8 = _mm_and_si128(Sv8, _mm_set1_epi32(0xff));
 
-	    // A maximum frequency of 4096 doesn't fit in our s3 array. Fix
-	    __m128i cmp5 = _mm_cmpeq_epi32(fv5, zero);
-	    fv5 = _mm_blendv_epi8(fv5, max_freq, cmp5);
-	    __m128i cmp6 = _mm_cmpeq_epi32(fv6, zero);
-	    fv6 = _mm_blendv_epi8(fv6, max_freq, cmp6);
-	    __m128i cmp7 = _mm_cmpeq_epi32(fv7, zero);
-	    fv7 = _mm_blendv_epi8(fv7, max_freq, cmp7);
-	    __m128i cmp8 = _mm_cmpeq_epi32(fv8, zero);
-	    fv8 = _mm_blendv_epi8(fv8, max_freq, cmp8);
+            // A maximum frequency of 4096 doesn't fit in our s3 array. Fix
+            __m128i cmp5 = _mm_cmpeq_epi32(fv5, zero);
+            fv5 = _mm_blendv_epi8(fv5, max_freq, cmp5);
+            __m128i cmp6 = _mm_cmpeq_epi32(fv6, zero);
+            fv6 = _mm_blendv_epi8(fv6, max_freq, cmp6);
+            __m128i cmp7 = _mm_cmpeq_epi32(fv7, zero);
+            fv7 = _mm_blendv_epi8(fv7, max_freq, cmp7);
+            __m128i cmp8 = _mm_cmpeq_epi32(fv8, zero);
+            fv8 = _mm_blendv_epi8(fv8, max_freq, cmp8);
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
-	    Rv5 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-		          _mm_srli_epi32(Rv5,TF_SHIFT_O1), fv5), bv5);
-	    Rv6 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv6,TF_SHIFT_O1), fv6), bv6);
-	    Rv7 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv7,TF_SHIFT_O1), fv7), bv7);
-	    Rv8 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv8,TF_SHIFT_O1), fv8), bv8);
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1) + b[z];
+            Rv5 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv5,TF_SHIFT_O1), fv5), bv5);
+            Rv6 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv6,TF_SHIFT_O1), fv6), bv6);
+            Rv7 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv7,TF_SHIFT_O1), fv7), bv7);
+            Rv8 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv8,TF_SHIFT_O1), fv8), bv8);
 
-	    Lv5 = sv5;
-	    Lv6 = sv6;
-	    Lv7 = sv7;
-	    Lv8 = sv8;
+            Lv5 = sv5;
+            Lv6 = sv6;
+            Lv7 = sv7;
+            Lv8 = sv8;
 
-	    // Tricky one:  out[i+z] = s[z];
-	    //             ---d---c ---b---a  sv1
-	    //             ---h---g ---f---e  sv2
-	    // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
-	    // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
-	    sv5 = _mm_packus_epi32(sv5, sv6);
-	    sv7 = _mm_packus_epi32(sv7, sv8);
-	    sv5 = _mm_packus_epi16(sv5, sv7);
+            // Tricky one:  out[i+z] = s[z];
+            //             ---d---c ---b---a  sv1
+            //             ---h---g ---f---e  sv2
+            // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
+            // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
+            sv5 = _mm_packus_epi32(sv5, sv6);
+            sv7 = _mm_packus_epi32(sv7, sv8);
+            sv5 = _mm_packus_epi16(sv5, sv7);
 
-	    // c =  R[z] < RANS_BYTE_L;
-	    __m128i renorm_mask5, renorm_mask6, renorm_mask7, renorm_mask8;
-	    renorm_mask5 = _mm_cmplt_epu32_imm(Rv5, RANS_BYTE_L);
-	    renorm_mask6 = _mm_cmplt_epu32_imm(Rv6, RANS_BYTE_L);
-	    renorm_mask7 = _mm_cmplt_epu32_imm(Rv7, RANS_BYTE_L);
-	    renorm_mask8 = _mm_cmplt_epu32_imm(Rv8, RANS_BYTE_L);
-	
-	    // Shuffle the renorm values to correct lanes and incr sp pointer
-	    __m128i Vv5 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask5 = _mm_movemask_ps((__m128)renorm_mask5);
-	    Vv5 = _mm_shuffle_epi8(Vv5, _mm_load_si128((__m128i*)pidx[imask5]));
-	    sp += _mm_popcnt_u32(imask5);
+            // c =  R[z] < RANS_BYTE_L;
+            __m128i renorm_mask5, renorm_mask6, renorm_mask7, renorm_mask8;
+            renorm_mask5 = _mm_cmplt_epu32_imm(Rv5, RANS_BYTE_L);
+            renorm_mask6 = _mm_cmplt_epu32_imm(Rv6, RANS_BYTE_L);
+            renorm_mask7 = _mm_cmplt_epu32_imm(Rv7, RANS_BYTE_L);
+            renorm_mask8 = _mm_cmplt_epu32_imm(Rv8, RANS_BYTE_L);
+        
+            // Shuffle the renorm values to correct lanes and incr sp pointer
+            __m128i Vv5 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask5 = _mm_movemask_ps((__m128)renorm_mask5);
+            Vv5 = _mm_shuffle_epi8(Vv5, _mm_load_si128((__m128i*)pidx[imask5]));
+            sp += _mm_popcnt_u32(imask5);
 
-	    __m128i Vv6 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask6 = _mm_movemask_ps((__m128)renorm_mask6);
-	    sp += _mm_popcnt_u32(imask6);
-	    Vv6 = _mm_shuffle_epi8(Vv6, _mm_load_si128((__m128i*)pidx[imask6]));
+            __m128i Vv6 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask6 = _mm_movemask_ps((__m128)renorm_mask6);
+            sp += _mm_popcnt_u32(imask6);
+            Vv6 = _mm_shuffle_epi8(Vv6, _mm_load_si128((__m128i*)pidx[imask6]));
 
-	    __m128i Vv7 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask7 = _mm_movemask_ps((__m128)renorm_mask7);
-	    Vv7 = _mm_shuffle_epi8(Vv7, _mm_load_si128((__m128i*)pidx[imask7]));
-	    sp += _mm_popcnt_u32(imask7);
+            __m128i Vv7 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask7 = _mm_movemask_ps((__m128)renorm_mask7);
+            Vv7 = _mm_shuffle_epi8(Vv7, _mm_load_si128((__m128i*)pidx[imask7]));
+            sp += _mm_popcnt_u32(imask7);
 
-	    __m128i Vv8 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask8 = _mm_movemask_ps((__m128)renorm_mask8);
-	    sp += _mm_popcnt_u32(imask8);
-	    Vv8 = _mm_shuffle_epi8(Vv8, _mm_load_si128((__m128i*)pidx[imask8]));
+            __m128i Vv8 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask8 = _mm_movemask_ps((__m128)renorm_mask8);
+            sp += _mm_popcnt_u32(imask8);
+            Vv8 = _mm_shuffle_epi8(Vv8, _mm_load_si128((__m128i*)pidx[imask8]));
 
-	    __m128i Yv5 = _mm_slli_epi32(Rv5, 16);
-	    __m128i Yv6 = _mm_slli_epi32(Rv6, 16);
-	    __m128i Yv7 = _mm_slli_epi32(Rv7, 16);
-	    __m128i Yv8 = _mm_slli_epi32(Rv8, 16);
+            __m128i Yv5 = _mm_slli_epi32(Rv5, 16);
+            __m128i Yv6 = _mm_slli_epi32(Rv6, 16);
+            __m128i Yv7 = _mm_slli_epi32(Rv7, 16);
+            __m128i Yv8 = _mm_slli_epi32(Rv8, 16);
 
-	    // y = (R[z] << 16) | V[z];
-	    Yv5 = _mm_or_si128(Yv5, Vv5);
-	    Yv6 = _mm_or_si128(Yv6, Vv6);
-	    Yv7 = _mm_or_si128(Yv7, Vv7);
-	    Yv8 = _mm_or_si128(Yv8, Vv8);
+            // y = (R[z] << 16) | V[z];
+            Yv5 = _mm_or_si128(Yv5, Vv5);
+            Yv6 = _mm_or_si128(Yv6, Vv6);
+            Yv7 = _mm_or_si128(Yv7, Vv7);
+            Yv8 = _mm_or_si128(Yv8, Vv8);
 
-	    // R[z] = c ? Y[z] : R[z];
-	    Rv5 = _mm_blendv_epi8(Rv5, Yv5, renorm_mask5);
-	    Rv6 = _mm_blendv_epi8(Rv6, Yv6, renorm_mask6);
-	    Rv7 = _mm_blendv_epi8(Rv7, Yv7, renorm_mask7);
-	    Rv8 = _mm_blendv_epi8(Rv8, Yv8, renorm_mask8);
+            // R[z] = c ? Y[z] : R[z];
+            Rv5 = _mm_blendv_epi8(Rv5, Yv5, renorm_mask5);
+            Rv6 = _mm_blendv_epi8(Rv6, Yv6, renorm_mask6);
+            Rv7 = _mm_blendv_epi8(Rv7, Yv7, renorm_mask7);
+            Rv8 = _mm_blendv_epi8(Rv8, Yv8, renorm_mask8);
 
-	    // Maybe just a store128 instead?
-	    _mm_store_si128((__m128i *)&tbuf[tidx][ 0], sv1);
-	    _mm_store_si128((__m128i *)&tbuf[tidx][16], sv5);
-	    //	*(uint64_t *)&out[i+ 0] = _mm_extract_epi64(sv1, 0);
-	    //	*(uint64_t *)&out[i+ 8] = _mm_extract_epi64(sv1, 1);
-	    //	*(uint64_t *)&out[i+16] = _mm_extract_epi64(sv5, 0);
-	    //	*(uint64_t *)&out[i+24] = _mm_extract_epi64(sv5, 1);
+            // Maybe just a store128 instead?
+            _mm_store_si128((__m128i *)&tbuf[tidx][ 0], sv1);
+            _mm_store_si128((__m128i *)&tbuf[tidx][16], sv5);
+            //  *(uint64_t *)&out[i+ 0] = _mm_extract_epi64(sv1, 0);
+            //  *(uint64_t *)&out[i+ 8] = _mm_extract_epi64(sv1, 1);
+            //  *(uint64_t *)&out[i+16] = _mm_extract_epi64(sv5, 0);
+            //  *(uint64_t *)&out[i+24] = _mm_extract_epi64(sv5, 1);
 
-	    // WRONG - need to reorder these periodically.
+            // WRONG - need to reorder these periodically.
 
-	    i4[0]++;
-	    if (++tidx == 32) {
-		i4[0]-=32;
-		transpose_and_copy(out, i4, tbuf);
-		tidx = 0;
-	    }
+            i4[0]++;
+            if (++tidx == 32) {
+                i4[0]-=32;
+                transpose_and_copy(out, i4, tbuf);
+                tidx = 0;
+            }
 
-	}
-	isz4 += 64;
+        }
+        isz4 += 64;
 
-	STORE128(Rv, R);
-	STORE128(Lv, l);
-	ptr = (uint8_t *)sp;
+        STORE128(Rv, R);
+        STORE128(Lv, l);
+        ptr = (uint8_t *)sp;
 
-	i4[0]-=tidx;
-	int T;
-	for (z = 0; z < NX; z++)
-	    for (T = 0; T < tidx; T++)
-		out[i4[z]++] = tbuf[T][z];
+        i4[0]-=tidx;
+        int T;
+        for (z = 0; z < NX; z++)
+            for (T = 0; T < tidx; T++)
+                out[i4[z]++] = tbuf[T][z];
 
-	// Scalar version for close to the end of in[] array so we don't
-	// do SIMD loads beyond the end of the buffer
-	for (; i4[0] < isz4;) {
-	    for (z = 0; z < NX; z++) {
-		uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
-		uint32_t S = s3[l[z]][m];
-		unsigned char c = S & 0xff;
-		out[i4[z]++] = c;
-		uint32_t F = S>>(TF_SHIFT_O1+8);
-		R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
-		    ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
-		RansDecRenormSafe(&R[z], &ptr, ptr_end);
-		l[z] = c;
-	    }
-	}
+        // Scalar version for close to the end of in[] array so we don't
+        // do SIMD loads beyond the end of the buffer
+        for (; i4[0] < isz4;) {
+            for (z = 0; z < NX; z++) {
+                uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
+                uint32_t S = s3[l[z]][m];
+                unsigned char c = S & 0xff;
+                out[i4[z]++] = c;
+                uint32_t F = S>>(TF_SHIFT_O1+8);
+                R[z] = (F?F:4096) * (R[z]>>TF_SHIFT_O1) +
+                    ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
+                RansDecRenormSafe(&R[z], &ptr, ptr_end);
+                l[z] = c;
+            }
+        }
 
-	// Remainder
-	z = NX-1;
-	for (; i4[z] < out_sz; ) {
-	    uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
-	    uint32_t S = s3[l[z]][m];
-	    unsigned char c = S & 0xff;
-	    out[i4[z]++] = c;
-	    R[z] = (S>>(TF_SHIFT_O1+8)) * (R[z]>>TF_SHIFT_O1) +
-		((S>>8) & ((1u<<TF_SHIFT_O1)-1));
-	    RansDecRenormSafe(&R[z], &ptr, ptr_end);
-	    l[z] = c;
-	}
+        // Remainder
+        z = NX-1;
+        for (; i4[z] < out_sz; ) {
+            uint32_t m = R[z] & ((1u<<TF_SHIFT_O1)-1);
+            uint32_t S = s3[l[z]][m];
+            unsigned char c = S & 0xff;
+            out[i4[z]++] = c;
+            R[z] = (S>>(TF_SHIFT_O1+8)) * (R[z]>>TF_SHIFT_O1) +
+                ((S>>8) & ((1u<<TF_SHIFT_O1)-1));
+            RansDecRenormSafe(&R[z], &ptr, ptr_end);
+            l[z] = c;
+        }
     } else {
-	// TF_SHIFT_O1 = 10
+        // TF_SHIFT_O1 = 10
         uint16_t *sp = (uint16_t *)ptr;
-	const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
-	__m128i maskv  = _mm_set1_epi32(mask); // set mask in all lanes
-	uint8_t tbuf[32][32];
-	int tidx = 0;
-	LOAD128(Rv, R);
-	LOAD128(Lv, l);
+        const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
+        __m128i maskv  = _mm_set1_epi32(mask); // set mask in all lanes
+        uint8_t tbuf[32][32];
+        int tidx = 0;
+        LOAD128(Rv, R);
+        LOAD128(Lv, l);
 
-	isz4 -= 64;
-	for (; i4[0] < isz4 && (uint8_t *)sp+72 < ptr_end; ) {
-	    //for (z = 0; z < NX; z++)
-	    //  m[z] = R[z] & mask;
-	    __m128i masked1 = _mm_and_si128(Rv1, maskv);
-	    __m128i masked2 = _mm_and_si128(Rv2, maskv);
-	    __m128i masked3 = _mm_and_si128(Rv3, maskv);
-	    __m128i masked4 = _mm_and_si128(Rv4, maskv);
+        isz4 -= 64;
+        for (; i4[0] < isz4 && (uint8_t *)sp+72 < ptr_end; ) {
+            //for (z = 0; z < NX; z++)
+            //  m[z] = R[z] & mask;
+            __m128i masked1 = _mm_and_si128(Rv1, maskv);
+            __m128i masked2 = _mm_and_si128(Rv2, maskv);
+            __m128i masked3 = _mm_and_si128(Rv3, maskv);
+            __m128i masked4 = _mm_and_si128(Rv4, maskv);
 
-	    Lv1 = _mm_slli_epi32(Lv1, TF_SHIFT_O1_FAST);
-	    Lv2 = _mm_slli_epi32(Lv2, TF_SHIFT_O1_FAST);
-	    Lv3 = _mm_slli_epi32(Lv3, TF_SHIFT_O1_FAST);
-	    Lv4 = _mm_slli_epi32(Lv4, TF_SHIFT_O1_FAST);
-	    masked1 = _mm_add_epi32(masked1, Lv1);
-	    masked2 = _mm_add_epi32(masked2, Lv2);
-	    masked3 = _mm_add_epi32(masked3, Lv3);
-	    masked4 = _mm_add_epi32(masked4, Lv4);
+            Lv1 = _mm_slli_epi32(Lv1, TF_SHIFT_O1_FAST);
+            Lv2 = _mm_slli_epi32(Lv2, TF_SHIFT_O1_FAST);
+            Lv3 = _mm_slli_epi32(Lv3, TF_SHIFT_O1_FAST);
+            Lv4 = _mm_slli_epi32(Lv4, TF_SHIFT_O1_FAST);
+            masked1 = _mm_add_epi32(masked1, Lv1);
+            masked2 = _mm_add_epi32(masked2, Lv2);
+            masked3 = _mm_add_epi32(masked3, Lv3);
+            masked4 = _mm_add_epi32(masked4, Lv4);
 
-	    //  S[z] = s3[l[z]][m[z]];
-	    __m128i Sv1 = _mm_i32gather_epi32x((int *)s3F, masked1, sizeof(*s3));
-	    __m128i Sv2 = _mm_i32gather_epi32x((int *)s3F, masked2, sizeof(*s3));
-	    __m128i Sv3 = _mm_i32gather_epi32x((int *)s3F, masked3, sizeof(*s3));
-	    __m128i Sv4 = _mm_i32gather_epi32x((int *)s3F, masked4, sizeof(*s3));
+            //  S[z] = s3[l[z]][m[z]];
+            __m128i Sv1 = _mm_i32gather_epi32x((int *)s3F, masked1, sizeof(*s3));
+            __m128i Sv2 = _mm_i32gather_epi32x((int *)s3F, masked2, sizeof(*s3));
+            __m128i Sv3 = _mm_i32gather_epi32x((int *)s3F, masked3, sizeof(*s3));
+            __m128i Sv4 = _mm_i32gather_epi32x((int *)s3F, masked4, sizeof(*s3));
 
-	    //  f[z] = S[z]>>(TF_SHIFT+8);
-	    __m128i fv1 = _mm_srli_epi32(Sv1, TF_SHIFT_O1_FAST+8);
-	    __m128i fv2 = _mm_srli_epi32(Sv2, TF_SHIFT_O1_FAST+8);
-	    __m128i fv3 = _mm_srli_epi32(Sv3, TF_SHIFT_O1_FAST+8);
-	    __m128i fv4 = _mm_srli_epi32(Sv4, TF_SHIFT_O1_FAST+8);
+            //  f[z] = S[z]>>(TF_SHIFT+8);
+            __m128i fv1 = _mm_srli_epi32(Sv1, TF_SHIFT_O1_FAST+8);
+            __m128i fv2 = _mm_srli_epi32(Sv2, TF_SHIFT_O1_FAST+8);
+            __m128i fv3 = _mm_srli_epi32(Sv3, TF_SHIFT_O1_FAST+8);
+            __m128i fv4 = _mm_srli_epi32(Sv4, TF_SHIFT_O1_FAST+8);
 
-	    //  b[z] = (S[z]>>8) & mask;
-	    __m128i bv1 = _mm_and_si128(_mm_srli_epi32(Sv1, 8), maskv);
-	    __m128i bv2 = _mm_and_si128(_mm_srli_epi32(Sv2, 8), maskv);
-	    __m128i bv3 = _mm_and_si128(_mm_srli_epi32(Sv3, 8), maskv);
-	    __m128i bv4 = _mm_and_si128(_mm_srli_epi32(Sv4, 8), maskv);
+            //  b[z] = (S[z]>>8) & mask;
+            __m128i bv1 = _mm_and_si128(_mm_srli_epi32(Sv1, 8), maskv);
+            __m128i bv2 = _mm_and_si128(_mm_srli_epi32(Sv2, 8), maskv);
+            __m128i bv3 = _mm_and_si128(_mm_srli_epi32(Sv3, 8), maskv);
+            __m128i bv4 = _mm_and_si128(_mm_srli_epi32(Sv4, 8), maskv);
 
-	    //  s[z] = S[z] & 0xff;
-	    __m128i sv1 = _mm_and_si128(Sv1, _mm_set1_epi32(0xff));
-	    __m128i sv2 = _mm_and_si128(Sv2, _mm_set1_epi32(0xff));
-	    __m128i sv3 = _mm_and_si128(Sv3, _mm_set1_epi32(0xff));
-	    __m128i sv4 = _mm_and_si128(Sv4, _mm_set1_epi32(0xff));
+            //  s[z] = S[z] & 0xff;
+            __m128i sv1 = _mm_and_si128(Sv1, _mm_set1_epi32(0xff));
+            __m128i sv2 = _mm_and_si128(Sv2, _mm_set1_epi32(0xff));
+            __m128i sv3 = _mm_and_si128(Sv3, _mm_set1_epi32(0xff));
+            __m128i sv4 = _mm_and_si128(Sv4, _mm_set1_epi32(0xff));
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1_FAST) + b[z];
-	    Rv1 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-		          _mm_srli_epi32(Rv1,TF_SHIFT_O1_FAST), fv1), bv1);
-	    Rv2 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv2,TF_SHIFT_O1_FAST), fv2), bv2);
-	    Rv3 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv3,TF_SHIFT_O1_FAST), fv3), bv3);
-	    Rv4 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv4,TF_SHIFT_O1_FAST), fv4), bv4);
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1_FAST) + b[z];
+            Rv1 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv1,TF_SHIFT_O1_FAST), fv1), bv1);
+            Rv2 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv2,TF_SHIFT_O1_FAST), fv2), bv2);
+            Rv3 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv3,TF_SHIFT_O1_FAST), fv3), bv3);
+            Rv4 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv4,TF_SHIFT_O1_FAST), fv4), bv4);
 
-	    Lv1 = sv1;
-	    Lv2 = sv2;
-	    Lv3 = sv3;
-	    Lv4 = sv4;
+            Lv1 = sv1;
+            Lv2 = sv2;
+            Lv3 = sv3;
+            Lv4 = sv4;
 
-	    // Tricky one:  out[i+z] = s[z];
-	    //             ---d---c ---b---a  sv1
-	    //             ---h---g ---f---e  sv2
-	    // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
-	    // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
-	    sv1 = _mm_packus_epi32(sv1, sv2);
-	    sv3 = _mm_packus_epi32(sv3, sv4);
-	    sv1 = _mm_packus_epi16(sv1, sv3);
+            // Tricky one:  out[i+z] = s[z];
+            //             ---d---c ---b---a  sv1
+            //             ---h---g ---f---e  sv2
+            // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
+            // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
+            sv1 = _mm_packus_epi32(sv1, sv2);
+            sv3 = _mm_packus_epi32(sv3, sv4);
+            sv1 = _mm_packus_epi16(sv1, sv3);
 
-	    // c =  R[z] < RANS_BYTE_L;
-	    // A little tricky as we only have signed comparisons.
-	    // See https://stackoverflow.com/questions/32945410/sse2-intrinsics-comparing-unsigned-integers
+            // c =  R[z] < RANS_BYTE_L;
+            // A little tricky as we only have signed comparisons.
+            // See https://stackoverflow.com/questions/32945410/sse2-intrinsics-comparing-unsigned-integers
 
 //#define _mm_cmplt_epu32_imm(a,b) _mm_andnot_si128(_mm_cmpeq_epi32(_mm_max_epu32((a),_mm_set1_epi32(b)), (a)), _mm_set1_epi32(-1));
 
-	    //#define _mm_cmplt_epu32_imm(a,b) _mm_cmpgt_epi32(_mm_set1_epi32((b)-0x80000000), _mm_xor_si128((a), _mm_set1_epi32(0x80000000)))
+            //#define _mm_cmplt_epu32_imm(a,b) _mm_cmpgt_epi32(_mm_set1_epi32((b)-0x80000000), _mm_xor_si128((a), _mm_set1_epi32(0x80000000)))
 
-	    __m128i renorm_mask1, renorm_mask2, renorm_mask3, renorm_mask4;
-	    renorm_mask1 = _mm_cmplt_epu32_imm(Rv1, RANS_BYTE_L);
-	    renorm_mask2 = _mm_cmplt_epu32_imm(Rv2, RANS_BYTE_L);
-	    renorm_mask3 = _mm_cmplt_epu32_imm(Rv3, RANS_BYTE_L);
-	    renorm_mask4 = _mm_cmplt_epu32_imm(Rv4, RANS_BYTE_L);
+            __m128i renorm_mask1, renorm_mask2, renorm_mask3, renorm_mask4;
+            renorm_mask1 = _mm_cmplt_epu32_imm(Rv1, RANS_BYTE_L);
+            renorm_mask2 = _mm_cmplt_epu32_imm(Rv2, RANS_BYTE_L);
+            renorm_mask3 = _mm_cmplt_epu32_imm(Rv3, RANS_BYTE_L);
+            renorm_mask4 = _mm_cmplt_epu32_imm(Rv4, RANS_BYTE_L);
 
-	    //#define P(A,B,C,D) ((A)+((B)<<2) + ((C)<<4) + ((D)<<6))
-#define P(A,B,C,D) 				\
-	    { A+0,A+1,A+2,A+3,			\
-  	      B+0,B+1,B+2,B+3,			\
-	      C+0,C+1,C+2,C+3,			\
-	      D+0,D+1,D+2,D+3}
+            //#define P(A,B,C,D) ((A)+((B)<<2) + ((C)<<4) + ((D)<<6))
+#define P(A,B,C,D)                              \
+            { A+0,A+1,A+2,A+3,                  \
+              B+0,B+1,B+2,B+3,                  \
+              C+0,C+1,C+2,C+3,                  \
+              D+0,D+1,D+2,D+3}
 #ifdef _
 #undef _
 #endif
 #define _ 0x80
-	    uint8_t pidx[16][16] = {
-		P(_,_,_,_),
-		P(0,_,_,_),
-		P(_,0,_,_),
-		P(0,4,_,_),
+            uint8_t pidx[16][16] = {
+                P(_,_,_,_),
+                P(0,_,_,_),
+                P(_,0,_,_),
+                P(0,4,_,_),
 
-		P(_,_,0,_),
-		P(0,_,4,_),
-		P(_,0,4,_),
-		P(0,4,8,_),
+                P(_,_,0,_),
+                P(0,_,4,_),
+                P(_,0,4,_),
+                P(0,4,8,_),
 
-		P(_,_,_,0),
-		P(0,_,_,4),
-		P(_,0,_,4),
-		P(0,4,_,8),
+                P(_,_,_,0),
+                P(0,_,_,4),
+                P(_,0,_,4),
+                P(0,4,_,8),
 
-		P(_,_,0,4),
-		P(0,_,4,8),
-		P(_,0,4,8),
-		P(0,4,8,12),
-	    };
+                P(_,_,0,4),
+                P(0,_,4,8),
+                P(_,0,4,8),
+                P(0,4,8,12),
+            };
 #undef _
 
-	    // Shuffle the renorm values to correct lanes and incr sp pointer
-	    __m128i Vv1 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask1 = _mm_movemask_ps((__m128)renorm_mask1);
-	    Vv1 = _mm_shuffle_epi8(Vv1, _mm_load_si128((__m128i*)pidx[imask1]));
-	    sp += _mm_popcnt_u32(imask1);
+            // Shuffle the renorm values to correct lanes and incr sp pointer
+            __m128i Vv1 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask1 = _mm_movemask_ps((__m128)renorm_mask1);
+            Vv1 = _mm_shuffle_epi8(Vv1, _mm_load_si128((__m128i*)pidx[imask1]));
+            sp += _mm_popcnt_u32(imask1);
 
-	    __m128i Vv2 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask2 = _mm_movemask_ps((__m128)renorm_mask2);
-	    sp += _mm_popcnt_u32(imask2);
-	    Vv2 = _mm_shuffle_epi8(Vv2, _mm_load_si128((__m128i*)pidx[imask2]));
+            __m128i Vv2 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask2 = _mm_movemask_ps((__m128)renorm_mask2);
+            sp += _mm_popcnt_u32(imask2);
+            Vv2 = _mm_shuffle_epi8(Vv2, _mm_load_si128((__m128i*)pidx[imask2]));
 
-	    __m128i Vv3 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask3 = _mm_movemask_ps((__m128)renorm_mask3);
-	    Vv3 = _mm_shuffle_epi8(Vv3, _mm_load_si128((__m128i*)pidx[imask3]));
-	    sp += _mm_popcnt_u32(imask3);
+            __m128i Vv3 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask3 = _mm_movemask_ps((__m128)renorm_mask3);
+            Vv3 = _mm_shuffle_epi8(Vv3, _mm_load_si128((__m128i*)pidx[imask3]));
+            sp += _mm_popcnt_u32(imask3);
 
-	    __m128i Vv4 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask4 = _mm_movemask_ps((__m128)renorm_mask4);
-	    sp += _mm_popcnt_u32(imask4);
-	    Vv4 = _mm_shuffle_epi8(Vv4, _mm_load_si128((__m128i*)pidx[imask4]));
+            __m128i Vv4 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask4 = _mm_movemask_ps((__m128)renorm_mask4);
+            sp += _mm_popcnt_u32(imask4);
+            Vv4 = _mm_shuffle_epi8(Vv4, _mm_load_si128((__m128i*)pidx[imask4]));
 
-	    __m128i Yv1 = _mm_slli_epi32(Rv1, 16);
-	    __m128i Yv2 = _mm_slli_epi32(Rv2, 16);
-	    __m128i Yv3 = _mm_slli_epi32(Rv3, 16);
-	    __m128i Yv4 = _mm_slli_epi32(Rv4, 16);
+            __m128i Yv1 = _mm_slli_epi32(Rv1, 16);
+            __m128i Yv2 = _mm_slli_epi32(Rv2, 16);
+            __m128i Yv3 = _mm_slli_epi32(Rv3, 16);
+            __m128i Yv4 = _mm_slli_epi32(Rv4, 16);
 
-	    // y = (R[z] << 16) | V[z];
-	    Yv1 = _mm_or_si128(Yv1, Vv1);
-	    Yv2 = _mm_or_si128(Yv2, Vv2);
-	    Yv3 = _mm_or_si128(Yv3, Vv3);
-	    Yv4 = _mm_or_si128(Yv4, Vv4);
+            // y = (R[z] << 16) | V[z];
+            Yv1 = _mm_or_si128(Yv1, Vv1);
+            Yv2 = _mm_or_si128(Yv2, Vv2);
+            Yv3 = _mm_or_si128(Yv3, Vv3);
+            Yv4 = _mm_or_si128(Yv4, Vv4);
 
-	    // R[z] = c ? Y[z] : R[z];
-	    Rv1 = _mm_blendv_epi8(Rv1, Yv1, renorm_mask1);
-	    Rv2 = _mm_blendv_epi8(Rv2, Yv2, renorm_mask2);
-	    Rv3 = _mm_blendv_epi8(Rv3, Yv3, renorm_mask3);
-	    Rv4 = _mm_blendv_epi8(Rv4, Yv4, renorm_mask4);
+            // R[z] = c ? Y[z] : R[z];
+            Rv1 = _mm_blendv_epi8(Rv1, Yv1, renorm_mask1);
+            Rv2 = _mm_blendv_epi8(Rv2, Yv2, renorm_mask2);
+            Rv3 = _mm_blendv_epi8(Rv3, Yv3, renorm_mask3);
+            Rv4 = _mm_blendv_epi8(Rv4, Yv4, renorm_mask4);
 
-	    // ------------------------------------------------------------
+            // ------------------------------------------------------------
 
-	    //  m[z] = R[z] & mask;
-	    __m128i masked5 = _mm_and_si128(Rv5, maskv);
-	    __m128i masked6 = _mm_and_si128(Rv6, maskv);
-	    __m128i masked7 = _mm_and_si128(Rv7, maskv);
-	    __m128i masked8 = _mm_and_si128(Rv8, maskv);
+            //  m[z] = R[z] & mask;
+            __m128i masked5 = _mm_and_si128(Rv5, maskv);
+            __m128i masked6 = _mm_and_si128(Rv6, maskv);
+            __m128i masked7 = _mm_and_si128(Rv7, maskv);
+            __m128i masked8 = _mm_and_si128(Rv8, maskv);
 
 
-	    Lv5 = _mm_slli_epi32(Lv5, TF_SHIFT_O1_FAST);
-	    Lv6 = _mm_slli_epi32(Lv6, TF_SHIFT_O1_FAST);
-	    Lv7 = _mm_slli_epi32(Lv7, TF_SHIFT_O1_FAST);
-	    Lv8 = _mm_slli_epi32(Lv8, TF_SHIFT_O1_FAST);
-	    masked5 = _mm_add_epi32(masked5, Lv5);
-	    masked6 = _mm_add_epi32(masked6, Lv6);
-	    masked7 = _mm_add_epi32(masked7, Lv7);
-	    masked8 = _mm_add_epi32(masked8, Lv8);
+            Lv5 = _mm_slli_epi32(Lv5, TF_SHIFT_O1_FAST);
+            Lv6 = _mm_slli_epi32(Lv6, TF_SHIFT_O1_FAST);
+            Lv7 = _mm_slli_epi32(Lv7, TF_SHIFT_O1_FAST);
+            Lv8 = _mm_slli_epi32(Lv8, TF_SHIFT_O1_FAST);
+            masked5 = _mm_add_epi32(masked5, Lv5);
+            masked6 = _mm_add_epi32(masked6, Lv6);
+            masked7 = _mm_add_epi32(masked7, Lv7);
+            masked8 = _mm_add_epi32(masked8, Lv8);
 
-	    //  S[z] = s3[m[z]];
-	    __m128i Sv5 = _mm_i32gather_epi32x((int *)s3F, masked5, sizeof(*s3));
-	    __m128i Sv6 = _mm_i32gather_epi32x((int *)s3F, masked6, sizeof(*s3));
-	    __m128i Sv7 = _mm_i32gather_epi32x((int *)s3F, masked7, sizeof(*s3));
-	    __m128i Sv8 = _mm_i32gather_epi32x((int *)s3F, masked8, sizeof(*s3));
+            //  S[z] = s3[m[z]];
+            __m128i Sv5 = _mm_i32gather_epi32x((int *)s3F, masked5, sizeof(*s3));
+            __m128i Sv6 = _mm_i32gather_epi32x((int *)s3F, masked6, sizeof(*s3));
+            __m128i Sv7 = _mm_i32gather_epi32x((int *)s3F, masked7, sizeof(*s3));
+            __m128i Sv8 = _mm_i32gather_epi32x((int *)s3F, masked8, sizeof(*s3));
 
-	    //  f[z] = S[z]>>(TF_SHIFT_O1_FAST+8);
-	    __m128i fv5 = _mm_srli_epi32(Sv5, TF_SHIFT_O1_FAST+8);
-	    __m128i fv6 = _mm_srli_epi32(Sv6, TF_SHIFT_O1_FAST+8);
-	    __m128i fv7 = _mm_srli_epi32(Sv7, TF_SHIFT_O1_FAST+8);
-	    __m128i fv8 = _mm_srli_epi32(Sv8, TF_SHIFT_O1_FAST+8);
+            //  f[z] = S[z]>>(TF_SHIFT_O1_FAST+8);
+            __m128i fv5 = _mm_srli_epi32(Sv5, TF_SHIFT_O1_FAST+8);
+            __m128i fv6 = _mm_srli_epi32(Sv6, TF_SHIFT_O1_FAST+8);
+            __m128i fv7 = _mm_srli_epi32(Sv7, TF_SHIFT_O1_FAST+8);
+            __m128i fv8 = _mm_srli_epi32(Sv8, TF_SHIFT_O1_FAST+8);
 
-	    //  b[z] = (S[z]>>8) & mask;
-	    __m128i bv5 = _mm_and_si128(_mm_srli_epi32(Sv5, 8), maskv);
-	    __m128i bv6 = _mm_and_si128(_mm_srli_epi32(Sv6, 8), maskv);
-	    __m128i bv7 = _mm_and_si128(_mm_srli_epi32(Sv7, 8), maskv);
-	    __m128i bv8 = _mm_and_si128(_mm_srli_epi32(Sv8, 8), maskv);
+            //  b[z] = (S[z]>>8) & mask;
+            __m128i bv5 = _mm_and_si128(_mm_srli_epi32(Sv5, 8), maskv);
+            __m128i bv6 = _mm_and_si128(_mm_srli_epi32(Sv6, 8), maskv);
+            __m128i bv7 = _mm_and_si128(_mm_srli_epi32(Sv7, 8), maskv);
+            __m128i bv8 = _mm_and_si128(_mm_srli_epi32(Sv8, 8), maskv);
 
-	    //  s[z] = S[z] & 0xff;
-	    __m128i sv5 = _mm_and_si128(Sv5, _mm_set1_epi32(0xff));
-	    __m128i sv6 = _mm_and_si128(Sv6, _mm_set1_epi32(0xff));
-	    __m128i sv7 = _mm_and_si128(Sv7, _mm_set1_epi32(0xff));
-	    __m128i sv8 = _mm_and_si128(Sv8, _mm_set1_epi32(0xff));
+            //  s[z] = S[z] & 0xff;
+            __m128i sv5 = _mm_and_si128(Sv5, _mm_set1_epi32(0xff));
+            __m128i sv6 = _mm_and_si128(Sv6, _mm_set1_epi32(0xff));
+            __m128i sv7 = _mm_and_si128(Sv7, _mm_set1_epi32(0xff));
+            __m128i sv8 = _mm_and_si128(Sv8, _mm_set1_epi32(0xff));
 
-	    //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1_FAST) + b[z];
-	    Rv5 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-		          _mm_srli_epi32(Rv5,TF_SHIFT_O1_FAST), fv5), bv5);
-	    Rv6 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv6,TF_SHIFT_O1_FAST), fv6), bv6);
-	    Rv7 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv7,TF_SHIFT_O1_FAST), fv7), bv7);
-	    Rv8 = _mm_add_epi32(
-		      _mm_mullo_epi32(
-			  _mm_srli_epi32(Rv8,TF_SHIFT_O1_FAST), fv8), bv8);
+            //  R[z] = f[z] * (R[z] >> TF_SHIFT_O1_FAST) + b[z];
+            Rv5 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv5,TF_SHIFT_O1_FAST), fv5), bv5);
+            Rv6 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv6,TF_SHIFT_O1_FAST), fv6), bv6);
+            Rv7 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv7,TF_SHIFT_O1_FAST), fv7), bv7);
+            Rv8 = _mm_add_epi32(
+                      _mm_mullo_epi32(
+                          _mm_srli_epi32(Rv8,TF_SHIFT_O1_FAST), fv8), bv8);
 
-	    Lv5 = sv5;
-	    Lv6 = sv6;
-	    Lv7 = sv7;
-	    Lv8 = sv8;
+            Lv5 = sv5;
+            Lv6 = sv6;
+            Lv7 = sv7;
+            Lv8 = sv8;
 
-	    // Tricky one:  out[i+z] = s[z];
-	    //             ---d---c ---b---a  sv1
-	    //             ---h---g ---f---e  sv2
-	    // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
-	    // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
-	    sv5 = _mm_packus_epi32(sv5, sv6);
-	    sv7 = _mm_packus_epi32(sv7, sv8);
-	    sv5 = _mm_packus_epi16(sv5, sv7);
+            // Tricky one:  out[i+z] = s[z];
+            //             ---d---c ---b---a  sv1
+            //             ---h---g ---f---e  sv2
+            // packs_epi32 -h-g-f-e -d-c-b-a  sv1(2)
+            // packs_epi16 ponmlkji hgfedcba  sv1(2) / sv3(4)
+            sv5 = _mm_packus_epi32(sv5, sv6);
+            sv7 = _mm_packus_epi32(sv7, sv8);
+            sv5 = _mm_packus_epi16(sv5, sv7);
 
-	    // c =  R[z] < RANS_BYTE_L;
-	    __m128i renorm_mask5, renorm_mask6, renorm_mask7, renorm_mask8;
-	    renorm_mask5 = _mm_cmplt_epu32_imm(Rv5, RANS_BYTE_L);
-	    renorm_mask6 = _mm_cmplt_epu32_imm(Rv6, RANS_BYTE_L);
-	    renorm_mask7 = _mm_cmplt_epu32_imm(Rv7, RANS_BYTE_L);
-	    renorm_mask8 = _mm_cmplt_epu32_imm(Rv8, RANS_BYTE_L);
-	
-	    // Shuffle the renorm values to correct lanes and incr sp pointer
-	    __m128i Vv5 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask5 = _mm_movemask_ps((__m128)renorm_mask5);
-	    Vv5 = _mm_shuffle_epi8(Vv5, _mm_load_si128((__m128i*)pidx[imask5]));
-	    sp += _mm_popcnt_u32(imask5);
+            // c =  R[z] < RANS_BYTE_L;
+            __m128i renorm_mask5, renorm_mask6, renorm_mask7, renorm_mask8;
+            renorm_mask5 = _mm_cmplt_epu32_imm(Rv5, RANS_BYTE_L);
+            renorm_mask6 = _mm_cmplt_epu32_imm(Rv6, RANS_BYTE_L);
+            renorm_mask7 = _mm_cmplt_epu32_imm(Rv7, RANS_BYTE_L);
+            renorm_mask8 = _mm_cmplt_epu32_imm(Rv8, RANS_BYTE_L);
+        
+            // Shuffle the renorm values to correct lanes and incr sp pointer
+            __m128i Vv5 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask5 = _mm_movemask_ps((__m128)renorm_mask5);
+            Vv5 = _mm_shuffle_epi8(Vv5, _mm_load_si128((__m128i*)pidx[imask5]));
+            sp += _mm_popcnt_u32(imask5);
 
-	    __m128i Vv6 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask6 = _mm_movemask_ps((__m128)renorm_mask6);
-	    sp += _mm_popcnt_u32(imask6);
-	    Vv6 = _mm_shuffle_epi8(Vv6, _mm_load_si128((__m128i*)pidx[imask6]));
+            __m128i Vv6 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask6 = _mm_movemask_ps((__m128)renorm_mask6);
+            sp += _mm_popcnt_u32(imask6);
+            Vv6 = _mm_shuffle_epi8(Vv6, _mm_load_si128((__m128i*)pidx[imask6]));
 
-	    __m128i Vv7 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask7 = _mm_movemask_ps((__m128)renorm_mask7);
-	    Vv7 = _mm_shuffle_epi8(Vv7, _mm_load_si128((__m128i*)pidx[imask7]));
-	    sp += _mm_popcnt_u32(imask7);
+            __m128i Vv7 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask7 = _mm_movemask_ps((__m128)renorm_mask7);
+            Vv7 = _mm_shuffle_epi8(Vv7, _mm_load_si128((__m128i*)pidx[imask7]));
+            sp += _mm_popcnt_u32(imask7);
 
-	    __m128i Vv8 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
-	    unsigned int imask8 = _mm_movemask_ps((__m128)renorm_mask8);
-	    sp += _mm_popcnt_u32(imask8);
-	    Vv8 = _mm_shuffle_epi8(Vv8, _mm_load_si128((__m128i*)pidx[imask8]));
+            __m128i Vv8 = _mm_cvtepu16_epi32(_mm_loadu_si128((__m128i *)sp));
+            unsigned int imask8 = _mm_movemask_ps((__m128)renorm_mask8);
+            sp += _mm_popcnt_u32(imask8);
+            Vv8 = _mm_shuffle_epi8(Vv8, _mm_load_si128((__m128i*)pidx[imask8]));
 
-	    __m128i Yv5 = _mm_slli_epi32(Rv5, 16);
-	    __m128i Yv6 = _mm_slli_epi32(Rv6, 16);
-	    __m128i Yv7 = _mm_slli_epi32(Rv7, 16);
-	    __m128i Yv8 = _mm_slli_epi32(Rv8, 16);
+            __m128i Yv5 = _mm_slli_epi32(Rv5, 16);
+            __m128i Yv6 = _mm_slli_epi32(Rv6, 16);
+            __m128i Yv7 = _mm_slli_epi32(Rv7, 16);
+            __m128i Yv8 = _mm_slli_epi32(Rv8, 16);
 
-	    // y = (R[z] << 16) | V[z];
-	    Yv5 = _mm_or_si128(Yv5, Vv5);
-	    Yv6 = _mm_or_si128(Yv6, Vv6);
-	    Yv7 = _mm_or_si128(Yv7, Vv7);
-	    Yv8 = _mm_or_si128(Yv8, Vv8);
+            // y = (R[z] << 16) | V[z];
+            Yv5 = _mm_or_si128(Yv5, Vv5);
+            Yv6 = _mm_or_si128(Yv6, Vv6);
+            Yv7 = _mm_or_si128(Yv7, Vv7);
+            Yv8 = _mm_or_si128(Yv8, Vv8);
 
-	    // R[z] = c ? Y[z] : R[z];
-	    Rv5 = _mm_blendv_epi8(Rv5, Yv5, renorm_mask5);
-	    Rv6 = _mm_blendv_epi8(Rv6, Yv6, renorm_mask6);
-	    Rv7 = _mm_blendv_epi8(Rv7, Yv7, renorm_mask7);
-	    Rv8 = _mm_blendv_epi8(Rv8, Yv8, renorm_mask8);
+            // R[z] = c ? Y[z] : R[z];
+            Rv5 = _mm_blendv_epi8(Rv5, Yv5, renorm_mask5);
+            Rv6 = _mm_blendv_epi8(Rv6, Yv6, renorm_mask6);
+            Rv7 = _mm_blendv_epi8(Rv7, Yv7, renorm_mask7);
+            Rv8 = _mm_blendv_epi8(Rv8, Yv8, renorm_mask8);
 
-	    // Maybe just a store128 instead?
-	    _mm_store_si128((__m128i *)&tbuf[tidx][ 0], sv1);
-	    _mm_store_si128((__m128i *)&tbuf[tidx][16], sv5);
-	    //	*(uint64_t *)&out[i+ 0] = _mm_extract_epi64(sv1, 0);
-	    //	*(uint64_t *)&out[i+ 8] = _mm_extract_epi64(sv1, 1);
-	    //	*(uint64_t *)&out[i+16] = _mm_extract_epi64(sv5, 0);
-	    //	*(uint64_t *)&out[i+24] = _mm_extract_epi64(sv5, 1);
+            // Maybe just a store128 instead?
+            _mm_store_si128((__m128i *)&tbuf[tidx][ 0], sv1);
+            _mm_store_si128((__m128i *)&tbuf[tidx][16], sv5);
+            //  *(uint64_t *)&out[i+ 0] = _mm_extract_epi64(sv1, 0);
+            //  *(uint64_t *)&out[i+ 8] = _mm_extract_epi64(sv1, 1);
+            //  *(uint64_t *)&out[i+16] = _mm_extract_epi64(sv5, 0);
+            //  *(uint64_t *)&out[i+24] = _mm_extract_epi64(sv5, 1);
 
-	    // WRONG - need to reorder these periodically.
+            // WRONG - need to reorder these periodically.
 
-	    i4[0]++;
-	    if (++tidx == 32) {
-		i4[0]-=32;
-		transpose_and_copy(out, i4, tbuf);
-		tidx = 0;
-	    }
-	}
-	isz4 += 64;
+            i4[0]++;
+            if (++tidx == 32) {
+                i4[0]-=32;
+                transpose_and_copy(out, i4, tbuf);
+                tidx = 0;
+            }
+        }
+        isz4 += 64;
 
-	STORE128(Rv, R);
-	STORE128(Lv, l);
-	ptr = (uint8_t *)sp;
+        STORE128(Rv, R);
+        STORE128(Lv, l);
+        ptr = (uint8_t *)sp;
 
-	i4[0]-=tidx;
-	int T;
-	for (z = 0; z < NX; z++)
-	    for (T = 0; T < tidx; T++)
-		out[i4[z]++] = tbuf[T][z];
+        i4[0]-=tidx;
+        int T;
+        for (z = 0; z < NX; z++)
+            for (T = 0; T < tidx; T++)
+                out[i4[z]++] = tbuf[T][z];
 
-	// Scalar version for close to the end of in[] array so we don't
-	// do SIMD loads beyond the end of the buffer
-	for (; i4[0] < isz4;) {
-	    for (z = 0; z < NX; z++) {
-		uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
-		uint32_t S = s3F[l[z]][m];
-		unsigned char c = S & 0xff;
-		out[i4[z]++] = c;
-		R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
-		    ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-		RansDecRenormSafe(&R[z], &ptr, ptr_end);
-		l[z] = c;
-	    }
-	}
+        // Scalar version for close to the end of in[] array so we don't
+        // do SIMD loads beyond the end of the buffer
+        for (; i4[0] < isz4;) {
+            for (z = 0; z < NX; z++) {
+                uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
+                uint32_t S = s3F[l[z]][m];
+                unsigned char c = S & 0xff;
+                out[i4[z]++] = c;
+                R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
+                    ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+                RansDecRenormSafe(&R[z], &ptr, ptr_end);
+                l[z] = c;
+            }
+        }
 
-	// Remainder
-	z = NX-1;
-	for (; i4[z] < out_sz; ) {
-	    uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
-	    uint32_t S = s3F[l[z]][m];
-	    unsigned char c = S & 0xff;
-	    out[i4[z]++] = c;
-	    R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
-		((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-	    RansDecRenormSafe(&R[z], &ptr, ptr_end);
-	    l[z] = c;
-	}
+        // Remainder
+        z = NX-1;
+        for (; i4[z] < out_sz; ) {
+            uint32_t m = R[z] & ((1u<<TF_SHIFT_O1_FAST)-1);
+            uint32_t S = s3F[l[z]][m];
+            unsigned char c = S & 0xff;
+            out[i4[z]++] = c;
+            R[z] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[z]>>TF_SHIFT_O1_FAST) +
+                ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+            RansDecRenormSafe(&R[z], &ptr, ptr_end);
+            l[z] = c;
+        }
     }
     //fprintf(stderr, "    1 Decoded %d bytes\n", (int)(ptr-in)); //c-size
 

--- a/htscodecs/rANS_static4x16.h
+++ b/htscodecs/rANS_static4x16.h
@@ -40,14 +40,14 @@ extern "C" {
 
 unsigned int rans_compress_bound_4x16(unsigned int size, int order);
 unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
-				     unsigned char *out, unsigned int *out_size,
-				     int order);
+                                     unsigned char *out, unsigned int *out_size,
+                                     int order);
 unsigned char *rans_compress_4x16(unsigned char *in, unsigned int in_size,
-				  unsigned int *out_size, int order);
+                                  unsigned int *out_size, int order);
 unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
-				       unsigned char *out, unsigned int *out_size);
+                                       unsigned char *out, unsigned int *out_size);
 unsigned char *rans_uncompress_4x16(unsigned char *in, unsigned int in_size,
-				    unsigned int *out_size);
+                                    unsigned int *out_size);
 
 // CPU detection control.  Used for testing and benchmarking.
 // These bitfields control what methods are permitted to be used.

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -92,12 +92,12 @@ unsigned int rans_compress_bound_4x16(unsigned int size, int order) {
 
     order &= 0xff;
     unsigned int sz = (order == 0
-	? 1.05*size + 257*3 + 4
-	: 1.05*size + 257*257*3 + 4 + 257*3+4) +
-	((order & RANS_ORDER_PACK) ? 1 : 0) +
-	((order & RANS_ORDER_RLE) ? 1 + 257*3+4: 0) + 20 +
-	((order & RANS_ORDER_X32) ? (32-4)*4 : 0) +
-	((order & RANS_ORDER_STRIPE) ? 1 + 5*N: 0);
+        ? 1.05*size + 257*3 + 4
+        : 1.05*size + 257*257*3 + 4 + 257*3+4) +
+        ((order & RANS_ORDER_PACK) ? 1 : 0) +
+        ((order & RANS_ORDER_RLE) ? 1 + 257*3+4: 0) + 20 +
+        ((order & RANS_ORDER_X32) ? (32-4)*4 : 0) +
+        ((order & RANS_ORDER_STRIPE) ? 1 + 5*N: 0);
     return sz + (sz&1) + 2; // make this even so buffers are word aligned
 }
 
@@ -106,7 +106,7 @@ unsigned int rans_compress_bound_4x16(unsigned int size, int order) {
 // NB: The output buffer does not hold the original size, so it is up to
 // the caller to store this.
 unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
-				     unsigned char *out, unsigned int *out_size) {
+                                     unsigned char *out, unsigned int *out_size) {
     unsigned char *cp, *out_end;
     RansEncSymbol syms[256];
     RansState rans0;
@@ -119,20 +119,20 @@ unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
     int bound = rans_compress_bound_4x16(in_size,0)-20; // -20 for order/size/meta
 
     if (!out) {
-	*out_size = bound;
-	out = malloc(*out_size);
+        *out_size = bound;
+        out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     // If "out" isn't word aligned, tweak out_end/ptr to ensure it is.
     // We already added more round in bound to allow for this.
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     ptr = out_end = out + bound;
 
     if (in_size == 0)
-	goto empty;
+        goto empty;
 
     // Compute statistics
     hist8(in, in_size, F);
@@ -141,10 +141,10 @@ unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
     uint32_t fsum = in_size;
     uint32_t max_val = round2(fsum);
     if (max_val > TOTFREQ)
-	max_val = TOTFREQ;
+        max_val = TOTFREQ;
 
     if (normalise_freq(F, fsum, max_val) < 0)
-	return NULL;
+        return NULL;
     fsum=max_val;
 
     cp = out;
@@ -153,14 +153,14 @@ unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
     //write(2, out+4, cp-(out+4));
 
     if (normalise_freq(F, fsum, TOTFREQ) < 0)
-	return NULL;
+        return NULL;
 
     // Encode statistics.
     for (x = rle = j = 0; j < 256; j++) {
-	if (F[j]) {
-	    RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
-	    x += F[j];
-	}
+        if (F[j]) {
+            RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
+            x += F[j];
+        }
     }
 
     RansEncInit(&rans0);
@@ -173,38 +173,38 @@ unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
     case 2: RansEncPutSymbol(&rans1, &ptr, &syms[in[in_size-(i-1)]]);
     case 1: RansEncPutSymbol(&rans0, &ptr, &syms[in[in_size-(i-0)]]);
     case 0:
-	break;
+        break;
     }
     for (i=(in_size &~3); i>0; i-=4) {
-	RansEncSymbol *s3 = &syms[in[i-1]];
-	RansEncSymbol *s2 = &syms[in[i-2]];
-	RansEncSymbol *s1 = &syms[in[i-3]];
-	RansEncSymbol *s0 = &syms[in[i-4]];
+        RansEncSymbol *s3 = &syms[in[i-1]];
+        RansEncSymbol *s2 = &syms[in[i-2]];
+        RansEncSymbol *s1 = &syms[in[i-3]];
+        RansEncSymbol *s0 = &syms[in[i-4]];
 
 #if 1
-	RansEncPutSymbol(&rans3, &ptr, s3);
-	RansEncPutSymbol(&rans2, &ptr, s2);
-	RansEncPutSymbol(&rans1, &ptr, s1);
-	RansEncPutSymbol(&rans0, &ptr, s0);
+        RansEncPutSymbol(&rans3, &ptr, s3);
+        RansEncPutSymbol(&rans2, &ptr, s2);
+        RansEncPutSymbol(&rans1, &ptr, s1);
+        RansEncPutSymbol(&rans0, &ptr, s0);
 #else
-	// Slightly beter on gcc, much better on clang
-	uint16_t *ptr16 = (uint16_t *)ptr;
+        // Slightly beter on gcc, much better on clang
+        uint16_t *ptr16 = (uint16_t *)ptr;
 
-	if (rans3 >= s3->x_max) *--ptr16 = (uint16_t)rans3, rans3 >>= 16;
-	if (rans2 >= s2->x_max) *--ptr16 = (uint16_t)rans2, rans2 >>= 16;
-	uint32_t q3 = (uint32_t) (((uint64_t)rans3 * s3->rcp_freq) >> s3->rcp_shift);
-	uint32_t q2 = (uint32_t) (((uint64_t)rans2 * s2->rcp_freq) >> s2->rcp_shift);
-	rans3 += s3->bias + q3 * s3->cmpl_freq;
-	rans2 += s2->bias + q2 * s2->cmpl_freq;
+        if (rans3 >= s3->x_max) *--ptr16 = (uint16_t)rans3, rans3 >>= 16;
+        if (rans2 >= s2->x_max) *--ptr16 = (uint16_t)rans2, rans2 >>= 16;
+        uint32_t q3 = (uint32_t) (((uint64_t)rans3 * s3->rcp_freq) >> s3->rcp_shift);
+        uint32_t q2 = (uint32_t) (((uint64_t)rans2 * s2->rcp_freq) >> s2->rcp_shift);
+        rans3 += s3->bias + q3 * s3->cmpl_freq;
+        rans2 += s2->bias + q2 * s2->cmpl_freq;
 
-	if (rans1 >= s1->x_max) *--ptr16 = (uint16_t)rans1, rans1 >>= 16;
-	if (rans0 >= s0->x_max) *--ptr16 = (uint16_t)rans0, rans0 >>= 16;
-	uint32_t q1 = (uint32_t) (((uint64_t)rans1 * s1->rcp_freq) >> s1->rcp_shift);
-	uint32_t q0 = (uint32_t) (((uint64_t)rans0 * s0->rcp_freq) >> s0->rcp_shift);
-	rans1 += s1->bias + q1 * s1->cmpl_freq;
-	rans0 += s0->bias + q0 * s0->cmpl_freq;
+        if (rans1 >= s1->x_max) *--ptr16 = (uint16_t)rans1, rans1 >>= 16;
+        if (rans0 >= s0->x_max) *--ptr16 = (uint16_t)rans0, rans0 >>= 16;
+        uint32_t q1 = (uint32_t) (((uint64_t)rans1 * s1->rcp_freq) >> s1->rcp_shift);
+        uint32_t q0 = (uint32_t) (((uint64_t)rans0 * s0->rcp_freq) >> s0->rcp_shift);
+        rans1 += s1->bias + q1 * s1->cmpl_freq;
+        rans0 += s0->bias + q0 * s0->cmpl_freq;
 
-	ptr = (uint8_t *)ptr16;
+        ptr = (uint8_t *)ptr16;
 #endif
     }
 
@@ -223,16 +223,16 @@ unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
 }
 
 unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
-				       unsigned char *out, unsigned int out_sz) {
+                                       unsigned char *out, unsigned int out_sz) {
     if (in_size < 16) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -245,38 +245,38 @@ unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
     uint8_t  ssym [TOTFREQ+64]; // faster to use 16-bit on clang
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
     if (!out)
-	return NULL;
+        return NULL;
 
     // Precompute reverse lookup of frequency.
     uint32_t F[256] = {0}, fsum;
     int fsz = decode_freq(cp, cp_end, F, &fsum);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     normalise_freq_shift(F, fsum, TOTFREQ);
 
     // Build symbols; fixme, do as part of decode, see the _d variant
     for (j = x = 0; j < 256; j++) {
-	if (F[j]) {
-	    if (F[j] > TOTFREQ - x)
-		goto err;
-	    for (y = 0; y < F[j]; y++) {
-		ssym [y + x] = j;
-		sfreq[y + x] = F[j];
-		sbase[y + x] = y;
-	    }
-	    x += F[j];
-	}
+        if (F[j]) {
+            if (F[j] > TOTFREQ - x)
+                goto err;
+            for (y = 0; y < F[j]; y++) {
+                ssym [y + x] = j;
+                sfreq[y + x] = F[j];
+                sbase[y + x] = y;
+            }
+            x += F[j];
+        }
     }
 
     if (x != TOTFREQ)
-	goto err;
+        goto err;
 
     if (cp+16 > cp_end+8)
-	goto err;
+        goto err;
 
     RansState R[4];
     RansDecInit(&R[0], &cp); if (R[0] < RANS_BYTE_L) goto err;
@@ -288,45 +288,45 @@ unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
 //
 //    for (i = 0; cp < cp_end-8 && i < (out_sz&~7); i+=8) {
 //        for(j=0; j<8;j++) {
-//	    RansState m = RansDecGet(&R[j%4], TF_SHIFT);
-//	    R[j%4] = sfreq[m] * (R[j%4] >> TF_SHIFT) + sbase[m];
-//	    out[i+j] = ssym[m];
-//	    RansDecRenorm(&R[j%4], &cp);
+//          RansState m = RansDecGet(&R[j%4], TF_SHIFT);
+//          R[j%4] = sfreq[m] * (R[j%4] >> TF_SHIFT) + sbase[m];
+//          out[i+j] = ssym[m];
+//          RansDecRenorm(&R[j%4], &cp);
 //        }
 //    }
 
     for (i = 0; cp < cp_end-8 && i < (out_sz&~7); i+=8) {
-	for (j = 0; j < 8; j+=4) {
-	    RansState m0 = RansDecGet(&R[0], TF_SHIFT);
-	    RansState m1 = RansDecGet(&R[1], TF_SHIFT);
-	    R[0] = sfreq[m0] * (R[0] >> TF_SHIFT) + sbase[m0];
-	    R[1] = sfreq[m1] * (R[1] >> TF_SHIFT) + sbase[m1];
+        for (j = 0; j < 8; j+=4) {
+            RansState m0 = RansDecGet(&R[0], TF_SHIFT);
+            RansState m1 = RansDecGet(&R[1], TF_SHIFT);
+            R[0] = sfreq[m0] * (R[0] >> TF_SHIFT) + sbase[m0];
+            R[1] = sfreq[m1] * (R[1] >> TF_SHIFT) + sbase[m1];
 
-	    RansState m2 = RansDecGet(&R[2], TF_SHIFT);
-	    RansState m3 = RansDecGet(&R[3], TF_SHIFT);
+            RansState m2 = RansDecGet(&R[2], TF_SHIFT);
+            RansState m3 = RansDecGet(&R[3], TF_SHIFT);
 
-	    RansDecRenorm(&R[0], &cp);
-	    RansDecRenorm(&R[1], &cp);
+            RansDecRenorm(&R[0], &cp);
+            RansDecRenorm(&R[1], &cp);
 
-	    R[2] = sfreq[m2] * (R[2] >> TF_SHIFT) + sbase[m2];
-	    R[3] = sfreq[m3] * (R[3] >> TF_SHIFT) + sbase[m3];
+            R[2] = sfreq[m2] * (R[2] >> TF_SHIFT) + sbase[m2];
+            R[3] = sfreq[m3] * (R[3] >> TF_SHIFT) + sbase[m3];
 
-	    out[i+j+0] = ssym[m0];
-	    out[i+j+1] = ssym[m1];
-	    out[i+j+2] = ssym[m2];
-	    out[i+j+3] = ssym[m3];
+            out[i+j+0] = ssym[m0];
+            out[i+j+1] = ssym[m1];
+            out[i+j+2] = ssym[m2];
+            out[i+j+3] = ssym[m3];
 
-	    RansDecRenorm(&R[2], &cp);
-	    RansDecRenorm(&R[3], &cp);
-	}
+            RansDecRenorm(&R[2], &cp);
+            RansDecRenorm(&R[3], &cp);
+        }
     }
 
     // remainder
     for (; i < out_sz; i++) {
         RansState m = RansDecGet(&R[i%4], TF_SHIFT);
-	R[i%4] = sfreq[m] * (R[i%4] >> TF_SHIFT) + sbase[m];
-	out[i] = ssym[m];
-	RansDecRenormSafe(&R[i%4], &cp, cp_end+8);
+        R[i%4] = sfreq[m] * (R[i%4] >> TF_SHIFT) + sbase[m];
+        out[i] = ssym[m];
+        RansDecRenormSafe(&R[i%4], &cp, cp_end+8);
     }
 
     //fprintf(stderr, "    0 Decoded %d bytes\n", (int)(cp-in)); //c-size
@@ -355,94 +355,94 @@ int rans_compute_shift(uint32_t *F0, uint32_t (*F)[256], uint32_t *T, int *S) {
     double e10 = 0, e12 = 0;
     int max_tot = 0;
     for (i = 0; i < 256; i++) {
-	if (F0[i] == 0)
-	    continue;
-	int max_val = round2(T[i]);
-	int ns = 0;
+        if (F0[i] == 0)
+            continue;
+        int max_val = round2(T[i]);
+        int ns = 0;
 #define MAX(a,b) ((a)>(b)?(a):(b))
 
-	// Number of samples that get their freq bumped to 1
-	int sm10 = 0, sm12 = 0;
-	for (j = 0; j < 256; j++) {
-	    if (F[i][j] && max_val / F[i][j] > TOTFREQ_O1_FAST)
-		sm10++;
-	    if (F[i][j] && max_val / F[i][j] > TOTFREQ_O1)
-		sm12++;
-	}
+        // Number of samples that get their freq bumped to 1
+        int sm10 = 0, sm12 = 0;
+        for (j = 0; j < 256; j++) {
+            if (F[i][j] && max_val / F[i][j] > TOTFREQ_O1_FAST)
+                sm10++;
+            if (F[i][j] && max_val / F[i][j] > TOTFREQ_O1)
+                sm12++;
+        }
 
-	double l10 = log(TOTFREQ_O1_FAST + sm10);
-	double l12 = log(TOTFREQ_O1      + sm12);
-	double T_slow = (double)TOTFREQ_O1/T[i];
-	double T_fast = (double)TOTFREQ_O1_FAST/T[i];
+        double l10 = log(TOTFREQ_O1_FAST + sm10);
+        double l12 = log(TOTFREQ_O1      + sm12);
+        double T_slow = (double)TOTFREQ_O1/T[i];
+        double T_fast = (double)TOTFREQ_O1_FAST/T[i];
 
-	for (j = 0; j < 256; j++) {
-	    if (F[i][j]) {
-		ns++;
+        for (j = 0; j < 256; j++) {
+            if (F[i][j]) {
+                ns++;
 
-		e10 -= F[i][j] * (fast_log(MAX(F[i][j]*T_fast,1)) - l10);
-		e12 -= F[i][j] * (fast_log(MAX(F[i][j]*T_slow,1)) - l12);
+                e10 -= F[i][j] * (fast_log(MAX(F[i][j]*T_fast,1)) - l10);
+                e12 -= F[i][j] * (fast_log(MAX(F[i][j]*T_slow,1)) - l12);
 
-		// Estimation of compressed symbol freq table too.
-		e10 += 1.3;
-		e12 += 4.7;
-	    }
-	}
+                // Estimation of compressed symbol freq table too.
+                e10 += 1.3;
+                e12 += 4.7;
+            }
+        }
 
-	// Order-1 frequencies often end up totalling under TOTFREQ.
-	// In this case it's smaller to output the real frequencies
-	// prior to normalisation and normalise after (with an extra
-	// normalisation step needed in the decoder too).
-	//
-	// Thus we normalise to a power of 2 only, store those,
-	// and renormalise later here (and in decoder) by bit-shift
-	// to get to the fixed size.
-	if (ns < 64 && max_val > 128) max_val /= 2;
-	if (max_val > 1024)           max_val /= 2;
-	if (max_val > TOTFREQ_O1)     max_val = TOTFREQ_O1;
-	S[i] = max_val; // scale to max this
-	if (max_tot < max_val)
-	    max_tot = max_val;
+        // Order-1 frequencies often end up totalling under TOTFREQ.
+        // In this case it's smaller to output the real frequencies
+        // prior to normalisation and normalise after (with an extra
+        // normalisation step needed in the decoder too).
+        //
+        // Thus we normalise to a power of 2 only, store those,
+        // and renormalise later here (and in decoder) by bit-shift
+        // to get to the fixed size.
+        if (ns < 64 && max_val > 128) max_val /= 2;
+        if (max_val > 1024)           max_val /= 2;
+        if (max_val > TOTFREQ_O1)     max_val = TOTFREQ_O1;
+        S[i] = max_val; // scale to max this
+        if (max_tot < max_val)
+            max_tot = max_val;
     }
     int shift = e10/e12 < 1.01 || max_tot <= TOTFREQ_O1_FAST
-	? TF_SHIFT_O1_FAST
-	: TF_SHIFT_O1;
+        ? TF_SHIFT_O1_FAST
+        : TF_SHIFT_O1;
 
 //    fprintf(stderr, "e10/12 = %f %f %f, shift %d\n",
-//    	    e10/log(256), e12/log(256), e10/e12, shift);
+//          e10/log(256), e12/log(256), e10/e12, shift);
 
     return shift;
 }
 
 static
 unsigned char *rans_compress_O1_4x16(unsigned char *in, unsigned int in_size,
-				     unsigned char *out, unsigned int *out_size) {
+                                     unsigned char *out, unsigned int *out_size) {
     unsigned char *cp, *out_end, *out_free = NULL;
     unsigned int tab_size;
 
     int bound = rans_compress_bound_4x16(in_size,1)-20; // -20 for order/size/meta
 
     if (!out) {
-	*out_size = bound;
-	out_free = out = malloc(*out_size);
+        *out_size = bound;
+        out_free = out = malloc(*out_size);
     }
     if (!out || bound > *out_size)
-	return NULL;
+        return NULL;
 
     if (((size_t)out)&1)
-	bound--;
+        bound--;
     out_end = out + bound;
 
     RansEncSymbol (*syms)[256] = htscodecs_tls_alloc(256 * (sizeof(*syms)));
     if (!syms) {
-	free(out_free);
-	return NULL;
+        free(out_free);
+        return NULL;
     }
 
     cp = out;
     int shift = encode_freq1(in, in_size, 4, syms, &cp); 
     if (shift < 0) {
-	htscodecs_tls_free(syms);
-	return NULL;
+        htscodecs_tls_free(syms);
+        return NULL;
     }
     tab_size = cp - out;
 
@@ -468,27 +468,27 @@ unsigned char *rans_compress_O1_4x16(unsigned char *in, unsigned int in_size,
     // Deal with the remainder
     l3 = in[in_size-1];
     for (i3 = in_size-2; i3 > 4*isz4-2; i3--) {
-	unsigned char c3 = in[i3];
-	RansEncPutSymbol(&rans3, &ptr, &syms[c3][l3]);
-	l3 = c3;
+        unsigned char c3 = in[i3];
+        RansEncPutSymbol(&rans3, &ptr, &syms[c3][l3]);
+        l3 = c3;
     }
 
     for (; i0 >= 0; i0--, i1--, i2--, i3--) {
-	unsigned char c0, c1, c2, c3;
-	RansEncSymbol *s3 = &syms[c3 = in[i3]][l3];
-	RansEncSymbol *s2 = &syms[c2 = in[i2]][l2];
-	RansEncSymbol *s1 = &syms[c1 = in[i1]][l1];
-	RansEncSymbol *s0 = &syms[c0 = in[i0]][l0];
+        unsigned char c0, c1, c2, c3;
+        RansEncSymbol *s3 = &syms[c3 = in[i3]][l3];
+        RansEncSymbol *s2 = &syms[c2 = in[i2]][l2];
+        RansEncSymbol *s1 = &syms[c1 = in[i1]][l1];
+        RansEncSymbol *s0 = &syms[c0 = in[i0]][l0];
 
-	RansEncPutSymbol(&rans3, &ptr, s3);
-	RansEncPutSymbol(&rans2, &ptr, s2);
-	RansEncPutSymbol(&rans1, &ptr, s1);
-	RansEncPutSymbol(&rans0, &ptr, s0);
+        RansEncPutSymbol(&rans3, &ptr, s3);
+        RansEncPutSymbol(&rans2, &ptr, s2);
+        RansEncPutSymbol(&rans1, &ptr, s1);
+        RansEncPutSymbol(&rans0, &ptr, s0);
 
-	l0 = c0;
-	l1 = c1;
-	l2 = c2;
-	l3 = c3;
+        l0 = c0;
+        l1 = c1;
+        l2 = c2;
+        l3 = c3;
     }
 
     RansEncPutSymbol(&rans3, &ptr, &syms[0][l3]);
@@ -516,16 +516,16 @@ unsigned char *rans_compress_O1_4x16(unsigned char *in, unsigned int in_size,
 
 static
 unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
-				       unsigned char *out, unsigned int out_sz) {
+                                       unsigned char *out, unsigned int out_sz) {
     if (in_size < 16) // 4-states at least
-	return NULL;
+        return NULL;
 
     if (out_sz >= INT_MAX)
-	return NULL; // protect against some overflow cases
+        return NULL; // protect against some overflow cases
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (out_sz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     /* Load in the static tables */
@@ -541,24 +541,24 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
     //uint32_t s3[256][TOTFREQ_O1_FAST];
 
     if (!sfb_)
-	return NULL;
+        return NULL;
     fb_t (*fb)[256] = htscodecs_tls_alloc(256 * sizeof(*fb));
     if (!fb)
-	goto err;
+        goto err;
     uint8_t *sfb[256];
     if ((*cp >> 4) == TF_SHIFT_O1) {
-	for (i = 0; i < 256; i++)
-	    sfb[i]=  sfb_ + i*(TOTFREQ_O1+MAGIC2);
+        for (i = 0; i < 256; i++)
+            sfb[i]=  sfb_ + i*(TOTFREQ_O1+MAGIC2);
     } else {
-	for (i = 0; i < 256; i++)
-	    sfb[i]=  sfb_ + i*(TOTFREQ_O1_FAST+MAGIC2);
+        for (i = 0; i < 256; i++)
+            sfb[i]=  sfb_ + i*(TOTFREQ_O1_FAST+MAGIC2);
     }
 
     if (!out)
-	out_free = out = malloc(out_sz);
+        out_free = out = malloc(out_sz);
 
     if (!out)
-	goto err;
+        goto err;
 
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
@@ -567,76 +567,76 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
     unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
-	uint32_t u_freq_sz, c_freq_sz;
-	cp += var_get_u32(cp, cp_end, &u_freq_sz);
-	cp += var_get_u32(cp, cp_end, &c_freq_sz);
-	if (c_freq_sz >= cp_end - cp - 16)
-	    goto err;
-	tab_end = cp + c_freq_sz;
-	if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL, u_freq_sz)))
-	    goto err;
-	cp = c_freq;
-	c_freq_end = c_freq + u_freq_sz;
+        uint32_t u_freq_sz, c_freq_sz;
+        cp += var_get_u32(cp, cp_end, &u_freq_sz);
+        cp += var_get_u32(cp, cp_end, &c_freq_sz);
+        if (c_freq_sz >= cp_end - cp - 16)
+            goto err;
+        tab_end = cp + c_freq_sz;
+        if (!(c_freq = rans_uncompress_O0_4x16(cp, c_freq_sz, NULL, u_freq_sz)))
+            goto err;
+        cp = c_freq;
+        c_freq_end = c_freq + u_freq_sz;
     }
 
     // Decode order-0 symbol list; avoids needing in order-1 tables
     uint32_t F0[256] = {0};
     int fsz = decode_alphabet(cp, c_freq_end, F0);
     if (!fsz)
-	goto err;
+        goto err;
     cp += fsz;
 
     if (cp >= c_freq_end)
-	goto err;
+        goto err;
 
     const int s3_fast_on = in_size >= 100000;
 
     for (i = 0; i < 256; i++) {
-	if (F0[i] == 0)
-	    continue;
+        if (F0[i] == 0)
+            continue;
 
-	uint32_t F[256] = {0}, T = 0;
-	fsz = decode_freq_d(cp, c_freq_end, F0, F, &T);
-	if (!fsz)
-	    goto err;
-	cp += fsz;
+        uint32_t F[256] = {0}, T = 0;
+        fsz = decode_freq_d(cp, c_freq_end, F0, F, &T);
+        if (!fsz)
+            goto err;
+        cp += fsz;
 
-	if (!T) {
-	    //fprintf(stderr, "No freq for F_%d\n", i);
-	    continue;
-	}
+        if (!T) {
+            //fprintf(stderr, "No freq for F_%d\n", i);
+            continue;
+        }
 
-	normalise_freq_shift(F, T, 1<<shift);
+        normalise_freq_shift(F, T, 1<<shift);
 
-	// Build symbols; fixme, do as part of decode, see the _d variant
-	for (j = x = 0; j < 256; j++) {
-	    if (F[j]) {
-		if (F[j] > (1<<shift) - x)
-		    goto err;
+        // Build symbols; fixme, do as part of decode, see the _d variant
+        for (j = x = 0; j < 256; j++) {
+            if (F[j]) {
+                if (F[j] > (1<<shift) - x)
+                    goto err;
 
-		if (shift == TF_SHIFT_O1_FAST && s3_fast_on) {
-		    int y;
-		    for (y = 0; y < F[j]; y++)
-			s3[i][y+x] = (((uint32_t)F[j])<<(shift+8)) |(y<<8) |j;
-		} else {
-		    memset(&sfb[i][x], j, F[j]);
-		    fb[i][j].f = F[j];
-		    fb[i][j].b = x;
-		}
-		x += F[j];
-	    }
-	}
-	if (x != (1<<shift))
-	    goto err;
+                if (shift == TF_SHIFT_O1_FAST && s3_fast_on) {
+                    int y;
+                    for (y = 0; y < F[j]; y++)
+                        s3[i][y+x] = (((uint32_t)F[j])<<(shift+8)) |(y<<8) |j;
+                } else {
+                    memset(&sfb[i][x], j, F[j]);
+                    fb[i][j].f = F[j];
+                    fb[i][j].b = x;
+                }
+                x += F[j];
+            }
+        }
+        if (x != (1<<shift))
+            goto err;
     }
 
     if (tab_end)
-	cp = tab_end;
+        cp = tab_end;
     free(c_freq);
     c_freq = NULL;
 
     if (cp+16 > cp_end)
-	goto err;
+        goto err;
 
     RansState rans0, rans1, rans2, rans3;
     uint8_t *ptr = cp, *ptr_end = in + in_size - 8;
@@ -658,145 +658,145 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
     // Around 15% faster to specialise for 10/12 than to have one
     // loop with shift as a variable.
     if (shift == TF_SHIFT_O1) {
-	// TF_SHIFT_O1 = 12
+        // TF_SHIFT_O1 = 12
 
-	const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
-	for (; i4[0] < isz4; i4[0]++, i4[1]++, i4[2]++, i4[3]++) {
-	    uint16_t m, c;
-	    c = sfb[l0][m = R[0] & mask];
-	    R[0] = fb[l0][c].f * (R[0]>>TF_SHIFT_O1) + m - fb[l0][c].b;
-	    out[i4[0]] = l0 = c;
+        const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
+        for (; i4[0] < isz4; i4[0]++, i4[1]++, i4[2]++, i4[3]++) {
+            uint16_t m, c;
+            c = sfb[l0][m = R[0] & mask];
+            R[0] = fb[l0][c].f * (R[0]>>TF_SHIFT_O1) + m - fb[l0][c].b;
+            out[i4[0]] = l0 = c;
 
-	    c = sfb[l1][m = R[1] & mask];
-	    R[1] = fb[l1][c].f * (R[1]>>TF_SHIFT_O1) + m - fb[l1][c].b;
-	    out[i4[1]] = l1 = c;
+            c = sfb[l1][m = R[1] & mask];
+            R[1] = fb[l1][c].f * (R[1]>>TF_SHIFT_O1) + m - fb[l1][c].b;
+            out[i4[1]] = l1 = c;
 
-	    c = sfb[l2][m = R[2] & mask];
-	    R[2] = fb[l2][c].f * (R[2]>>TF_SHIFT_O1) + m - fb[l2][c].b;
-	    out[i4[2]] = l2 = c;
+            c = sfb[l2][m = R[2] & mask];
+            R[2] = fb[l2][c].f * (R[2]>>TF_SHIFT_O1) + m - fb[l2][c].b;
+            out[i4[2]] = l2 = c;
 
-	    c = sfb[l3][m = R[3] & mask];
-	    R[3] = fb[l3][c].f * (R[3]>>TF_SHIFT_O1) + m - fb[l3][c].b;
-	    out[i4[3]] = l3 = c;
+            c = sfb[l3][m = R[3] & mask];
+            R[3] = fb[l3][c].f * (R[3]>>TF_SHIFT_O1) + m - fb[l3][c].b;
+            out[i4[3]] = l3 = c;
 
-	    if (ptr < ptr_end) {
-		RansDecRenorm(&R[0], &ptr);
-		RansDecRenorm(&R[1], &ptr);
-		RansDecRenorm(&R[2], &ptr);
-		RansDecRenorm(&R[3], &ptr);
-	    } else {
-		RansDecRenormSafe(&R[0], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[1], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[2], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
-	    }
-	}
+            if (ptr < ptr_end) {
+                RansDecRenorm(&R[0], &ptr);
+                RansDecRenorm(&R[1], &ptr);
+                RansDecRenorm(&R[2], &ptr);
+                RansDecRenorm(&R[3], &ptr);
+            } else {
+                RansDecRenormSafe(&R[0], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[1], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[2], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
+            }
+        }
 
-	// Remainder
-	for (; i4[3] < out_sz; i4[3]++) {
-	    uint32_t m3 = R[3] & ((1u<<TF_SHIFT_O1)-1);
-	    unsigned char c3 = sfb[l3][m3];
-	    out[i4[3]] = c3;
-	    R[3] = fb[l3][c3].f * (R[3]>>TF_SHIFT_O1) + m3 - fb[l3][c3].b;
-	    RansDecRenormSafe(&R[3], &ptr, ptr_end + 8);
-	    l3 = c3;
-	}
+        // Remainder
+        for (; i4[3] < out_sz; i4[3]++) {
+            uint32_t m3 = R[3] & ((1u<<TF_SHIFT_O1)-1);
+            unsigned char c3 = sfb[l3][m3];
+            out[i4[3]] = c3;
+            R[3] = fb[l3][c3].f * (R[3]>>TF_SHIFT_O1) + m3 - fb[l3][c3].b;
+            RansDecRenormSafe(&R[3], &ptr, ptr_end + 8);
+            l3 = c3;
+        }
     } else if (!s3_fast_on) {
-	// TF_SHIFT_O1 = 10 with sfb[256][1024] & fb[256]256] array lookup
-	// Slightly faster for -o193 on q4 (high comp), but also less
-	// initialisation cost for smaller data
-	const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
-	for (; i4[0] < isz4; i4[0]++, i4[1]++, i4[2]++, i4[3]++) {
-	    uint16_t m, c;
-	    c = sfb[l0][m = R[0] & mask];
-	    R[0] = fb[l0][c].f * (R[0]>>TF_SHIFT_O1_FAST) + m - fb[l0][c].b;
-	    out[i4[0]] = l0 = c;
+        // TF_SHIFT_O1 = 10 with sfb[256][1024] & fb[256]256] array lookup
+        // Slightly faster for -o193 on q4 (high comp), but also less
+        // initialisation cost for smaller data
+        const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
+        for (; i4[0] < isz4; i4[0]++, i4[1]++, i4[2]++, i4[3]++) {
+            uint16_t m, c;
+            c = sfb[l0][m = R[0] & mask];
+            R[0] = fb[l0][c].f * (R[0]>>TF_SHIFT_O1_FAST) + m - fb[l0][c].b;
+            out[i4[0]] = l0 = c;
 
-	    c = sfb[l1][m = R[1] & mask];
-	    R[1] = fb[l1][c].f * (R[1]>>TF_SHIFT_O1_FAST) + m - fb[l1][c].b;
-	    out[i4[1]] = l1 = c;
+            c = sfb[l1][m = R[1] & mask];
+            R[1] = fb[l1][c].f * (R[1]>>TF_SHIFT_O1_FAST) + m - fb[l1][c].b;
+            out[i4[1]] = l1 = c;
 
-	    c = sfb[l2][m = R[2] & mask];
-	    R[2] = fb[l2][c].f * (R[2]>>TF_SHIFT_O1_FAST) + m - fb[l2][c].b;
-	    out[i4[2]] = l2 = c;
+            c = sfb[l2][m = R[2] & mask];
+            R[2] = fb[l2][c].f * (R[2]>>TF_SHIFT_O1_FAST) + m - fb[l2][c].b;
+            out[i4[2]] = l2 = c;
 
-	    c = sfb[l3][m = R[3] & mask];
-	    R[3] = fb[l3][c].f * (R[3]>>TF_SHIFT_O1_FAST) + m - fb[l3][c].b;
-	    out[i4[3]] = l3 = c;
+            c = sfb[l3][m = R[3] & mask];
+            R[3] = fb[l3][c].f * (R[3]>>TF_SHIFT_O1_FAST) + m - fb[l3][c].b;
+            out[i4[3]] = l3 = c;
 
-	    if (ptr < ptr_end) {
-		RansDecRenorm(&R[0], &ptr);
-		RansDecRenorm(&R[1], &ptr);
-		RansDecRenorm(&R[2], &ptr);
-		RansDecRenorm(&R[3], &ptr);
-	    } else {
-		RansDecRenormSafe(&R[0], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[1], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[2], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
-	    }
-	}
+            if (ptr < ptr_end) {
+                RansDecRenorm(&R[0], &ptr);
+                RansDecRenorm(&R[1], &ptr);
+                RansDecRenorm(&R[2], &ptr);
+                RansDecRenorm(&R[3], &ptr);
+            } else {
+                RansDecRenormSafe(&R[0], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[1], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[2], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
+            }
+        }
 
-	// Remainder
-	for (; i4[3] < out_sz; i4[3]++) {
-	    uint32_t m3 = R[3] & ((1u<<TF_SHIFT_O1_FAST)-1);
-	    unsigned char c3 = sfb[l3][m3];
-	    out[i4[3]] = c3;
-	    R[3] = fb[l3][c3].f * (R[3]>>TF_SHIFT_O1_FAST) + m3 - fb[l3][c3].b;
-	    RansDecRenormSafe(&R[3], &ptr, ptr_end + 8);
-	    l3 = c3;
-	}
+        // Remainder
+        for (; i4[3] < out_sz; i4[3]++) {
+            uint32_t m3 = R[3] & ((1u<<TF_SHIFT_O1_FAST)-1);
+            unsigned char c3 = sfb[l3][m3];
+            out[i4[3]] = c3;
+            R[3] = fb[l3][c3].f * (R[3]>>TF_SHIFT_O1_FAST) + m3 - fb[l3][c3].b;
+            RansDecRenormSafe(&R[3], &ptr, ptr_end + 8);
+            l3 = c3;
+        }
     } else {
-	// TF_SHIFT_O1_FAST.
-	// Significantly faster for -o1 on q40 (low comp).
-	// Higher initialisation cost, so only use if big blocks.
-	const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
-	for (; i4[0] < isz4; i4[0]++, i4[1]++, i4[2]++, i4[3]++) {
-	    uint32_t S0 = s3[l0][R[0] & mask];
-	    uint32_t S1 = s3[l1][R[1] & mask];
-	    l0 = out[i4[0]] = S0;
-	    l1 = out[i4[1]] = S1;
-	    uint16_t F0 = S0>>(TF_SHIFT_O1_FAST+8);
-	    uint16_t F1 = S1>>(TF_SHIFT_O1_FAST+8);
-	    uint16_t B0 = (S0>>8) & mask;
-	    uint16_t B1 = (S1>>8) & mask;
+        // TF_SHIFT_O1_FAST.
+        // Significantly faster for -o1 on q40 (low comp).
+        // Higher initialisation cost, so only use if big blocks.
+        const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
+        for (; i4[0] < isz4; i4[0]++, i4[1]++, i4[2]++, i4[3]++) {
+            uint32_t S0 = s3[l0][R[0] & mask];
+            uint32_t S1 = s3[l1][R[1] & mask];
+            l0 = out[i4[0]] = S0;
+            l1 = out[i4[1]] = S1;
+            uint16_t F0 = S0>>(TF_SHIFT_O1_FAST+8);
+            uint16_t F1 = S1>>(TF_SHIFT_O1_FAST+8);
+            uint16_t B0 = (S0>>8) & mask;
+            uint16_t B1 = (S1>>8) & mask;
 
-	    R[0] = F0 * (R[0]>>TF_SHIFT_O1_FAST) + B0;
-	    R[1] = F1 * (R[1]>>TF_SHIFT_O1_FAST) + B1;
+            R[0] = F0 * (R[0]>>TF_SHIFT_O1_FAST) + B0;
+            R[1] = F1 * (R[1]>>TF_SHIFT_O1_FAST) + B1;
 
-	    uint32_t S2 = s3[l2][R[2] & mask];
-	    uint32_t S3 = s3[l3][R[3] & mask];
-	    l2 = out[i4[2]] = S2;
-	    l3 = out[i4[3]] = S3;
-	    uint16_t F2 = S2>>(TF_SHIFT_O1_FAST+8);
-	    uint16_t F3 = S3>>(TF_SHIFT_O1_FAST+8);
-	    uint16_t B2 = (S2>>8) & mask;
-	    uint16_t B3 = (S3>>8) & mask;
+            uint32_t S2 = s3[l2][R[2] & mask];
+            uint32_t S3 = s3[l3][R[3] & mask];
+            l2 = out[i4[2]] = S2;
+            l3 = out[i4[3]] = S3;
+            uint16_t F2 = S2>>(TF_SHIFT_O1_FAST+8);
+            uint16_t F3 = S3>>(TF_SHIFT_O1_FAST+8);
+            uint16_t B2 = (S2>>8) & mask;
+            uint16_t B3 = (S3>>8) & mask;
 
-	    R[2] = F2 * (R[2]>>TF_SHIFT_O1_FAST) + B2;
-	    R[3] = F3 * (R[3]>>TF_SHIFT_O1_FAST) + B3;
+            R[2] = F2 * (R[2]>>TF_SHIFT_O1_FAST) + B2;
+            R[3] = F3 * (R[3]>>TF_SHIFT_O1_FAST) + B3;
 
-	    if (ptr < ptr_end) {
-		RansDecRenorm(&R[0], &ptr);
-		RansDecRenorm(&R[1], &ptr);
-		RansDecRenorm(&R[2], &ptr);
-		RansDecRenorm(&R[3], &ptr);
-	    } else {
-		RansDecRenormSafe(&R[0], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[1], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[2], &ptr, ptr_end+8);
-		RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
-	    }
-	}
+            if (ptr < ptr_end) {
+                RansDecRenorm(&R[0], &ptr);
+                RansDecRenorm(&R[1], &ptr);
+                RansDecRenorm(&R[2], &ptr);
+                RansDecRenorm(&R[3], &ptr);
+            } else {
+                RansDecRenormSafe(&R[0], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[1], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[2], &ptr, ptr_end+8);
+                RansDecRenormSafe(&R[3], &ptr, ptr_end+8);
+            }
+        }
 
-	// Remainder
-	for (; i4[3] < out_sz; i4[3]++) {
-	    uint32_t S = s3[l3][R[3] & ((1u<<TF_SHIFT_O1_FAST)-1)];
-	    l3 = out[i4[3]] = S;
-	    R[3] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[3]>>TF_SHIFT_O1_FAST)
-		+ ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
-	    RansDecRenormSafe(&R[3], &ptr, ptr_end + 8);
-	}
+        // Remainder
+        for (; i4[3] < out_sz; i4[3]++) {
+            uint32_t S = s3[l3][R[3] & ((1u<<TF_SHIFT_O1_FAST)-1)];
+            l3 = out[i4[3]] = S;
+            R[3] = (S>>(TF_SHIFT_O1_FAST+8)) * (R[3]>>TF_SHIFT_O1_FAST)
+                + ((S>>8) & ((1u<<TF_SHIFT_O1_FAST)-1));
+            RansDecRenormSafe(&R[3], &ptr, ptr_end + 8);
+        }
     }
     //fprintf(stderr, "    1 Decoded %d bytes\n", (int)(ptr-in)); //c-size
 
@@ -863,24 +863,24 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
 
     int level = __get_cpuid_max(0, NULL);
     if (level >= 1) {
-	__cpuid_count(1, 0, eax, ebx, ecx, edx);
+        __cpuid_count(1, 0, eax, ebx, ecx, edx);
 #if defined(bit_SSSE3)
-	have_ssse3 = ecx & bit_SSSE3;
+        have_ssse3 = ecx & bit_SSSE3;
 #endif
 #if defined(bit_POPCNT)
-	have_popcnt = ecx & bit_POPCNT;
+        have_popcnt = ecx & bit_POPCNT;
 #endif
 #if defined(bit_SSE4_1)
-	have_sse4_1 = ecx & bit_SSE4_1;
+        have_sse4_1 = ecx & bit_SSE4_1;
 #endif
     }
     if (level >= 7) {
-	__cpuid_count(7, 0, eax, ebx, ecx, edx);
+        __cpuid_count(7, 0, eax, ebx, ecx, edx);
 #if defined(bit_AVX2)
-	have_avx2 = ebx & bit_AVX2;
+        have_avx2 = ebx & bit_AVX2;
 #endif
 #if defined(bit_AVX512F)
-	have_avx512f = ebx & bit_AVX512F;
+        have_avx512f = ebx & bit_AVX512F;
 #endif
     }
 
@@ -907,18 +907,18 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
         return rans_compress_O1_32x16;
     } else {
 #if defined(HAVE_AVX512)
-	if (have_avx512f)
-	    return rans_compress_O0_32x16_avx512;
+        if (have_avx512f)
+            return rans_compress_O0_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-	if (have_avx2)
-	    return rans_compress_O0_32x16_avx2;
+        if (have_avx2)
+            return rans_compress_O0_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
-	if (have_sse4_1)
-	    return rans_compress_O0_32x16;
+        if (have_sse4_1)
+            return rans_compress_O0_32x16;
 #endif
-	return rans_compress_O0_32x16;
+        return rans_compress_O0_32x16;
     }
 }
 
@@ -944,24 +944,24 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
 
     int level = __get_cpuid_max(0, NULL);
     if (level >= 1) {
-	__cpuid_count(1, 0, eax, ebx, ecx, edx);
+        __cpuid_count(1, 0, eax, ebx, ecx, edx);
 #if defined(bit_SSSE3)
-	have_ssse3 = ecx & bit_SSSE3;
+        have_ssse3 = ecx & bit_SSSE3;
 #endif
 #if defined(bit_POPCNT)
-	have_popcnt = ecx & bit_POPCNT;
+        have_popcnt = ecx & bit_POPCNT;
 #endif
 #if defined(bit_SSE4_1)
-	have_sse4_1 = ecx & bit_SSE4_1;
+        have_sse4_1 = ecx & bit_SSE4_1;
 #endif
     }
     if (level >= 7) {
-	__cpuid_count(7, 0, eax, ebx, ecx, edx);
+        __cpuid_count(7, 0, eax, ebx, ecx, edx);
 #if defined(bit_AVX2)
-	have_avx2 = ebx & bit_AVX2;
+        have_avx2 = ebx & bit_AVX2;
 #endif
 #if defined(bit_AVX512F)
-	have_avx512f = ebx & bit_AVX512F;
+        have_avx512f = ebx & bit_AVX512F;
 #endif
     }
 
@@ -972,17 +972,17 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
     if (!(rans_cpu & RANS_CPU_DEC_AVX2))   have_avx2 = 0;
     if (!(rans_cpu & RANS_CPU_DEC_SSE4))   have_sse4_1 = 0;
 
-    //	fprintf(stderr, "SSSE3 %d, SSE4.1 %d, POPCNT %d, AVX2 %d, AVX512F %d\n",
-    //		have_ssse3, have_sse4_1, have_popcnt, have_avx2, have_avx512f);
+    //  fprintf(stderr, "SSSE3 %d, SSE4.1 %d, POPCNT %d, AVX2 %d, AVX512F %d\n",
+    //          have_ssse3, have_sse4_1, have_popcnt, have_avx2, have_avx512f);
 
     if (order & 1) {
 #if defined(HAVE_AVX512)
-	if (have_avx512f)
-	    return rans_uncompress_O1_32x16_avx512;
+        if (have_avx512f)
+            return rans_uncompress_O1_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-	if (have_avx2)
-	    return rans_uncompress_O1_32x16_avx2;
+        if (have_avx2)
+            return rans_uncompress_O1_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
         if (have_sse4_1)
@@ -991,18 +991,18 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
         return rans_uncompress_O1_32x16;
     } else {
 #if defined(HAVE_AVX512)
-	if (have_avx512f)
-	    return rans_uncompress_O0_32x16_avx512;
+        if (have_avx512f)
+            return rans_uncompress_O0_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-	if (have_avx2)
-	    return rans_uncompress_O0_32x16_avx2;
+        if (have_avx2)
+            return rans_uncompress_O0_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
-	if (have_sse4_1)
-	    return rans_uncompress_O0_32x16_sse4;
+        if (have_sse4_1)
+            return rans_uncompress_O0_32x16_sse4;
 #endif
-	return rans_uncompress_O0_32x16;
+        return rans_uncompress_O0_32x16;
     }
 }
 
@@ -1015,18 +1015,18 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
      unsigned int *out_size) {
 
     if (do_simd) {
-	if (rans_cpu & RANS_CPU_ENC_NEON)
-	    return order & 1
-		? rans_compress_O1_32x16_neon
-		: rans_compress_O0_32x16_neon;
-	else
-	    return order & 1
-		? rans_compress_O1_32x16
-		: rans_compress_O0_32x16;
+        if (rans_cpu & RANS_CPU_ENC_NEON)
+            return order & 1
+                ? rans_compress_O1_32x16_neon
+                : rans_compress_O0_32x16_neon;
+        else
+            return order & 1
+                ? rans_compress_O1_32x16
+                : rans_compress_O0_32x16;
     } else {
-	return order & 1
-	    ? rans_compress_O1_4x16
-	    : rans_compress_O0_4x16;
+        return order & 1
+            ? rans_compress_O1_4x16
+            : rans_compress_O0_4x16;
     }
 }
 
@@ -1038,18 +1038,18 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
      unsigned int out_size) {
 
     if (do_simd) {
-	if (rans_cpu & RANS_CPU_DEC_NEON)
-	    return order & 1
-		? rans_uncompress_O1_32x16_neon
-		: rans_uncompress_O0_32x16_neon;
-	else
-	    return order & 1
-		? rans_uncompress_O1_32x16
-		: rans_uncompress_O0_32x16;
+        if (rans_cpu & RANS_CPU_DEC_NEON)
+            return order & 1
+                ? rans_uncompress_O1_32x16_neon
+                : rans_uncompress_O0_32x16_neon;
+        else
+            return order & 1
+                ? rans_uncompress_O1_32x16
+                : rans_uncompress_O0_32x16;
     } else {
-	return order & 1
-	    ? rans_uncompress_O1_4x16
-	    : rans_uncompress_O0_4x16;
+        return order & 1
+            ? rans_uncompress_O1_4x16
+            : rans_uncompress_O0_4x16;
     }
 }
 
@@ -1063,13 +1063,13 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
      unsigned int *out_size) {
 
     if (do_simd) {
-	return order & 1
-	    ? rans_compress_O1_32x16
-	    : rans_compress_O0_32x16;
+        return order & 1
+            ? rans_compress_O1_32x16
+            : rans_compress_O0_32x16;
     } else {
-	return order & 1
-	    ? rans_compress_O1_4x16
-	    : rans_compress_O0_4x16;
+        return order & 1
+            ? rans_compress_O1_4x16
+            : rans_compress_O0_4x16;
     }
 }
 
@@ -1081,13 +1081,13 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
      unsigned int out_size) {
 
     if (do_simd) {
-	return order & 1
-	    ? rans_uncompress_O1_32x16
-	    : rans_uncompress_O0_32x16;
+        return order & 1
+            ? rans_uncompress_O1_32x16
+            : rans_uncompress_O0_32x16;
     } else {
-	return order & 1
-	    ? rans_uncompress_O1_4x16
-	    : rans_uncompress_O0_4x16;
+        return order & 1
+            ? rans_uncompress_O1_4x16
+            : rans_uncompress_O0_4x16;
     }
 }
 
@@ -1099,18 +1099,18 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
  * Smallest is method, <in_size> <input>, so worst case 2 bytes longer.
  */
 unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
-				     unsigned char *out, unsigned int *out_size,
-				     int order) {
+                                     unsigned char *out, unsigned int *out_size,
+                                     int order) {
     unsigned int c_meta_len;
     uint8_t *meta = NULL, *rle = NULL, *packed = NULL;
     uint8_t *out_free = NULL;
 
     if (!out) {
-	*out_size = rans_compress_bound_4x16(in_size, order);
-	if (*out_size == 0)
-	    return NULL;
-	if (!(out_free = out = malloc(*out_size)))
-	    return NULL;
+        *out_size = rans_compress_bound_4x16(in_size, order);
+        if (*out_size == 0)
+            return NULL;
+        if (!(out_free = out = malloc(*out_size)))
+            return NULL;
     }
 
     unsigned char *out_end = out + *out_size;
@@ -1118,123 +1118,123 @@ unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
     // Permit 32-way unrolling for large blocks, paving the way for
     // AVX2 and AVX512 SIMD variants.
     if ((order & RANS_ORDER_SIMD_AUTO) && in_size >= 50000
-	&& !(order & RANS_ORDER_STRIPE))
-	order |= X_32;
+        && !(order & RANS_ORDER_STRIPE))
+        order |= X_32;
 
     if (in_size <= 20)
-	order &= ~RANS_ORDER_STRIPE;
+        order &= ~RANS_ORDER_STRIPE;
     if (in_size <= 1000)
-	order &= ~RANS_ORDER_X32;
+        order &= ~RANS_ORDER_X32;
 
     if (order & RANS_ORDER_STRIPE) {
-	int N = (order>>8) & 0xff;
-	if (N == 0) N = 4; // default for compatibility with old tests
+        int N = (order>>8) & 0xff;
+        if (N == 0) N = 4; // default for compatibility with old tests
 
-	unsigned char *transposed = malloc(in_size);
-	unsigned int part_len[256];
-	unsigned int idx[256];
-	if (!transposed) {
-	    free(out_free);
-	    return NULL;
-	}
-	int i, j, x;
+        unsigned char *transposed = malloc(in_size);
+        unsigned int part_len[256];
+        unsigned int idx[256];
+        if (!transposed) {
+            free(out_free);
+            return NULL;
+        }
+        int i, j, x;
 
-	for (i = 0; i < N; i++) {
-	    part_len[i] = in_size / N + ((in_size % N) > i);
-	    idx[i] = i ? idx[i-1] + part_len[i-1] : 0; // cumulative index
-	}
+        for (i = 0; i < N; i++) {
+            part_len[i] = in_size / N + ((in_size % N) > i);
+            idx[i] = i ? idx[i-1] + part_len[i-1] : 0; // cumulative index
+        }
 
 #define KN 8
-	i = x = 0;
-	if (in_size >= N*KN) {
-	    for (; i < in_size-N*KN;) {
-		int k;
-		unsigned char *ink = in+i;
-		for (j = 0; j < N; j++)
-		    for (k = 0; k < KN; k++)
-			transposed[idx[j]+x+k] = ink[j+N*k];
-		x += KN; i+=N*KN;
-	    }
-	}
+        i = x = 0;
+        if (in_size >= N*KN) {
+            for (; i < in_size-N*KN;) {
+                int k;
+                unsigned char *ink = in+i;
+                for (j = 0; j < N; j++)
+                    for (k = 0; k < KN; k++)
+                        transposed[idx[j]+x+k] = ink[j+N*k];
+                x += KN; i+=N*KN;
+            }
+        }
 #undef KN
-	for (; i < in_size-N; i += N, x++) {
-	    for (j = 0; j < N; j++)
-		transposed[idx[j]+x] = in[i+j];
-	}
+        for (; i < in_size-N; i += N, x++) {
+            for (j = 0; j < N; j++)
+                transposed[idx[j]+x] = in[i+j];
+        }
 
-	for (; i < in_size; i += N, x++) {
-	    for (j = 0; i+j < in_size; j++)
-		transposed[idx[j]+x] = in[i+j];
-	}
+        for (; i < in_size; i += N, x++) {
+            for (j = 0; i+j < in_size; j++)
+                transposed[idx[j]+x] = in[i+j];
+        }
 
-	unsigned int olen2;
-	unsigned char *out2, *out2_start;
-	c_meta_len = 1;
-	*out = order & ~RANS_ORDER_NOSZ;
-	c_meta_len += var_put_u32(out+c_meta_len, out_end, in_size);
-	out[c_meta_len++] = N;
-	
-	unsigned char *out_best = NULL;
-	unsigned int out_best_len = 0;
+        unsigned int olen2;
+        unsigned char *out2, *out2_start;
+        c_meta_len = 1;
+        *out = order & ~RANS_ORDER_NOSZ;
+        c_meta_len += var_put_u32(out+c_meta_len, out_end, in_size);
+        out[c_meta_len++] = N;
+        
+        unsigned char *out_best = NULL;
+        unsigned int out_best_len = 0;
 
-	out2_start = out2 = out+2+5*N; // shares a buffer with c_meta
+        out2_start = out2 = out+2+5*N; // shares a buffer with c_meta
         for (i = 0; i < N; i++) {
             // Brute force try all methods.
             int j, m[] = {1,64,128,0}, best_j = 0, best_sz = in_size+10;
             for (j = 0; j < sizeof(m)/sizeof(*m); j++) {
-		if ((order & m[j]) != m[j])
+                if ((order & m[j]) != m[j])
                     continue;
 
-		// order-1 *only*; bit check above cannot elide order-0
-		if ((order & RANS_ORDER_STRIPE_NO0) && (m[j]&1) == 0)
-		    continue;
+                // order-1 *only*; bit check above cannot elide order-0
+                if ((order & RANS_ORDER_STRIPE_NO0) && (m[j]&1) == 0)
+                    continue;
                 olen2 = *out_size - (out2 - out);
                 rans_compress_to_4x16(transposed+idx[i], part_len[i],
-				      out2, &olen2,
-				      m[j] | RANS_ORDER_NOSZ
-				      | (order&RANS_ORDER_X32));
+                                      out2, &olen2,
+                                      m[j] | RANS_ORDER_NOSZ
+                                      | (order&RANS_ORDER_X32));
                 if (best_sz > olen2) {
                     best_sz = olen2;
                     best_j = j;
-		    if (j < sizeof(m)/sizeof(*m) && olen2 > out_best_len) {
-			unsigned char *tmp = realloc(out_best, olen2);
-			if (!tmp) {
-			    free(out_free);
-			    return NULL;
-			}
-			out_best = tmp;
-			out_best_len = olen2;
-		    }
+                    if (j < sizeof(m)/sizeof(*m) && olen2 > out_best_len) {
+                        unsigned char *tmp = realloc(out_best, olen2);
+                        if (!tmp) {
+                            free(out_free);
+                            return NULL;
+                        }
+                        out_best = tmp;
+                        out_best_len = olen2;
+                    }
 
-		    // Cache a copy of the best so far
-		    memcpy(out_best, out2, olen2);
+                    // Cache a copy of the best so far
+                    memcpy(out_best, out2, olen2);
                 }
             }
-	    if (best_j < sizeof(m)/sizeof(*m)) {
-		// Copy the best compression to output buffer if not current
-		memcpy(out2, out_best, best_sz);
-		olen2 = best_sz;
-	    }
+            if (best_j < sizeof(m)/sizeof(*m)) {
+                // Copy the best compression to output buffer if not current
+                memcpy(out2, out_best, best_sz);
+                olen2 = best_sz;
+            }
 
             out2 += olen2;
             c_meta_len += var_put_u32(out+c_meta_len, out_end, olen2);
         }
-	if (out_best)
-	    free(out_best);
+        if (out_best)
+            free(out_best);
 
-	memmove(out+c_meta_len, out2_start, out2-out2_start);
-	free(transposed);
-	*out_size = c_meta_len + out2-out2_start;
-	return out;
+        memmove(out+c_meta_len, out2_start, out2-out2_start);
+        free(transposed);
+        *out_size = c_meta_len + out2-out2_start;
+        return out;
     }
 
     if (order & RANS_ORDER_CAT) {
-	out[0] = RANS_ORDER_CAT;
-	c_meta_len = 1;
-	c_meta_len += var_put_u32(&out[1], out_end, in_size);
-	memcpy(out+c_meta_len, in, in_size);
-	*out_size = c_meta_len + in_size;
-	return out;
+        out[0] = RANS_ORDER_CAT;
+        c_meta_len = 1;
+        c_meta_len += var_put_u32(&out[1], out_end, in_size);
+        memcpy(out+c_meta_len, in, in_size);
+        *out_size = c_meta_len + in_size;
+        return out;
     }
 
     int do_pack = order & RANS_ORDER_PACK;
@@ -1246,7 +1246,7 @@ unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
     c_meta_len = 1;
 
     if (!no_size)
-	c_meta_len += var_put_u32(&out[1], out_end, in_size);
+        c_meta_len += var_put_u32(&out[1], out_end, in_size);
 
     order &= 3;
 
@@ -1256,97 +1256,97 @@ unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
     // packed + rle literals.
 
     if (do_pack && in_size) {
-	// PACK 2, 4 or 8 symbols into one byte.
-	int pmeta_len;
-	uint64_t packed_len;
-	packed = hts_pack(in, in_size, out+c_meta_len, &pmeta_len, &packed_len);
-	if (!packed || (pmeta_len == 1 && out[c_meta_len] > 16)) {
-	    out[0] &= ~RANS_ORDER_PACK;
-	    do_pack = 0;
-	    free(packed);
-	    packed = NULL;
-	} else {
-	    in = packed;
-	    in_size = packed_len;
-	    c_meta_len += pmeta_len;
+        // PACK 2, 4 or 8 symbols into one byte.
+        int pmeta_len;
+        uint64_t packed_len;
+        packed = hts_pack(in, in_size, out+c_meta_len, &pmeta_len, &packed_len);
+        if (!packed || (pmeta_len == 1 && out[c_meta_len] > 16)) {
+            out[0] &= ~RANS_ORDER_PACK;
+            do_pack = 0;
+            free(packed);
+            packed = NULL;
+        } else {
+            in = packed;
+            in_size = packed_len;
+            c_meta_len += pmeta_len;
 
-	    // Could derive this rather than storing verbatim.
-	    // Orig size * 8/nbits (+1 if not multiple of 8/n)
-	    int sz = var_put_u32(out+c_meta_len, out_end, in_size);
-	    c_meta_len += sz;
-	    *out_size -= sz;
-	}
+            // Could derive this rather than storing verbatim.
+            // Orig size * 8/nbits (+1 if not multiple of 8/n)
+            int sz = var_put_u32(out+c_meta_len, out_end, in_size);
+            c_meta_len += sz;
+            *out_size -= sz;
+        }
     } else if (do_pack) {
-	out[0] &= ~RANS_ORDER_PACK;
+        out[0] &= ~RANS_ORDER_PACK;
     }
 
     if (do_rle && in_size) {
-	// RLE 'in' -> rle_length + rle_literals arrays
-	unsigned int rmeta_len, c_rmeta_len;
-	uint64_t rle_len;
-	c_rmeta_len = in_size+257;
-	if (!(meta = malloc(c_rmeta_len))) {
-	    free(out_free);
-	    return NULL;
-	}
+        // RLE 'in' -> rle_length + rle_literals arrays
+        unsigned int rmeta_len, c_rmeta_len;
+        uint64_t rle_len;
+        c_rmeta_len = in_size+257;
+        if (!(meta = malloc(c_rmeta_len))) {
+            free(out_free);
+            return NULL;
+        }
 
-	uint8_t rle_syms[256];
-	int rle_nsyms = 0;
-	uint64_t rmeta_len64;
-	rle = hts_rle_encode(in, in_size, meta, &rmeta_len64,
-			     rle_syms, &rle_nsyms, NULL, &rle_len);
-	memmove(meta+1+rle_nsyms, meta, rmeta_len64);
-	meta[0] = rle_nsyms;
-	memcpy(meta+1, rle_syms, rle_nsyms);
-	rmeta_len = rmeta_len64 + rle_nsyms+1;
+        uint8_t rle_syms[256];
+        int rle_nsyms = 0;
+        uint64_t rmeta_len64;
+        rle = hts_rle_encode(in, in_size, meta, &rmeta_len64,
+                             rle_syms, &rle_nsyms, NULL, &rle_len);
+        memmove(meta+1+rle_nsyms, meta, rmeta_len64);
+        meta[0] = rle_nsyms;
+        memcpy(meta+1, rle_syms, rle_nsyms);
+        rmeta_len = rmeta_len64 + rle_nsyms+1;
 
-	if (!rle || rle_len + rmeta_len >= .99*in_size) {
-	    // Not worth the speed hit.
-	    out[0] &= ~RANS_ORDER_RLE;
-	    do_rle = 0;
-	    free(rle);
-	    rle = NULL;
-	} else {
-	    // Compress lengths with O0 and literals with O0/O1 ("order" param)
-	    int sz = var_put_u32(out+c_meta_len, out_end, rmeta_len*2), sz2;
-	    sz += var_put_u32(out+c_meta_len+sz, out_end, rle_len);
-	    c_rmeta_len = *out_size - (c_meta_len+sz+5);
-	    rans_enc_func(do_simd, 0)(meta, rmeta_len, out+c_meta_len+sz+5, &c_rmeta_len);
-	    if (c_rmeta_len < rmeta_len) {
-		sz2 = var_put_u32(out+c_meta_len+sz, out_end, c_rmeta_len);
-		memmove(out+c_meta_len+sz+sz2, out+c_meta_len+sz+5, c_rmeta_len);
-	    } else {
-		// Uncompressed RLE meta-data as too small
-		sz = var_put_u32(out+c_meta_len, out_end, rmeta_len*2+1);
-		sz2 = var_put_u32(out+c_meta_len+sz, out_end, rle_len);
-		memcpy(out+c_meta_len+sz+sz2, meta, rmeta_len);
-		c_rmeta_len = rmeta_len;
-	    }
+        if (!rle || rle_len + rmeta_len >= .99*in_size) {
+            // Not worth the speed hit.
+            out[0] &= ~RANS_ORDER_RLE;
+            do_rle = 0;
+            free(rle);
+            rle = NULL;
+        } else {
+            // Compress lengths with O0 and literals with O0/O1 ("order" param)
+            int sz = var_put_u32(out+c_meta_len, out_end, rmeta_len*2), sz2;
+            sz += var_put_u32(out+c_meta_len+sz, out_end, rle_len);
+            c_rmeta_len = *out_size - (c_meta_len+sz+5);
+            rans_enc_func(do_simd, 0)(meta, rmeta_len, out+c_meta_len+sz+5, &c_rmeta_len);
+            if (c_rmeta_len < rmeta_len) {
+                sz2 = var_put_u32(out+c_meta_len+sz, out_end, c_rmeta_len);
+                memmove(out+c_meta_len+sz+sz2, out+c_meta_len+sz+5, c_rmeta_len);
+            } else {
+                // Uncompressed RLE meta-data as too small
+                sz = var_put_u32(out+c_meta_len, out_end, rmeta_len*2+1);
+                sz2 = var_put_u32(out+c_meta_len+sz, out_end, rle_len);
+                memcpy(out+c_meta_len+sz+sz2, meta, rmeta_len);
+                c_rmeta_len = rmeta_len;
+            }
 
-	    c_meta_len += sz + sz2 + c_rmeta_len;
+            c_meta_len += sz + sz2 + c_rmeta_len;
 
-	    in = rle;
-	    in_size = rle_len;
-	}
+            in = rle;
+            in_size = rle_len;
+        }
 
-	free(meta);
+        free(meta);
     } else if (do_rle) {
-	out[0] &= ~RANS_ORDER_RLE;
+        out[0] &= ~RANS_ORDER_RLE;
     }
 
     *out_size -= c_meta_len;
     if (order && in_size < 8) {
-	out[0] &= ~1;
-	order  &= ~1;
+        out[0] &= ~1;
+        order  &= ~1;
     }
 
     rans_enc_func(do_simd, order)(in, in_size, out+c_meta_len, out_size);
 
     if (*out_size >= in_size) {
-	out[0] &= ~3;
-	out[0] |= RANS_ORDER_CAT | no_size;
-	memcpy(out+c_meta_len, in, in_size);
-	*out_size = in_size;
+        out[0] &= ~3;
+        out[0] |= RANS_ORDER_CAT | no_size;
+        memcpy(out+c_meta_len, in, in_size);
+        *out_size = in_size;
     }
 
     free(rle);
@@ -1358,97 +1358,97 @@ unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
 }
 
 unsigned char *rans_compress_4x16(unsigned char *in, unsigned int in_size,
-				  unsigned int *out_size, int order) {
+                                  unsigned int *out_size, int order) {
     return rans_compress_to_4x16(in, in_size, NULL, out_size, order);
 }
 
 unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
-				       unsigned char *out, unsigned int *out_size) {
+                                       unsigned char *out, unsigned int *out_size) {
     unsigned char *in_end = in + in_size;
     unsigned char *out_free = NULL, *tmp_free = NULL, *meta_free = NULL;
 
     if (in_size == 0)
-	return NULL;
+        return NULL;
 
     if (*in & RANS_ORDER_STRIPE) {
-	unsigned int ulen, olen, c_meta_len = 1;
-	int i;
-	uint64_t clen_tot = 0;
+        unsigned int ulen, olen, c_meta_len = 1;
+        int i;
+        uint64_t clen_tot = 0;
 
-	// Decode lengths
-	c_meta_len += var_get_u32(in+c_meta_len, in_end, &ulen);
-	if (c_meta_len >= in_size)
-	    return NULL;
-	unsigned int N = in[c_meta_len++];
+        // Decode lengths
+        c_meta_len += var_get_u32(in+c_meta_len, in_end, &ulen);
+        if (c_meta_len >= in_size)
+            return NULL;
+        unsigned int N = in[c_meta_len++];
         if (N < 1)  // Must be at least one stripe
             return NULL;
-	unsigned int clenN[256], ulenN[256], idxN[256];
-	if (!out) {
-	    if (ulen >= INT_MAX)
-		return NULL;
+        unsigned int clenN[256], ulenN[256], idxN[256];
+        if (!out) {
+            if (ulen >= INT_MAX)
+                return NULL;
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-	    if (ulen > 100000)
-		return NULL;
+            if (ulen > 100000)
+                return NULL;
 #endif
-	    if (!(out_free = out = malloc(ulen))) {
-		return NULL;
-	    }
-	    *out_size = ulen;
-	}
-	if (ulen != *out_size) {
-	    free(out_free);
-	    return NULL;
-	}
+            if (!(out_free = out = malloc(ulen))) {
+                return NULL;
+            }
+            *out_size = ulen;
+        }
+        if (ulen != *out_size) {
+            free(out_free);
+            return NULL;
+        }
 
-	for (i = 0; i < N; i++) {
-	    ulenN[i] = ulen / N + ((ulen % N) > i);
-	    idxN[i] = i ? idxN[i-1] + ulenN[i-1] : 0;
-	    c_meta_len += var_get_u32(in+c_meta_len, in_end, &clenN[i]);
-	    clen_tot += clenN[i];
-	    if (c_meta_len > in_size || clenN[i] > in_size || clenN[i] < 1) {
-		free(out_free);
-		return NULL;
-	    }
-	}
+        for (i = 0; i < N; i++) {
+            ulenN[i] = ulen / N + ((ulen % N) > i);
+            idxN[i] = i ? idxN[i-1] + ulenN[i-1] : 0;
+            c_meta_len += var_get_u32(in+c_meta_len, in_end, &clenN[i]);
+            clen_tot += clenN[i];
+            if (c_meta_len > in_size || clenN[i] > in_size || clenN[i] < 1) {
+                free(out_free);
+                return NULL;
+            }
+        }
 
-	// We can call this with a larger buffer, but once we've determined
-	// how much we really use we limit it so the recursion becomes easier
-	// to limit.
-	if (c_meta_len + clen_tot > in_size) {
-	    free(out_free);
-	    return NULL;
-	}
-	in_size = c_meta_len + clen_tot;
+        // We can call this with a larger buffer, but once we've determined
+        // how much we really use we limit it so the recursion becomes easier
+        // to limit.
+        if (c_meta_len + clen_tot > in_size) {
+            free(out_free);
+            return NULL;
+        }
+        in_size = c_meta_len + clen_tot;
 
-	//fprintf(stderr, "    stripe meta %d\n", c_meta_len); //c-size
+        //fprintf(stderr, "    stripe meta %d\n", c_meta_len); //c-size
 
-	// Uncompress the N streams
-	unsigned char *outN = malloc(ulen);
-	if (!outN) {
-	    free(out_free);
-	    return NULL;
-	}
-	for (i = 0; i < N; i++) {
-	    olen = ulenN[i];
-	    if (in_size < c_meta_len) {
-		free(out_free);
-		free(outN);
-		return NULL;
-	    }
-	    if (!rans_uncompress_to_4x16(in+c_meta_len, in_size-c_meta_len, outN + idxN[i], &olen)
-		|| olen != ulenN[i]) {
-		free(out_free);
-		free(outN);
-		return NULL;
-	    }
-	    c_meta_len += clenN[i];
-	}
+        // Uncompress the N streams
+        unsigned char *outN = malloc(ulen);
+        if (!outN) {
+            free(out_free);
+            return NULL;
+        }
+        for (i = 0; i < N; i++) {
+            olen = ulenN[i];
+            if (in_size < c_meta_len) {
+                free(out_free);
+                free(outN);
+                return NULL;
+            }
+            if (!rans_uncompress_to_4x16(in+c_meta_len, in_size-c_meta_len, outN + idxN[i], &olen)
+                || olen != ulenN[i]) {
+                free(out_free);
+                free(outN);
+                return NULL;
+            }
+            c_meta_len += clenN[i];
+        }
 
-	unstripe(out, outN, ulen, N, idxN);
+        unstripe(out, outN, ulen, N, idxN);
 
-	free(outN);
-	*out_size = ulen;
-	return out;
+        free(outN);
+        *out_size = ulen;
+        return out;
     }
 
     int order = *in++;  in_size--;
@@ -1462,33 +1462,33 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
     int sz = 0;
     unsigned int osz;
     if (!no_size) {
-	sz = var_get_u32(in, in_end, &osz);
+        sz = var_get_u32(in, in_end, &osz);
     } else
-	sz = 0, osz = *out_size;
+        sz = 0, osz = *out_size;
     in += sz;
     in_size -= sz;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (osz > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     if (no_size && !out)
-	goto err; // Need one or the other
+        goto err; // Need one or the other
 
     if (!out) {
-	*out_size = osz;
-	if (!(out = out_free = malloc(*out_size)))
-	    return NULL;
+        *out_size = osz;
+        if (!(out = out_free = malloc(*out_size)))
+            return NULL;
     } else {
-	if (*out_size < osz)
-	goto err;
-	*out_size = osz;
+        if (*out_size < osz)
+        goto err;
+        *out_size = osz;
     }
 
 //    if (do_pack || do_rle) {
-//	in += sz; // size field not needed when pure rANS
-//	in_size -= sz;
+//      in += sz; // size field not needed when pure rANS
+//      in_size -= sz;
 //    }
 
     uint32_t c_meta_size = 0;
@@ -1516,27 +1516,27 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
     // followed by rANS compressed data.
 
     if (do_pack || do_rle) {
-	if (!(tmp = tmp_free = malloc(*out_size)))
-	    goto err;
-	if (do_pack && do_rle) {
-	    tmp1 = out;
-	    tmp2 = tmp;
-	    tmp3 = out;
-	} else if (do_pack) {
-	    tmp1 = tmp;
-	    tmp2 = tmp1;
-	    tmp3 = out;
-	} else if (do_rle) {
-	    tmp1 = tmp;
-	    tmp2 = out;
-	    tmp3 = out;
-	}
+        if (!(tmp = tmp_free = malloc(*out_size)))
+            goto err;
+        if (do_pack && do_rle) {
+            tmp1 = out;
+            tmp2 = tmp;
+            tmp3 = out;
+        } else if (do_pack) {
+            tmp1 = tmp;
+            tmp2 = tmp1;
+            tmp3 = out;
+        } else if (do_rle) {
+            tmp1 = tmp;
+            tmp2 = out;
+            tmp3 = out;
+        }
     } else {
-	// neither
-	tmp  = NULL;
-	tmp1 = out;
-	tmp2 = out;
-	tmp3 = out;
+        // neither
+        tmp  = NULL;
+        tmp1 = out;
+        tmp2 = out;
+        tmp3 = out;
     }
 
     // Decode the bit-packing map.
@@ -1544,102 +1544,102 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
     int npacked_sym = 0;
     uint64_t unpacked_sz = 0; // FIXME: rename to packed_per_byte
     if (do_pack) {
-	c_meta_size = hts_unpack_meta(in, in_size, *out_size, map, &npacked_sym);
-	if (c_meta_size == 0)
-	    goto err;
+        c_meta_size = hts_unpack_meta(in, in_size, *out_size, map, &npacked_sym);
+        if (c_meta_size == 0)
+            goto err;
 
-	unpacked_sz = osz;
-	in      += c_meta_size;
-	in_size -= c_meta_size;
+        unpacked_sz = osz;
+        in      += c_meta_size;
+        in_size -= c_meta_size;
 
-	// New unpacked size.  We could derive this bit from *out_size
-	// and npacked_sym.
-	unsigned int osz;
-	sz = var_get_u32(in, in_end, &osz);
-	in += sz;
-	in_size -= sz;
-	if (osz > tmp1_size)
-	    goto err;
-	tmp1_size = osz;
+        // New unpacked size.  We could derive this bit from *out_size
+        // and npacked_sym.
+        unsigned int osz;
+        sz = var_get_u32(in, in_end, &osz);
+        in += sz;
+        in_size -= sz;
+        if (osz > tmp1_size)
+            goto err;
+        tmp1_size = osz;
     }
 
     uint8_t *meta = NULL;
     uint32_t u_meta_size = 0;
     if (do_rle) {
-	// Uncompress meta data
-	uint32_t c_meta_size, rle_len, sz;
-	sz  = var_get_u32(in,    in_end, &u_meta_size);
-	sz += var_get_u32(in+sz, in_end, &rle_len);
-	if (rle_len > tmp1_size) // should never grow
-	    goto err;
-	if (u_meta_size & 1) {
-	    meta = in + sz;
-	    u_meta_size = u_meta_size/2 > (in_end-meta) ? (in_end-meta) : u_meta_size/2;
-	    c_meta_size = u_meta_size;
-	} else {
-	    sz += var_get_u32(in+sz, in_end, &c_meta_size);
-	    u_meta_size /= 2;
+        // Uncompress meta data
+        uint32_t c_meta_size, rle_len, sz;
+        sz  = var_get_u32(in,    in_end, &u_meta_size);
+        sz += var_get_u32(in+sz, in_end, &rle_len);
+        if (rle_len > tmp1_size) // should never grow
+            goto err;
+        if (u_meta_size & 1) {
+            meta = in + sz;
+            u_meta_size = u_meta_size/2 > (in_end-meta) ? (in_end-meta) : u_meta_size/2;
+            c_meta_size = u_meta_size;
+        } else {
+            sz += var_get_u32(in+sz, in_end, &c_meta_size);
+            u_meta_size /= 2;
 
-	    meta_free = meta = rans_dec_func(do_simd, 0)(in+sz, in_size-sz, NULL, u_meta_size);
-	    if (!meta)
-		goto err;
-	}
-	if (c_meta_size+sz > in_size)
-	    goto err;
-	in      += c_meta_size+sz;
-	in_size -= c_meta_size+sz;
-	tmp1_size = rle_len;
+            meta_free = meta = rans_dec_func(do_simd, 0)(in+sz, in_size-sz, NULL, u_meta_size);
+            if (!meta)
+                goto err;
+        }
+        if (c_meta_size+sz > in_size)
+            goto err;
+        in      += c_meta_size+sz;
+        in_size -= c_meta_size+sz;
+        tmp1_size = rle_len;
     }
     //fprintf(stderr, "    meta_size %d bytes\n", (int)(in - orig_in)); //c-size
 
     // uncompress RLE data.  in -> tmp1
     if (in_size) {
-	if (do_cat) {
-	    //fprintf(stderr, "    CAT %d\n", tmp1_size); //c-size
-	    if (tmp1_size > in_size)
-		goto err;
-	    if (tmp1_size > *out_size)
-		goto err;
-	    memcpy(tmp1, in, tmp1_size);
-	} else {
-	    tmp1 = rans_dec_func(do_simd, order)(in, in_size, tmp1, tmp1_size);
-	    if (!tmp1)
-		goto err;
-	}
+        if (do_cat) {
+            //fprintf(stderr, "    CAT %d\n", tmp1_size); //c-size
+            if (tmp1_size > in_size)
+                goto err;
+            if (tmp1_size > *out_size)
+                goto err;
+            memcpy(tmp1, in, tmp1_size);
+        } else {
+            tmp1 = rans_dec_func(do_simd, order)(in, in_size, tmp1, tmp1_size);
+            if (!tmp1)
+                goto err;
+        }
     } else {
-	tmp1_size = 0;
+        tmp1_size = 0;
     }
     tmp2_size = tmp3_size = tmp1_size;
 
     if (do_rle) {
-	// Unpack RLE.  tmp1 -> tmp2.
-	if (u_meta_size == 0)
-	    goto err;
-	uint64_t unrle_size = *out_size;
-	int rle_nsyms = *meta ? *meta : 256;
-	if (u_meta_size < 1+rle_nsyms)
-	    goto err;
-	if (!hts_rle_decode(tmp1, tmp1_size,
-			    meta+1+rle_nsyms, u_meta_size-(1+rle_nsyms),
-			    meta+1, rle_nsyms, tmp2, &unrle_size))
-	    goto err;
-	tmp3_size = tmp2_size = unrle_size;
-	free(meta_free);
-	meta_free = NULL;
+        // Unpack RLE.  tmp1 -> tmp2.
+        if (u_meta_size == 0)
+            goto err;
+        uint64_t unrle_size = *out_size;
+        int rle_nsyms = *meta ? *meta : 256;
+        if (u_meta_size < 1+rle_nsyms)
+            goto err;
+        if (!hts_rle_decode(tmp1, tmp1_size,
+                            meta+1+rle_nsyms, u_meta_size-(1+rle_nsyms),
+                            meta+1, rle_nsyms, tmp2, &unrle_size))
+            goto err;
+        tmp3_size = tmp2_size = unrle_size;
+        free(meta_free);
+        meta_free = NULL;
     }
     if (do_pack) {
-	// Unpack bits via pack-map.  tmp2 -> tmp3
-	if (npacked_sym == 1)
-	    unpacked_sz = tmp2_size;
-	//uint8_t *porig = unpack(tmp2, tmp2_size, unpacked_sz, npacked_sym, map);
-	//memcpy(tmp3, porig, unpacked_sz);
-	if (!hts_unpack(tmp2, tmp2_size, tmp3, unpacked_sz, npacked_sym, map))
-	    goto err;
-	tmp3_size = unpacked_sz;
+        // Unpack bits via pack-map.  tmp2 -> tmp3
+        if (npacked_sym == 1)
+            unpacked_sz = tmp2_size;
+        //uint8_t *porig = unpack(tmp2, tmp2_size, unpacked_sz, npacked_sym, map);
+        //memcpy(tmp3, porig, unpacked_sz);
+        if (!hts_unpack(tmp2, tmp2_size, tmp3, unpacked_sz, npacked_sym, map))
+            goto err;
+        tmp3_size = unpacked_sz;
     }
 
     if (tmp)
-	free(tmp);
+        free(tmp);
 
     *out_size = tmp3_size;
     return tmp3;
@@ -1652,6 +1652,6 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
 }
 
 unsigned char *rans_uncompress_4x16(unsigned char *in, unsigned int in_size,
-				    unsigned int *out_size) {
+                                    unsigned int *out_size) {
     return rans_uncompress_to_4x16(in, in_size, NULL, out_size);
 }

--- a/htscodecs/rANS_word.h
+++ b/htscodecs/rANS_word.h
@@ -308,12 +308,12 @@ static inline void RansEncPutSymbol(RansState* r, uint8_t** pptr, RansEncSymbol 
     *pptr = (uint8_t *)(ptr-c);
 #else
     if (x > x_max) {
-	uint8_t* ptr = *pptr;
+        uint8_t* ptr = *pptr;
         ptr -= 2;
-	ptr[0] = x & 0xff;
-	ptr[1] = (x >> 8) & 0xff;
-	x >>= 16;
-	*pptr = ptr;
+        ptr[0] = x & 0xff;
+        ptr[1] = (x >> 8) & 0xff;
+        x >>= 16;
+        *pptr = ptr;
     }
 #endif
 
@@ -345,18 +345,18 @@ static inline void RansEncPutSymbol_branched(RansState* r, uint8_t** pptr, RansE
 #ifdef HTSCODECS_LITTLE_ENDIAN
     // The old non-branchless method
     if (x > x_max) {
-	(*pptr) -= 2;
+        (*pptr) -= 2;
         **(uint16_t **)pptr = x;
-	x >>= 16;
+        x >>= 16;
     }
 #else
     if (x > x_max) {
-	uint8_t* ptr = *pptr;
+        uint8_t* ptr = *pptr;
         ptr -= 2;
-	ptr[0] = x & 0xff;
-	ptr[1] = (x >> 8) & 0xff;
-	x >>= 16;
-	*pptr = ptr;
+        ptr[0] = x & 0xff;
+        ptr[1] = (x >> 8) & 0xff;
+        x >>= 16;
+        *pptr = ptr;
     }
 #endif
 
@@ -417,14 +417,14 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr) {
     uint32_t  x   = *r;
     uint16_t  *ptr = *(uint16_t **)pptr;
     __asm__ ("movzwl (%0),  %%eax\n\t"
-	     "mov    %1,    %%edx\n\t"
-	     "shl    $0x10, %%edx\n\t"
+             "mov    %1,    %%edx\n\t"
+             "shl    $0x10, %%edx\n\t"
              "or     %%eax, %%edx\n\t"
-	     "xor    %%eax, %%eax\n\t"
+             "xor    %%eax, %%eax\n\t"
              "cmp    $0x8000,%1\n\t"
              "cmovb  %%edx, %1\n\t"
-	     "lea    2(%0), %%rax\n\t"
-	     "cmovb  %%rax, %0\n\t"
+             "lea    2(%0), %%rax\n\t"
+             "cmovb  %%rax, %0\n\t"
              : "=r" (ptr), "=r" (x)
              : "0"  (ptr), "1"  (x)
              : "eax", "edx"
@@ -452,9 +452,9 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr)
 //    uint32_t y = (*pptr)[0] | ((*pptr)[1]<<8);
 //
 //    if (x < RANS_BYTE_L)
-//	(*pptr)+=2;
+//      (*pptr)+=2;
 //    if (x < RANS_BYTE_L)
-//	x = (x << 16) | y;
+//      x = (x << 16) | y;
 //
 //    *r = x;
 }

--- a/htscodecs/rle.c
+++ b/htscodecs/rle.c
@@ -46,90 +46,90 @@
 //-----------------------------------------------------------------------------
 // Auto compute rle_syms / rle_nsyms
 static void rle_find_syms(uint8_t *data, uint64_t data_len,
-			  int64_t *saved, // dim >= 256 
-			  uint8_t *rle_syms, int *rle_nsyms) {
+                          int64_t *saved, // dim >= 256 
+                          uint8_t *rle_syms, int *rle_nsyms) {
     int last = -1, n;
     uint64_t i;
 
     if (data_len > 256) {
-	// 186/450
-	// Interleaved buffers to avoid cache collisions
-	int64_t saved2[256+MAGIC] = {0};
-	int64_t saved3[256+MAGIC] = {0};
-	int64_t saved4[256+MAGIC] = {0};
-	int64_t len4 = data_len&~3;
-	for (i = 0; i < len4; i+=4) {
-	    int d1 = (data[i+0] == last)     <<1;
-	    int d2 = (data[i+1] == data[i+0])<<1;
-	    int d3 = (data[i+2] == data[i+1])<<1;
-	    int d4 = (data[i+3] == data[i+2])<<1;
-	    last = data[i+3];
-	    saved [data[i+0]] += d1-1;
-	    saved2[data[i+1]] += d2-1;
-	    saved3[data[i+2]] += d3-1;
-	    saved4[data[i+3]] += d4-1;
-	}
-	while (i < data_len) {
-	    int d = (data[i] == last)<<1;
-	    saved[data[i]] += d - 1;
-	    last = data[i];
-	    i++;
-	}
-	for (i = 0; i < 256; i++)
-	    saved[i] += saved2[i] + saved3[i] + saved4[i];
+        // 186/450
+        // Interleaved buffers to avoid cache collisions
+        int64_t saved2[256+MAGIC] = {0};
+        int64_t saved3[256+MAGIC] = {0};
+        int64_t saved4[256+MAGIC] = {0};
+        int64_t len4 = data_len&~3;
+        for (i = 0; i < len4; i+=4) {
+            int d1 = (data[i+0] == last)     <<1;
+            int d2 = (data[i+1] == data[i+0])<<1;
+            int d3 = (data[i+2] == data[i+1])<<1;
+            int d4 = (data[i+3] == data[i+2])<<1;
+            last = data[i+3];
+            saved [data[i+0]] += d1-1;
+            saved2[data[i+1]] += d2-1;
+            saved3[data[i+2]] += d3-1;
+            saved4[data[i+3]] += d4-1;
+        }
+        while (i < data_len) {
+            int d = (data[i] == last)<<1;
+            saved[data[i]] += d - 1;
+            last = data[i];
+            i++;
+        }
+        for (i = 0; i < 256; i++)
+            saved[i] += saved2[i] + saved3[i] + saved4[i];
     } else {
-	// 163/391
-	for (i = 0; i < data_len; i++) {
-	    if (data[i] == last) {
-		saved[data[i]]++;
-	    } else {
-		saved[data[i]]--;
-		last = data[i];
-	    }
-	}
+        // 163/391
+        for (i = 0; i < data_len; i++) {
+            if (data[i] == last) {
+                saved[data[i]]++;
+            } else {
+                saved[data[i]]--;
+                last = data[i];
+            }
+        }
     }
 
     // Map back to a list
     for (i = n = 0; i < 256; i++) {
-	if (saved[i] > 0)
-	    rle_syms[n++] = i;
+        if (saved[i] > 0)
+            rle_syms[n++] = i;
     }
     *rle_nsyms = n;
 }
 
 uint8_t *hts_rle_encode(uint8_t *data, uint64_t data_len,
-			uint8_t *run,  uint64_t *run_len,
-			uint8_t *rle_syms, int *rle_nsyms,
-			uint8_t *out, uint64_t *out_len) {
+                        uint8_t *run,  uint64_t *run_len,
+                        uint8_t *rle_syms, int *rle_nsyms,
+                        uint8_t *out, uint64_t *out_len) {
     uint64_t i, j, k;
     if (!out)
-	if (!(out = malloc(data_len*2)))
-	    return NULL;
+        if (!(out = malloc(data_len*2)))
+            return NULL;
 
     // Two pass:  Firstly compute which symbols are worth using RLE on.
     int64_t saved[256+MAGIC] = {0};
 
     if (*rle_nsyms) {
-	for (i = 0; i < *rle_nsyms; i++)
-	    saved[rle_syms[i]] = 1;
+        for (i = 0; i < *rle_nsyms; i++)
+            saved[rle_syms[i]] = 1;
     } else {
-	// Writes back to rle_syms and rle_nsyms
-	rle_find_syms(data, data_len, saved, rle_syms, rle_nsyms);
+        // Writes back to rle_syms and rle_nsyms
+        rle_find_syms(data, data_len, saved, rle_syms, rle_nsyms);
     }
 
     // 2nd pass: perform RLE itself to out[] and run[] arrays.
     for (i = j = k = 0; i < data_len; i++) {
-	out[k++] = data[i];
-	if (saved[data[i]] > 0) {
-	    int rlen = i;
-	    int last = data[i];
-	    while (i < data_len && data[i] == last)
-		i++;
-	    i--;
-	    rlen = i-rlen;
+        out[k++] = data[i];
+        if (saved[data[i]] > 0) {
+            int rlen = i;
+            int last = data[i];
+            while (i < data_len && data[i] == last)
+                i++;
+            i--;
+            rlen = i-rlen;
 
-	    j += var_put_u32(&run[j], NULL, rlen);
-	}
+            j += var_put_u32(&run[j], NULL, rlen);
+        }
     }
     
     *run_len = j;
@@ -140,45 +140,45 @@ uint8_t *hts_rle_encode(uint8_t *data, uint64_t data_len,
 // On input *out_len holds the allocated size of out[].
 // On output it holds the used size of out[].
 uint8_t *hts_rle_decode(uint8_t *lit, uint64_t lit_len,
-			uint8_t *run, uint64_t run_len,
-			uint8_t *rle_syms, int rle_nsyms,
-			uint8_t *out, uint64_t *out_len) {
+                        uint8_t *run, uint64_t run_len,
+                        uint8_t *rle_syms, int rle_nsyms,
+                        uint8_t *out, uint64_t *out_len) {
     uint64_t j;
     uint8_t *run_end = run + run_len;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (*out_len > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     int saved[256] = {0};
     for (j = 0; j < rle_nsyms; j++)
-	saved[rle_syms[j]] = 1;
+        saved[rle_syms[j]] = 1;
 
     uint8_t *lit_end = lit + lit_len;
     uint8_t *out_end = out + *out_len;
     uint8_t *outp = out;
 
     while (lit < lit_end) {
-	if (outp >= out_end)
-	    goto err;
+        if (outp >= out_end)
+            goto err;
 
-	uint8_t b = *lit;
-	if (saved[b]) {
-	    uint32_t rlen;
-	    run += var_get_u32(run, run_end, &rlen);
-	    if (rlen) {
-		if (outp + rlen >= out_end)
-		    goto err;
-		memset(outp, b, rlen+1);
-		outp += rlen+1;
-	    } else {
-		*outp++ = b;
-	    }
-	} else {
-	    *outp++ = b;
-	}
-	lit++;
+        uint8_t b = *lit;
+        if (saved[b]) {
+            uint32_t rlen;
+            run += var_get_u32(run, run_end, &rlen);
+            if (rlen) {
+                if (outp + rlen >= out_end)
+                    goto err;
+                memset(outp, b, rlen+1);
+                outp += rlen+1;
+            } else {
+                *outp++ = b;
+            }
+        } else {
+            *outp++ = b;
+        }
+        lit++;
     }
 
     *out_len = outp-out;
@@ -190,18 +190,18 @@ uint8_t *hts_rle_decode(uint8_t *lit, uint64_t lit_len,
 
 // Deprecated interface; to remove when we next to an ABI breakage
 uint8_t *rle_encode(uint8_t *data, uint64_t data_len,
-		    uint8_t *run,  uint64_t *run_len,
-		    uint8_t *rle_syms, int *rle_nsyms,
-		    uint8_t *out, uint64_t *out_len) {
+                    uint8_t *run,  uint64_t *run_len,
+                    uint8_t *rle_syms, int *rle_nsyms,
+                    uint8_t *out, uint64_t *out_len) {
     return hts_rle_encode(data, data_len, run, run_len,
-			  rle_syms, rle_nsyms, out, out_len);
+                          rle_syms, rle_nsyms, out, out_len);
 }
 
 // Deprecated interface; to remove when we next to an ABI breakage
 uint8_t *rle_decode(uint8_t *lit, uint64_t lit_len,
-		    uint8_t *run, uint64_t run_len,
-		    uint8_t *rle_syms, int rle_nsyms,
-		    uint8_t *out, uint64_t *out_len) {
+                    uint8_t *run, uint64_t run_len,
+                    uint8_t *rle_syms, int rle_nsyms,
+                    uint8_t *out, uint64_t *out_len) {
     return hts_rle_decode(lit, lit_len, run, run_len,
-			  rle_syms, rle_nsyms, out, out_len);
+                          rle_syms, rle_nsyms, out, out_len);
 }

--- a/htscodecs/rle.h
+++ b/htscodecs/rle.h
@@ -67,9 +67,9 @@ extern "C" {
  * Returns NULL of failure
  */
 uint8_t *hts_rle_encode(uint8_t *data, uint64_t data_len,
-			uint8_t *run,  uint64_t *run_len,
-			uint8_t *rle_syms, int *rle_nsyms,
-			uint8_t *out, uint64_t *out_len);
+                        uint8_t *run,  uint64_t *run_len,
+                        uint8_t *rle_syms, int *rle_nsyms,
+                        uint8_t *out, uint64_t *out_len);
 
 /*
  * Expands a run lengthed data steam from a pair of literal and
@@ -82,9 +82,9 @@ uint8_t *hts_rle_encode(uint8_t *data, uint64_t data_len,
  *         NULL on failure.
  */
 uint8_t *hts_rle_decode(uint8_t *lit, uint64_t lit_len,
-			uint8_t *run, uint64_t run_len,
-			uint8_t *rle_syms, int rle_nsyms,
-			uint8_t *out, uint64_t *out_len);
+                        uint8_t *run, uint64_t run_len,
+                        uint8_t *rle_syms, int rle_nsyms,
+                        uint8_t *out, uint64_t *out_len);
 
 // TODO: Add rle scanning func to compute rle_syms.
 

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -119,7 +119,7 @@
 #define MAX_NAMES 1000000
 
 enum name_type {N_ERR = -1, N_TYPE = 0, N_ALPHA, N_CHAR, N_DIGITS0, N_DZLEN, N_DUP, N_DIFF, 
-		N_DIGITS, N_DDELTA, N_DDELTA0, N_MATCH, N_NOP, N_END, N_ALL};
+                N_DIGITS, N_DDELTA, N_DDELTA0, N_MATCH, N_NOP, N_END, N_ALL};
 
 typedef struct trie {
     char c;
@@ -168,23 +168,23 @@ typedef struct {
 
 static name_context *create_context(int max_names) {
     if (max_names <= 0)
-	return NULL;
+        return NULL;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (max_names > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     // An arbitrary limit to prevent malformed data from consuming excessive
     // amounts of memory.  Consider upping this if we have genuine use cases
     // for larger blocks.
     if (max_names > 1e7) {
-	fprintf(stderr, "Name codec currently has a max of 10 million rec.\n");
-	return NULL;
+        fprintf(stderr, "Name codec currently has a max of 10 million rec.\n");
+        return NULL;
     }
 
     name_context *ctx = htscodecs_tls_alloc(sizeof(*ctx) +
-					    ++max_names*sizeof(*ctx->lc));
+                                            ++max_names*sizeof(*ctx->lc));
     if (!ctx) return NULL;
     ctx->max_names = max_names;
 
@@ -206,16 +206,16 @@ static name_context *create_context(int max_names) {
 
 static void free_context(name_context *ctx) {
     if (!ctx)
-	return;
+        return;
 
     if (ctx->t_head)
-	free(ctx->t_head);
+        free(ctx->t_head);
     if (ctx->pool)
-	pool_destroy(ctx->pool);
+        pool_destroy(ctx->pool);
 
     int i;
     for (i = 0; i < ctx->max_tok*16; i++)
-	free(ctx->desc[i].buf);
+        free(ctx->desc[i].buf);
 
     htscodecs_tls_free(ctx);
 }
@@ -291,19 +291,19 @@ static int append_uint32_var(char *cp, uint32_t i) {
 // Ensure room for sz more bytes.
 static int descriptor_grow(descriptor *fd, uint32_t sz) {
     while (fd->buf_l + sz > fd->buf_a) {
-	size_t buf_a = fd->buf_a ? fd->buf_a*2 : 65536;
-	unsigned char *buf = realloc(fd->buf, buf_a);
-	if (!buf)
-	    return -1;
-	fd->buf = buf;
-	fd->buf_a = buf_a;
+        size_t buf_a = fd->buf_a ? fd->buf_a*2 : 65536;
+        unsigned char *buf = realloc(fd->buf, buf_a);
+        if (!buf)
+            return -1;
+        fd->buf = buf;
+        fd->buf_a = buf_a;
     }
 
     return 0;
 }
 
 static int encode_token_type(name_context *ctx, int ntok,
-			     enum name_type type) {
+                             enum name_type type) {
     int id = ntok<<4;
 
     if (descriptor_grow(&ctx->desc[id], 1) < 0) return -1;
@@ -329,11 +329,11 @@ static enum name_type decode_token_type(name_context *ctx, int ntok) {
 
 // int stored as 32-bit quantities
 static int encode_token_int(name_context *ctx, int ntok,
-			    enum name_type type, uint32_t val) {
+                            enum name_type type, uint32_t val) {
     int id = (ntok<<4) | type;
 
     if (encode_token_type(ctx, ntok, type) < 0) return -1;
-    if (descriptor_grow(&ctx->desc[id], 4) < 0)	return -1;
+    if (descriptor_grow(&ctx->desc[id], 4) < 0) return -1;
 
     uint8_t *cp = &ctx->desc[id].buf[ctx->desc[id].buf_l];
     cp[0] = (val >>  0) & 0xff;
@@ -347,11 +347,11 @@ static int encode_token_int(name_context *ctx, int ntok,
 
 // Return 0 on success, -1 on failure;
 static int decode_token_int(name_context *ctx, int ntok,
-			    enum name_type type, uint32_t *val) {
+                            enum name_type type, uint32_t *val) {
     int id = (ntok<<4) | type;
 
     if (ctx->desc[id].buf_l + 4 > ctx->desc[id].buf_a)
-	return -1;
+        return -1;
 
     uint8_t *cp = ctx->desc[id].buf + ctx->desc[id].buf_l;
     *val = (cp[0]) + (cp[1]<<8) + (cp[2]<<16) + ((uint32_t)cp[3]<<24);
@@ -362,11 +362,11 @@ static int decode_token_int(name_context *ctx, int ntok,
 
 // 8 bit integer quantity
 static int encode_token_int1(name_context *ctx, int ntok,
-			     enum name_type type, uint32_t val) {
+                             enum name_type type, uint32_t val) {
     int id = (ntok<<4) | type;
 
     if (encode_token_type(ctx, ntok, type) < 0) return -1;
-    if (descriptor_grow(&ctx->desc[id], 1) < 0)	return -1;
+    if (descriptor_grow(&ctx->desc[id], 1) < 0) return -1;
 
     ctx->desc[id].buf[ctx->desc[id].buf_l++] = val;
 
@@ -374,10 +374,10 @@ static int encode_token_int1(name_context *ctx, int ntok,
 }
 
 static int encode_token_int1_(name_context *ctx, int ntok,
-			      enum name_type type, uint32_t val) {
+                              enum name_type type, uint32_t val) {
     int id = (ntok<<4) | type;
 
-    if (descriptor_grow(&ctx->desc[id], 1) < 0)	return -1;
+    if (descriptor_grow(&ctx->desc[id], 1) < 0) return -1;
 
     ctx->desc[id].buf[ctx->desc[id].buf_l++] = val;
 
@@ -386,11 +386,11 @@ static int encode_token_int1_(name_context *ctx, int ntok,
 
 // Return 0 on success, -1 on failure;
 static int decode_token_int1(name_context *ctx, int ntok,
-			     enum name_type type, uint32_t *val) {
+                             enum name_type type, uint32_t *val) {
     int id = (ntok<<4) | type;
 
     if (ctx->desc[id].buf_l  >= ctx->desc[id].buf_a)
-	return -1;
+        return -1;
     *val = ctx->desc[id].buf[ctx->desc[id].buf_l++];
 
     return 0;
@@ -402,7 +402,7 @@ static int decode_token_int1(name_context *ctx, int ntok,
 // Maybe XOR with previous string as context?
 // This permits partial match to be encoded efficiently.
 static int encode_token_alpha(name_context *ctx, int ntok,
-			      char *str, int len) {
+                              char *str, int len) {
     int id = (ntok<<4) | N_ALPHA;
 
     if (encode_token_type(ctx, ntok, N_ALPHA) < 0)  return -1;
@@ -421,10 +421,10 @@ static int decode_token_alpha(name_context *ctx, int ntok, char *str, int max_le
     char c;
     int len = 0;
     if (ctx->desc[id].buf_l  >= ctx->desc[id].buf_a)
-	return -1;
+        return -1;
     do {
-	c = ctx->desc[id].buf[ctx->desc[id].buf_l++];
-	str[len++] = c;
+        c = ctx->desc[id].buf[ctx->desc[id].buf_l++];
+        str[len++] = c;
     } while(c && len < max_len && ctx->desc[id].buf_l < ctx->desc[id].buf_a);
 
     return len-1;
@@ -446,7 +446,7 @@ static int decode_token_char(name_context *ctx, int ntok, char *str) {
     int id = (ntok<<4) | N_CHAR;
 
     if (ctx->desc[id].buf_l  >= ctx->desc[id].buf_a)
-	return -1;
+        return -1;
     *str = ctx->desc[id].buf[ctx->desc[id].buf_l++];
 
     return 1;
@@ -473,44 +473,44 @@ int build_trie(name_context *ctx, char *data, size_t len, int n) {
     trie_t *t;
 
     if (!ctx->t_head) {
-	ctx->t_head = calloc(1, sizeof(*ctx->t_head));
-	if (!ctx->t_head)
-	    return -1;
+        ctx->t_head = calloc(1, sizeof(*ctx->t_head));
+        if (!ctx->t_head)
+            return -1;
     }
 
     // Build our trie, also counting input lines
     for (nlines = i = 0; i < len; i++, nlines++) {
-	t = ctx->t_head;
-	t->count++;
-	while (i < len && data[i] > '\n') {
-	    unsigned char c = data[i++];
-	    if (c & 0x80)
-		//fprintf(stderr, "8-bit ASCII is unsupported\n");
-		abort();
-	    c &= 127;
+        t = ctx->t_head;
+        t->count++;
+        while (i < len && data[i] > '\n') {
+            unsigned char c = data[i++];
+            if (c & 0x80)
+                //fprintf(stderr, "8-bit ASCII is unsupported\n");
+                abort();
+            c &= 127;
 
 
-	    trie_t *x = t->next, *l = NULL;
-	    while (x && x->c != c) {
-		l = x; x = x->sibling;
-	    }
-	    if (!x) {
-		if (!ctx->pool)
-		    ctx->pool = pool_create(sizeof(trie_t));
-		if (!(x = (trie_t *)pool_alloc(ctx->pool)))
-		    return -1;
-		memset(x, 0, sizeof(*x));
-		if (!l)
-		    x = t->next    = x;
-		else
-		    x = l->sibling = x;
-		x->n = n;
-		x->c = c;
-	    }
-	    t = x;
-	    t->c = c;
-	    t->count++;
-	}
+            trie_t *x = t->next, *l = NULL;
+            while (x && x->c != c) {
+                l = x; x = x->sibling;
+            }
+            if (!x) {
+                if (!ctx->pool)
+                    ctx->pool = pool_create(sizeof(trie_t));
+                if (!(x = (trie_t *)pool_alloc(ctx->pool)))
+                    return -1;
+                memset(x, 0, sizeof(*x));
+                if (!l)
+                    x = t->next    = x;
+                else
+                    x = l->sibling = x;
+                x->n = n;
+                x->c = c;
+            }
+            t = x;
+            t->c = c;
+            t->count++;
+        }
     }
 
     return 0;
@@ -519,62 +519,62 @@ int build_trie(name_context *ctx, char *data, size_t len, int n) {
 #if 0
 void dump_trie(trie_t *t, int depth) {
     if (depth == 0) {
-	printf("graph x_%p {\n    splines = ortho\n    ranksep=2\n", t);
-	printf("    p_%p [label=\"\"];\n", t);
-	dump_trie(t, 1);
-	printf("}\n");
+        printf("graph x_%p {\n    splines = ortho\n    ranksep=2\n", t);
+        printf("    p_%p [label=\"\"];\n", t);
+        dump_trie(t, 1);
+        printf("}\n");
     } else {
-	int j, k, count;//, cj;
-	char label[100], *cp;
-	trie_t *tp = t;
+        int j, k, count;//, cj;
+        char label[100], *cp;
+        trie_t *tp = t;
 
 //    patricia:
-//	for (count = j = 0; j < 128; j++)
-//	    if (t->next[j])
-//		count++, cj=j;
+//      for (count = j = 0; j < 128; j++)
+//          if (t->next[j])
+//              count++, cj=j;
 //
-//	if (count == 1) {
-//	    t = t->next[cj];
-//	    *cp++ = cj;
-//	    goto patricia;
-//	}
+//      if (count == 1) {
+//          t = t->next[cj];
+//          *cp++ = cj;
+//          goto patricia;
+//      }
 
-	trie_t *x;
-	for (x = t->next; x; x = x->sibling) {
-	    printf("    p_%p [label=\"%c\"];\n", x, x->c);
-	    printf("    p_%p -- p_%p [label=\"%d\", penwidth=\"%f\"];\n", tp, x, x->count, MAX((log(x->count)-3)*2,1));
-	    //if (depth <= 11)
-		dump_trie(x, depth+1);
-	}
+        trie_t *x;
+        for (x = t->next; x; x = x->sibling) {
+            printf("    p_%p [label=\"%c\"];\n", x, x->c);
+            printf("    p_%p -- p_%p [label=\"%d\", penwidth=\"%f\"];\n", tp, x, x->count, MAX((log(x->count)-3)*2,1));
+            //if (depth <= 11)
+                dump_trie(x, depth+1);
+        }
 
-#if 0	    
-	for (j = 0; j < 128; j++) {
-	    trie_t *tn;
+#if 0       
+        for (j = 0; j < 128; j++) {
+            trie_t *tn;
 
-	    if (!t->next[j])
-		continue;
+            if (!t->next[j])
+                continue;
 
-	    cp = label;
-	    tn = t->next[j];
-	    *cp++ = j;
-//	patricia:
+            cp = label;
+            tn = t->next[j];
+            *cp++ = j;
+//      patricia:
 
-	    for (count = k = 0; k < 128; k++)
-		if (tn->next[k])
-		    count++;//, cj=k;
+            for (count = k = 0; k < 128; k++)
+                if (tn->next[k])
+                    count++;//, cj=k;
 
-//	    if (count == 1) {
-//		tn = tn->next[cj];
-//		*cp++ = cj;
-//		goto patricia;
-//	    }
-	    *cp++ = 0;
+//          if (count == 1) {
+//              tn = tn->next[cj];
+//              *cp++ = cj;
+//              goto patricia;
+//          }
+            *cp++ = 0;
 
-	    printf("    p_%p [label=\"%s\"];\n", tn, label);
-	    printf("    p_%p -- p_%p [label=\"%d\", penwidth=\"%f\"];\n", tp, tn, tn->count, MAX((log(tn->count)-3)*2,1));
-	    if (depth <= 11)
-		dump_trie(tn, depth+1);
-	}
+            printf("    p_%p [label=\"%s\"];\n", tn, label);
+            printf("    p_%p -- p_%p [label=\"%d\", penwidth=\"%f\"];\n", tp, tn, tn->count, MAX((log(tn->count)-3)*2,1));
+            if (depth <= 11)
+                dump_trie(tn, depth+1);
+        }
 #endif
     }
 }
@@ -597,75 +597,75 @@ int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, in
     int l   = *data == '@' ? len-1  : len;
     int f = (*data == '>') ? 1 : 0;
     if (l > 70 && d[f+0] == 'm' && d[7] == '_' && d[f+14] == '_' && d[f+61] == '/') {
-	prefix_len = 60; // PacBio
-	*is_fixed = 0;
+        prefix_len = 60; // PacBio
+        *is_fixed = 0;
     } else if (l == 17 && d[f+5] == ':' && d[f+11] == ':') {
-	prefix_len = 6;  // IonTorrent
-	*fixed_len = 6;
-	*is_fixed = 1;
+        prefix_len = 6;  // IonTorrent
+        *fixed_len = 6;
+        *is_fixed = 1;
     } else if (l > 37 && d[f+8] == '-' && d[f+13] == '-' && d[f+18] == '-' && d[f+23] == '-' &&
-	       ((d[f+0] >= '0' && d[f+0] <='9') || (d[f+0] >= 'a' && d[f+0] <= 'f')) &&
-	       ((d[f+35] >= '0' && d[f+35] <='9') || (d[f+35] >= 'a' && d[f+35] <= 'f'))) {
-	// ONT: f33d30d5-6eb8-4115-8f46-154c2620a5da_Basecall_1D_template...
-	prefix_len = 37;
-	*fixed_len = 37;
-	*is_fixed = 1;
+               ((d[f+0] >= '0' && d[f+0] <='9') || (d[f+0] >= 'a' && d[f+0] <= 'f')) &&
+               ((d[f+35] >= '0' && d[f+35] <='9') || (d[f+35] >= 'a' && d[f+35] <= 'f'))) {
+        // ONT: f33d30d5-6eb8-4115-8f46-154c2620a5da_Basecall_1D_template...
+        prefix_len = 37;
+        *fixed_len = 37;
+        *is_fixed = 1;
     } else {
-	// Check Illumina and trim back to lane:tile:x:y.
-	int colons = 0;
-	for (i = 0; i < len && data[i] > ' '; i++)
-	    ;
-	while (i > 0 && colons < 4)
-	    if (data[--i] == ':')
-		colons++;
+        // Check Illumina and trim back to lane:tile:x:y.
+        int colons = 0;
+        for (i = 0; i < len && data[i] > ' '; i++)
+            ;
+        while (i > 0 && colons < 4)
+            if (data[--i] == ':')
+                colons++;
 
-	if (colons == 4) {
-	    // Constant illumina prefix
-	    *fixed_len = i+1;
-	    prefix_len = i+1;
-	    *is_fixed = 1;
-	} else {
-	    // Unknown, don't use a fixed len, but still search
-	    // for any exact matches.
-	    prefix_len = INT_MAX;
-	    *is_fixed = 0;
-	}
+        if (colons == 4) {
+            // Constant illumina prefix
+            *fixed_len = i+1;
+            prefix_len = i+1;
+            *is_fixed = 1;
+        } else {
+            // Unknown, don't use a fixed len, but still search
+            // for any exact matches.
+            prefix_len = INT_MAX;
+            *is_fixed = 0;
+        }
     }
     //prefix_len = INT_MAX;
 
     if (!ctx->t_head) {
-	ctx->t_head = calloc(1, sizeof(*ctx->t_head));
-	if (!ctx->t_head)
-	    return -1;
+        ctx->t_head = calloc(1, sizeof(*ctx->t_head));
+        if (!ctx->t_head)
+            return -1;
     }
 
     // Find an item in the trie
     for (nlines = i = 0; i < len; i++, nlines++) {
-	t = ctx->t_head;
-	while (i < len && data[i] > '\n') {
-	    unsigned char c = data[i++];
-	    if (c & 0x80)
-		//fprintf(stderr, "8-bit ASCII is unsupported\n");
-		abort();
-	    c &= 127;
+        t = ctx->t_head;
+        while (i < len && data[i] > '\n') {
+            unsigned char c = data[i++];
+            if (c & 0x80)
+                //fprintf(stderr, "8-bit ASCII is unsupported\n");
+                abort();
+            c &= 127;
 
-	    trie_t *x = t->next;
-	    while (x && x->c != c)
-		x = x->sibling;
-	    t = x;
+            trie_t *x = t->next;
+            while (x && x->c != c)
+                x = x->sibling;
+            t = x;
 
-//	    t = t->next[c];
+//          t = t->next[c];
 
-//	    if (!t)
-//		return -1;
+//          if (!t)
+//              return -1;
 
-	    from = t->n;
-	    if (i == prefix_len) p3 = t->n;
-	    //if (t->count >= .0035*ctx->t_head->count && t->n != n) p3 = t->n; // pacbio
-	    //if (i == 60) p3 = t->n; // pacbio
-	    //if (i == 7) p3 = t->n; // iontorrent
-	    t->n = n;
-	}
+            from = t->n;
+            if (i == prefix_len) p3 = t->n;
+            //if (t->count >= .0035*ctx->t_head->count && t->n != n) p3 = t->n; // pacbio
+            //if (i == 60) p3 = t->n; // pacbio
+            //if (i == 7) p3 = t->n; // iontorrent
+            t->n = n;
+        }
     }
 
     //printf("Looked for %d, found %d, prefix %d\n", n, from, p3);
@@ -701,20 +701,20 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
     //if (pnum == cnum) {pnum = cnum ? cnum-1 : 0;}
 #ifdef ENC_DEBUG
     fprintf(stderr, "%d: pnum=%d (%d), exact=%d\n%s\n%s\n",
-	    ctx->counter, pnum, cnum-pnum, exact, ctx->lc[pnum].last_name, name);
+            ctx->counter, pnum, cnum-pnum, exact, ctx->lc[pnum].last_name, name);
 #endif
 
     // Return DUP or DIFF switch, plus the distance.
     if (exact && len == strlen(ctx->lc[pnum].last_name)) {
-	encode_token_dup(ctx, cnum-pnum);
-	ctx->lc[cnum].last_name = name;
-	ctx->lc[cnum].last_ntok = ctx->lc[pnum].last_ntok;
-	// FIXME: optimise this
-	int nc = ctx->lc[cnum].last_ntok ? ctx->lc[cnum].last_ntok : MAX_TOKENS;
-	memcpy(ctx->lc[cnum].last_token_type, ctx->lc[pnum].last_token_type, nc * sizeof(int));
-	memcpy(ctx->lc[cnum].last_token_int , ctx->lc[pnum].last_token_int , nc * sizeof(int));
-	memcpy(ctx->lc[cnum].last_token_str , ctx->lc[pnum].last_token_str , nc * sizeof(int));
-	return 0;
+        encode_token_dup(ctx, cnum-pnum);
+        ctx->lc[cnum].last_name = name;
+        ctx->lc[cnum].last_ntok = ctx->lc[pnum].last_ntok;
+        // FIXME: optimise this
+        int nc = ctx->lc[cnum].last_ntok ? ctx->lc[cnum].last_ntok : MAX_TOKENS;
+        memcpy(ctx->lc[cnum].last_token_type, ctx->lc[pnum].last_token_type, nc * sizeof(int));
+        memcpy(ctx->lc[cnum].last_token_int , ctx->lc[pnum].last_token_int , nc * sizeof(int));
+        memcpy(ctx->lc[cnum].last_token_str , ctx->lc[pnum].last_token_str , nc * sizeof(int));
+        return 0;
     }
 
     encode_token_diff(ctx, cnum-pnum);
@@ -722,245 +722,245 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
     int ntok = 1;
     i = 0;
     if (is_fixed) {
-	if (ntok >= ctx->max_tok) {
-	    memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
-	    memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
-	    memset(&ctx->token_icount[ctx->max_tok], 0, sizeof(int));
-	    ctx->max_tok = ntok+1;
-	}
-	if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_ALPHA) {
-	    if (ctx->lc[pnum].last_token_int[ntok] == fixed_len && memcmp(name, ctx->lc[pnum].last_name, fixed_len) == 0) {
-		encode_token_match(ctx, ntok);
-	    } else {
-		encode_token_alpha(ctx, ntok, name, fixed_len);
-	    }
-	} else {
-	    encode_token_alpha(ctx, ntok, name, fixed_len);
-	}
-	ctx->lc[cnum].last_token_int[ntok] = fixed_len;
-	ctx->lc[cnum].last_token_str[ntok] = 0;
-	ctx->lc[cnum].last_token_type[ntok++] = N_ALPHA;
-	i = fixed_len;
+        if (ntok >= ctx->max_tok) {
+            memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
+            memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
+            memset(&ctx->token_icount[ctx->max_tok], 0, sizeof(int));
+            ctx->max_tok = ntok+1;
+        }
+        if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_ALPHA) {
+            if (ctx->lc[pnum].last_token_int[ntok] == fixed_len && memcmp(name, ctx->lc[pnum].last_name, fixed_len) == 0) {
+                encode_token_match(ctx, ntok);
+            } else {
+                encode_token_alpha(ctx, ntok, name, fixed_len);
+            }
+        } else {
+            encode_token_alpha(ctx, ntok, name, fixed_len);
+        }
+        ctx->lc[cnum].last_token_int[ntok] = fixed_len;
+        ctx->lc[cnum].last_token_str[ntok] = 0;
+        ctx->lc[cnum].last_token_type[ntok++] = N_ALPHA;
+        i = fixed_len;
     }
 
     for (; i < len; i++) {
-	if (ntok >= ctx->max_tok) {
-	    memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
-	    memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
-	    memset(&ctx->token_icount[ctx->max_tok], 0, sizeof(int));
-	    ctx->max_tok = ntok+1;
-	}
+        if (ntok >= ctx->max_tok) {
+            memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
+            memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
+            memset(&ctx->token_icount[ctx->max_tok], 0, sizeof(int));
+            ctx->max_tok = ntok+1;
+        }
 
-	/* Determine data type of this segment */
-	if (isalpha(name[i])) {
-	    int s = i+1;
-//	    int S = i+1;
+        /* Determine data type of this segment */
+        if (isalpha(name[i])) {
+            int s = i+1;
+//          int S = i+1;
 
-//	    // FIXME: try which of these is best.  alnum is good sometimes.
-//	    while (s < len && isalpha(name[s]))
-	    while (s < len && (isalpha(name[s]) || ispunct(name[s])))
-//	    while (s < len && name[s] != ':')
-//	    while (s < len && !isdigit(name[s]) && name[s] != ':')
-		s++;
+//          // FIXME: try which of these is best.  alnum is good sometimes.
+//          while (s < len && isalpha(name[s]))
+            while (s < len && (isalpha(name[s]) || ispunct(name[s])))
+//          while (s < len && name[s] != ':')
+//          while (s < len && !isdigit(name[s]) && name[s] != ':')
+                s++;
 
-//	    if (!is_fixed) {
-//		while (S < len && isalnum(name[S]))
-//		    S++;
-//		if (s < S)
-//		    s = S;
-//	    }
+//          if (!is_fixed) {
+//              while (S < len && isalnum(name[S]))
+//                  S++;
+//              if (s < S)
+//                  s = S;
+//          }
 
-	    // Single byte strings are better encoded as chars.
-	    if (s-i == 1) goto n_char;
+            // Single byte strings are better encoded as chars.
+            if (s-i == 1) goto n_char;
 
-	    if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_ALPHA) {
-		if (s-i == ctx->lc[pnum].last_token_int[ntok] &&
-		    memcmp(&name[i], 
-			   &ctx->lc[pnum].last_name[ctx->lc[pnum].last_token_str[ntok]],
-			   s-i) == 0) {
+            if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_ALPHA) {
+                if (s-i == ctx->lc[pnum].last_token_int[ntok] &&
+                    memcmp(&name[i], 
+                           &ctx->lc[pnum].last_name[ctx->lc[pnum].last_token_str[ntok]],
+                           s-i) == 0) {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (alpha-mat, %.*s)\n", N_MATCH, s-i, &name[i]);
+                    fprintf(stderr, "Tok %d (alpha-mat, %.*s)\n", N_MATCH, s-i, &name[i]);
 #endif
-		    if (encode_token_match(ctx, ntok) < 0) return -1;
-		} else {
+                    if (encode_token_match(ctx, ntok) < 0) return -1;
+                } else {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (alpha, %.*s / %.*s)\n", N_ALPHA,
-		    	    s-i, &ctx->lc[pnum].last_name[ctx->lc[pnum].last_token_str[ntok]], s-i, &name[i]);
+                    fprintf(stderr, "Tok %d (alpha, %.*s / %.*s)\n", N_ALPHA,
+                            s-i, &ctx->lc[pnum].last_name[ctx->lc[pnum].last_token_str[ntok]], s-i, &name[i]);
 #endif
-		    // same token/length, but mismatches
-		    if (encode_token_alpha(ctx, ntok, &name[i], s-i) < 0) return -1;
-		}
-	    } else {
+                    // same token/length, but mismatches
+                    if (encode_token_alpha(ctx, ntok, &name[i], s-i) < 0) return -1;
+                }
+            } else {
 #ifdef ENC_DEBUG
-		fprintf(stderr, "Tok %d (new alpha, %.*s)\n", N_ALPHA, s-i, &name[i]);
+                fprintf(stderr, "Tok %d (new alpha, %.*s)\n", N_ALPHA, s-i, &name[i]);
 #endif
-		if (encode_token_alpha(ctx, ntok, &name[i], s-i) < 0) return -1;
-	    }
+                if (encode_token_alpha(ctx, ntok, &name[i], s-i) < 0) return -1;
+            }
 
-	    ctx->lc[cnum].last_token_int[ntok] = s-i;
-	    ctx->lc[cnum].last_token_str[ntok] = i;
-	    ctx->lc[cnum].last_token_type[ntok] = N_ALPHA;
+            ctx->lc[cnum].last_token_int[ntok] = s-i;
+            ctx->lc[cnum].last_token_str[ntok] = i;
+            ctx->lc[cnum].last_token_type[ntok] = N_ALPHA;
 
-	    i = s-1;
-	} else if (name[i] == '0') digits0: {
-	    // Digits starting with zero; encode length + value
-	    uint32_t s = i;
-	    uint32_t v = 0;
-	    int d = 0;
+            i = s-1;
+        } else if (name[i] == '0') digits0: {
+            // Digits starting with zero; encode length + value
+            uint32_t s = i;
+            uint32_t v = 0;
+            int d = 0;
 
-	    while (s < len && isdigit(name[s]) && s-i < 9) {
-		v = v*10 + name[s] - '0';
-		//putchar(name[s]);
-		s++;
-	    }
+            while (s < len && isdigit(name[s]) && s-i < 9) {
+                v = v*10 + name[s] - '0';
+                //putchar(name[s]);
+                s++;
+            }
 
-	    // TODO: optimise choice over whether to switch from DIGITS to DELTA
-	    // regularly vs all DIGITS, also MATCH vs DELTA 0.
-	    if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_DIGITS0) {
-		d = v - ctx->lc[pnum].last_token_int[ntok];
-		if (d == 0 && ctx->lc[pnum].last_token_str[ntok] == s-i) {
+            // TODO: optimise choice over whether to switch from DIGITS to DELTA
+            // regularly vs all DIGITS, also MATCH vs DELTA 0.
+            if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_DIGITS0) {
+                d = v - ctx->lc[pnum].last_token_int[ntok];
+                if (d == 0 && ctx->lc[pnum].last_token_str[ntok] == s-i) {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (dig-mat, %d)\n", N_MATCH, v);
+                    fprintf(stderr, "Tok %d (dig-mat, %d)\n", N_MATCH, v);
 #endif
-		    if (encode_token_match(ctx, ntok) < 0) return -1;
-		    //ctx->lc[pnum].last_token_delta[ntok]=0;
-		} else if (mode == 1 && d < 256 && d >= 0 && ctx->lc[pnum].last_token_str[ntok] == s-i) {
+                    if (encode_token_match(ctx, ntok) < 0) return -1;
+                    //ctx->lc[pnum].last_token_delta[ntok]=0;
+                } else if (mode == 1 && d < 256 && d >= 0 && ctx->lc[pnum].last_token_str[ntok] == s-i) {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (dig-delta, %d / %d)\n", N_DDELTA, ctx->lc[pnum].last_token_int[ntok], v);
+                    fprintf(stderr, "Tok %d (dig-delta, %d / %d)\n", N_DDELTA, ctx->lc[pnum].last_token_int[ntok], v);
 #endif
-		    //if (encode_token_int1_(ctx, ntok, N_DZLEN, s-i) < 0) return -1;
-		    if (encode_token_int1(ctx, ntok, N_DDELTA0, d) < 0) return -1;
-		    //ctx->lc[pnum].last_token_delta[ntok]=1;
-		} else {
+                    //if (encode_token_int1_(ctx, ntok, N_DZLEN, s-i) < 0) return -1;
+                    if (encode_token_int1(ctx, ntok, N_DDELTA0, d) < 0) return -1;
+                    //ctx->lc[pnum].last_token_delta[ntok]=1;
+                } else {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (dig, %d / %d)\n", N_DIGITS, ctx->lc[pnum].last_token_int[ntok], v);
+                    fprintf(stderr, "Tok %d (dig, %d / %d)\n", N_DIGITS, ctx->lc[pnum].last_token_int[ntok], v);
 #endif
-		    if (encode_token_int1_(ctx, ntok, N_DZLEN, s-i) < 0) return -1;
-		    if (encode_token_int(ctx, ntok, N_DIGITS0, v) < 0) return -1;
-		    //ctx->lc[pnum].last_token_delta[ntok]=0;
-		}
-	    } else {
+                    if (encode_token_int1_(ctx, ntok, N_DZLEN, s-i) < 0) return -1;
+                    if (encode_token_int(ctx, ntok, N_DIGITS0, v) < 0) return -1;
+                    //ctx->lc[pnum].last_token_delta[ntok]=0;
+                }
+            } else {
 #ifdef ENC_DEBUG
-		fprintf(stderr, "Tok %d (new dig, %d)\n", N_DIGITS, v);
+                fprintf(stderr, "Tok %d (new dig, %d)\n", N_DIGITS, v);
 #endif
-		if (encode_token_int1_(ctx, ntok, N_DZLEN, s-i) < 0) return -1;
-		if (encode_token_int(ctx, ntok, N_DIGITS0, v) < 0) return -1;
-		//ctx->lc[pnum].last_token_delta[ntok]=0;
-	    }
+                if (encode_token_int1_(ctx, ntok, N_DZLEN, s-i) < 0) return -1;
+                if (encode_token_int(ctx, ntok, N_DIGITS0, v) < 0) return -1;
+                //ctx->lc[pnum].last_token_delta[ntok]=0;
+            }
 
-	    ctx->lc[cnum].last_token_str[ntok] = s-i; // length
-	    ctx->lc[cnum].last_token_int[ntok] = v;
-	    ctx->lc[cnum].last_token_type[ntok] = N_DIGITS0;
+            ctx->lc[cnum].last_token_str[ntok] = s-i; // length
+            ctx->lc[cnum].last_token_int[ntok] = v;
+            ctx->lc[cnum].last_token_type[ntok] = N_DIGITS0;
 
-	    i = s-1;
-	} else if (isdigit(name[i])) {
-	    // digits starting 1-9; encode value
-	    uint32_t s = i;
-	    uint32_t v = 0;
-	    int d = 0;
+            i = s-1;
+        } else if (isdigit(name[i])) {
+            // digits starting 1-9; encode value
+            uint32_t s = i;
+            uint32_t v = 0;
+            int d = 0;
 
-	    while (s < len && isdigit(name[s]) && s-i < 9) {
-		v = v*10 + name[s] - '0';
-		//putchar(name[s]);
-		s++;
-	    }
+            while (s < len && isdigit(name[s]) && s-i < 9) {
+                v = v*10 + name[s] - '0';
+                //putchar(name[s]);
+                s++;
+            }
 
-	    // dataset/10/K562_cytosol_LID8465_TopHat_v2.names
-	    // col 4 is Illumina lane - we don't want match & delta in there
-	    // as it has multiple lanes (so not ALL match) and delta is just
-	    // random chance, increasing entropy instead.
-//	    if (ntok == 4  || ntok == 8 || ntok == 10) {
-//		encode_token_int(ctx, ntok, N_DIGITS, v);
-//	    } else {
+            // dataset/10/K562_cytosol_LID8465_TopHat_v2.names
+            // col 4 is Illumina lane - we don't want match & delta in there
+            // as it has multiple lanes (so not ALL match) and delta is just
+            // random chance, increasing entropy instead.
+//          if (ntok == 4  || ntok == 8 || ntok == 10) {
+//              encode_token_int(ctx, ntok, N_DIGITS, v);
+//          } else {
 
-	    // If the last token was DIGITS0 and we are the same length, then encode
-	    // using that method instead as it seems likely the entire column is fixed
-	    // width, sometimes with leading zeros.
-	    if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok &&
-		ctx->lc[pnum].last_token_type[ntok] == N_DIGITS0 &&
-		ctx->lc[pnum].last_token_str[ntok] == s-i)
-		goto digits0;
-	    
-	    // TODO: optimise choice over whether to switch from DIGITS to DELTA
-	    // regularly vs all DIGITS, also MATCH vs DELTA 0.
-	    if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_DIGITS) {
-		d = v - ctx->lc[pnum].last_token_int[ntok];
-		if (d == 0) {
+            // If the last token was DIGITS0 and we are the same length, then encode
+            // using that method instead as it seems likely the entire column is fixed
+            // width, sometimes with leading zeros.
+            if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok &&
+                ctx->lc[pnum].last_token_type[ntok] == N_DIGITS0 &&
+                ctx->lc[pnum].last_token_str[ntok] == s-i)
+                goto digits0;
+            
+            // TODO: optimise choice over whether to switch from DIGITS to DELTA
+            // regularly vs all DIGITS, also MATCH vs DELTA 0.
+            if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_DIGITS) {
+                d = v - ctx->lc[pnum].last_token_int[ntok];
+                if (d == 0) {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (dig-mat, %d)\n", N_MATCH, v);
+                    fprintf(stderr, "Tok %d (dig-mat, %d)\n", N_MATCH, v);
 #endif
-		    if (encode_token_match(ctx, ntok) < 0) return -1;
-		    //ctx->lc[pnum].last_token_delta[ntok]=0;
-		    //ctx->token_zcount[ntok]++;
-		} else if (mode == 1 && d < 256 && d >= 0
-			   //&& (10+ctx->token_dcount[ntok]) > (ctx->token_icount[ntok]+ctx->token_zcount[ntok])
-			   && (5+ctx->token_dcount[ntok]) > ctx->token_icount[ntok]
-			   ) {
+                    if (encode_token_match(ctx, ntok) < 0) return -1;
+                    //ctx->lc[pnum].last_token_delta[ntok]=0;
+                    //ctx->token_zcount[ntok]++;
+                } else if (mode == 1 && d < 256 && d >= 0
+                           //&& (10+ctx->token_dcount[ntok]) > (ctx->token_icount[ntok]+ctx->token_zcount[ntok])
+                           && (5+ctx->token_dcount[ntok]) > ctx->token_icount[ntok]
+                           ) {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (dig-delta, %d / %d)\n", N_DDELTA, ctx->lc[pnum].last_token_int[ntok], v);
+                    fprintf(stderr, "Tok %d (dig-delta, %d / %d)\n", N_DDELTA, ctx->lc[pnum].last_token_int[ntok], v);
 #endif
-		    if (encode_token_int1(ctx, ntok, N_DDELTA, d) < 0) return -1;
-		    //ctx->lc[pnum].last_token_delta[ntok]=1;
-		    ctx->token_dcount[ntok]++;
-		} else {
+                    if (encode_token_int1(ctx, ntok, N_DDELTA, d) < 0) return -1;
+                    //ctx->lc[pnum].last_token_delta[ntok]=1;
+                    ctx->token_dcount[ntok]++;
+                } else {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (dig, %d / %d)\n", N_DIGITS, ctx->lc[pnum].last_token_int[ntok], v);
+                    fprintf(stderr, "Tok %d (dig, %d / %d)\n", N_DIGITS, ctx->lc[pnum].last_token_int[ntok], v);
 #endif
-		    if (encode_token_int(ctx, ntok, N_DIGITS, v) < 0) return -1;
-		    //ctx->lc[pnum].last_token_delta[ntok]=0;
-		    ctx->token_icount[ntok]++;
-		}
-	    } else {
+                    if (encode_token_int(ctx, ntok, N_DIGITS, v) < 0) return -1;
+                    //ctx->lc[pnum].last_token_delta[ntok]=0;
+                    ctx->token_icount[ntok]++;
+                }
+            } else {
 #ifdef ENC_DEBUG
-		fprintf(stderr, "Tok %d (new dig, %d)\n", N_DIGITS, v);
+                fprintf(stderr, "Tok %d (new dig, %d)\n", N_DIGITS, v);
 #endif
-		if (encode_token_int(ctx, ntok, N_DIGITS, v) < 0) return -1;
-		//ctx->lc[pnum].last_token_delta[ntok]=0;
-	    }
-//	    }
+                if (encode_token_int(ctx, ntok, N_DIGITS, v) < 0) return -1;
+                //ctx->lc[pnum].last_token_delta[ntok]=0;
+            }
+//          }
 
-	    ctx->lc[cnum].last_token_int[ntok] = v;
-	    ctx->lc[cnum].last_token_type[ntok] = N_DIGITS;
+            ctx->lc[cnum].last_token_int[ntok] = v;
+            ctx->lc[cnum].last_token_type[ntok] = N_DIGITS;
 
-	    i = s-1;
-	} else {
-	n_char:
-	    //if (!isalpha(name[i])) putchar(name[i]);
-	    if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_CHAR) {
-		if (name[i] == ctx->lc[pnum].last_token_int[ntok]) {
+            i = s-1;
+        } else {
+        n_char:
+            //if (!isalpha(name[i])) putchar(name[i]);
+            if (pnum < cnum && ntok < ctx->lc[pnum].last_ntok && ctx->lc[pnum].last_token_type[ntok] == N_CHAR) {
+                if (name[i] == ctx->lc[pnum].last_token_int[ntok]) {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (chr-mat, %c)\n", N_MATCH, name[i]);
+                    fprintf(stderr, "Tok %d (chr-mat, %c)\n", N_MATCH, name[i]);
 #endif
-		    if (encode_token_match(ctx, ntok) < 0) return -1;
-		} else {
+                    if (encode_token_match(ctx, ntok) < 0) return -1;
+                } else {
 #ifdef ENC_DEBUG
-		    fprintf(stderr, "Tok %d (chr, %c / %c)\n", N_CHAR, ctx->lc[pnum].last_token_int[ntok], name[i]);
+                    fprintf(stderr, "Tok %d (chr, %c / %c)\n", N_CHAR, ctx->lc[pnum].last_token_int[ntok], name[i]);
 #endif
-		    if (encode_token_char(ctx, ntok, name[i]) < 0) return -1;
-		}
-	    } else {
+                    if (encode_token_char(ctx, ntok, name[i]) < 0) return -1;
+                }
+            } else {
 #ifdef ENC_DEBUG
-		fprintf(stderr, "Tok %d (new chr, %c)\n", N_CHAR, name[i]);
+                fprintf(stderr, "Tok %d (new chr, %c)\n", N_CHAR, name[i]);
 #endif
-		if (encode_token_char(ctx, ntok, name[i]) < 0) return -1;
-	    }
+                if (encode_token_char(ctx, ntok, name[i]) < 0) return -1;
+            }
 
-	    ctx->lc[cnum].last_token_int[ntok] = name[i];
-	    ctx->lc[cnum].last_token_type[ntok] = N_CHAR;
-	}
+            ctx->lc[cnum].last_token_int[ntok] = name[i];
+            ctx->lc[cnum].last_token_type[ntok] = N_CHAR;
+        }
 
-	ntok++;
-	//putchar(' ');
+        ntok++;
+        //putchar(' ');
     }
 
 #ifdef ENC_DEBUG
     fprintf(stderr, "Tok %d (end)\n", N_END);
 #endif
     if (ntok >= ctx->max_tok) {
-	memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
-	memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
-	memset(&ctx->token_icount[ctx->max_tok], 0, sizeof(int));
-	ctx->max_tok = ntok+1;
+        memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
+        memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
+        memset(&ctx->token_icount[ctx->max_tok], 0, sizeof(int));
+        ctx->max_tok = ntok+1;
     }
     if (encode_token_end(ctx, ntok) < 0) return -1;
 #ifdef ENC_DEBUG
@@ -984,168 +984,168 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
     int pnum, cnum = ctx->counter++;
 
     if (cnum >= ctx->max_names)
-	return -1;
+        return -1;
 
     if (t0 < 0 || t0 >= ctx->max_tok*16)
-	return 0;
+        return 0;
 
     if (decode_token_int(ctx, 0, t0, &dist) < 0 || dist > cnum)
-	return -1;
+        return -1;
     if ((pnum = cnum - dist) < 0) pnum = 0;
 
     //fprintf(stderr, "t0=%d, dist=%d, pnum=%d, cnum=%d\n", t0, dist, pnum, cnum);
 
     if (t0 == N_DUP) {
-	if (pnum == cnum)
-	    return -1;
+        if (pnum == cnum)
+            return -1;
 
-	if (strlen(ctx->lc[pnum].last_name) +1 >= name_len) return -1;
-	strcpy(name, ctx->lc[pnum].last_name);
-	// FIXME: optimise this
-	ctx->lc[cnum].last_name = name;
-	ctx->lc[cnum].last_ntok = ctx->lc[pnum].last_ntok;
-	int nc = ctx->lc[cnum].last_ntok ? ctx->lc[cnum].last_ntok : MAX_TOKENS;
-	memcpy(ctx->lc[cnum].last_token_type, ctx->lc[pnum].last_token_type, nc * sizeof(int));
-	memcpy(ctx->lc[cnum].last_token_int , ctx->lc[pnum].last_token_int , nc * sizeof(int));
-	memcpy(ctx->lc[cnum].last_token_str , ctx->lc[pnum].last_token_str , nc * sizeof(int));
+        if (strlen(ctx->lc[pnum].last_name) +1 >= name_len) return -1;
+        strcpy(name, ctx->lc[pnum].last_name);
+        // FIXME: optimise this
+        ctx->lc[cnum].last_name = name;
+        ctx->lc[cnum].last_ntok = ctx->lc[pnum].last_ntok;
+        int nc = ctx->lc[cnum].last_ntok ? ctx->lc[cnum].last_ntok : MAX_TOKENS;
+        memcpy(ctx->lc[cnum].last_token_type, ctx->lc[pnum].last_token_type, nc * sizeof(int));
+        memcpy(ctx->lc[cnum].last_token_int , ctx->lc[pnum].last_token_int , nc * sizeof(int));
+        memcpy(ctx->lc[cnum].last_token_str , ctx->lc[pnum].last_token_str , nc * sizeof(int));
 
-	return strlen(name)+1;
+        return strlen(name)+1;
     }
 
     *name = 0;
     int ntok, len = 0, len2;
 
     for (ntok = 1; ntok < MAX_TOKENS && ntok < ctx->max_tok; ntok++) {
-	uint32_t v, vl;
-	enum name_type tok;
-	tok = decode_token_type(ctx, ntok);
-	//fprintf(stderr, "Tok %d = %d\n", ntok, tok);
+        uint32_t v, vl;
+        enum name_type tok;
+        tok = decode_token_type(ctx, ntok);
+        //fprintf(stderr, "Tok %d = %d\n", ntok, tok);
 
-	ctx->lc[cnum].last_ntok = 0;
+        ctx->lc[cnum].last_ntok = 0;
 
-	switch (tok) {
-	case N_CHAR:
-	    if (len+1 >= name_len) return -1;
-	    if (decode_token_char(ctx, ntok, &name[len]) < 0) return -1;
-	    //fprintf(stderr, "Tok %d CHAR %c\n", ntok, name[len]);
-	    ctx->lc[cnum].last_token_type[ntok] = N_CHAR;
-	    ctx->lc[cnum].last_token_int [ntok] = name[len++];
-	    break;
+        switch (tok) {
+        case N_CHAR:
+            if (len+1 >= name_len) return -1;
+            if (decode_token_char(ctx, ntok, &name[len]) < 0) return -1;
+            //fprintf(stderr, "Tok %d CHAR %c\n", ntok, name[len]);
+            ctx->lc[cnum].last_token_type[ntok] = N_CHAR;
+            ctx->lc[cnum].last_token_int [ntok] = name[len++];
+            break;
 
-	case N_ALPHA:
-	    if ((len2 = decode_token_alpha(ctx, ntok, &name[len], name_len - len)) < 0)
-		return -1;
-	    //fprintf(stderr, "Tok %d ALPHA %.*s\n", ntok, len2, &name[len]);
-	    ctx->lc[cnum].last_token_type[ntok] = N_ALPHA;
-	    ctx->lc[cnum].last_token_str [ntok] = len;
-	    ctx->lc[cnum].last_token_int [ntok] = len2;
-	    len += len2;
-	    break;
+        case N_ALPHA:
+            if ((len2 = decode_token_alpha(ctx, ntok, &name[len], name_len - len)) < 0)
+                return -1;
+            //fprintf(stderr, "Tok %d ALPHA %.*s\n", ntok, len2, &name[len]);
+            ctx->lc[cnum].last_token_type[ntok] = N_ALPHA;
+            ctx->lc[cnum].last_token_str [ntok] = len;
+            ctx->lc[cnum].last_token_int [ntok] = len2;
+            len += len2;
+            break;
 
-	case N_DIGITS0: // [0-9]*
-	    if (decode_token_int1(ctx, ntok, N_DZLEN, &vl) < 0) return -1;
-	    if (decode_token_int(ctx, ntok, N_DIGITS0, &v) < 0) return -1;
-	    if (len+20+vl >= name_len) return -1;
-	    len += append_uint32_fixed(&name[len], v, vl);
-	    //fprintf(stderr, "Tok %d DIGITS0 %0*d\n", ntok, vl, v);
-	    ctx->lc[cnum].last_token_type[ntok] = N_DIGITS0;
-	    ctx->lc[cnum].last_token_int [ntok] = v;
-	    ctx->lc[cnum].last_token_str [ntok] = vl;
-	    break;
+        case N_DIGITS0: // [0-9]*
+            if (decode_token_int1(ctx, ntok, N_DZLEN, &vl) < 0) return -1;
+            if (decode_token_int(ctx, ntok, N_DIGITS0, &v) < 0) return -1;
+            if (len+20+vl >= name_len) return -1;
+            len += append_uint32_fixed(&name[len], v, vl);
+            //fprintf(stderr, "Tok %d DIGITS0 %0*d\n", ntok, vl, v);
+            ctx->lc[cnum].last_token_type[ntok] = N_DIGITS0;
+            ctx->lc[cnum].last_token_int [ntok] = v;
+            ctx->lc[cnum].last_token_str [ntok] = vl;
+            break;
 
-	case N_DDELTA0:
-	    if (ntok >= ctx->lc[pnum].last_ntok) return -1;
-	    if (decode_token_int1(ctx, ntok, N_DDELTA0, &v) < 0) return -1;
-	    v += ctx->lc[pnum].last_token_int[ntok];
-	    if (len+ctx->lc[pnum].last_token_str[ntok]+1 >= name_len) return -1;
-	    len += append_uint32_fixed(&name[len], v, ctx->lc[pnum].last_token_str[ntok]);
-	    //fprintf(stderr, "Tok %d DELTA0 %0*d\n", ntok, ctx->lc[pnum].last_token_str[ntok], v);
-	    ctx->lc[cnum].last_token_type[ntok] = N_DIGITS0;
-	    ctx->lc[cnum].last_token_int [ntok] = v;
-	    ctx->lc[cnum].last_token_str [ntok] = ctx->lc[pnum].last_token_str[ntok];
-	    break;
+        case N_DDELTA0:
+            if (ntok >= ctx->lc[pnum].last_ntok) return -1;
+            if (decode_token_int1(ctx, ntok, N_DDELTA0, &v) < 0) return -1;
+            v += ctx->lc[pnum].last_token_int[ntok];
+            if (len+ctx->lc[pnum].last_token_str[ntok]+1 >= name_len) return -1;
+            len += append_uint32_fixed(&name[len], v, ctx->lc[pnum].last_token_str[ntok]);
+            //fprintf(stderr, "Tok %d DELTA0 %0*d\n", ntok, ctx->lc[pnum].last_token_str[ntok], v);
+            ctx->lc[cnum].last_token_type[ntok] = N_DIGITS0;
+            ctx->lc[cnum].last_token_int [ntok] = v;
+            ctx->lc[cnum].last_token_str [ntok] = ctx->lc[pnum].last_token_str[ntok];
+            break;
 
-	case N_DIGITS: // [1-9][0-9]*
-	    if (decode_token_int(ctx, ntok, N_DIGITS, &v) < 0) return -1;
-	    if (len+20 >= name_len) return -1;
-	    len += append_uint32_var(&name[len], v);
-	    //fprintf(stderr, "Tok %d DIGITS %d\n", ntok, v);
-	    ctx->lc[cnum].last_token_type[ntok] = N_DIGITS;
-	    ctx->lc[cnum].last_token_int [ntok] = v;
-	    break;
+        case N_DIGITS: // [1-9][0-9]*
+            if (decode_token_int(ctx, ntok, N_DIGITS, &v) < 0) return -1;
+            if (len+20 >= name_len) return -1;
+            len += append_uint32_var(&name[len], v);
+            //fprintf(stderr, "Tok %d DIGITS %d\n", ntok, v);
+            ctx->lc[cnum].last_token_type[ntok] = N_DIGITS;
+            ctx->lc[cnum].last_token_int [ntok] = v;
+            break;
 
-	case N_DDELTA:
-	    if (ntok >= ctx->lc[pnum].last_ntok) return -1;
-	    if (decode_token_int1(ctx, ntok, N_DDELTA, &v) < 0) return -1;
-	    v += ctx->lc[pnum].last_token_int[ntok];
-	    if (len+20 >= name_len) return -1;
-	    len += append_uint32_var(&name[len], v);
-	    //fprintf(stderr, "Tok %d DELTA %d\n", ntok, v);
-	    ctx->lc[cnum].last_token_type[ntok] = N_DIGITS;
-	    ctx->lc[cnum].last_token_int [ntok] = v;
-	    break;
+        case N_DDELTA:
+            if (ntok >= ctx->lc[pnum].last_ntok) return -1;
+            if (decode_token_int1(ctx, ntok, N_DDELTA, &v) < 0) return -1;
+            v += ctx->lc[pnum].last_token_int[ntok];
+            if (len+20 >= name_len) return -1;
+            len += append_uint32_var(&name[len], v);
+            //fprintf(stderr, "Tok %d DELTA %d\n", ntok, v);
+            ctx->lc[cnum].last_token_type[ntok] = N_DIGITS;
+            ctx->lc[cnum].last_token_int [ntok] = v;
+            break;
 
-	case N_NOP:
-	    ctx->lc[cnum].last_token_type[ntok] = N_NOP;
-	    break;
+        case N_NOP:
+            ctx->lc[cnum].last_token_type[ntok] = N_NOP;
+            break;
 
-	case N_MATCH:
-	    if (ntok >= ctx->lc[pnum].last_ntok) return -1;
-	    switch (ctx->lc[pnum].last_token_type[ntok]) {
-	    case N_CHAR:
-		if (len+1 >= name_len) return -1;
-		name[len++] = ctx->lc[pnum].last_token_int[ntok];
-		//fprintf(stderr, "Tok %d MATCH CHAR %c\n", ntok, ctx->lc[pnum].last_token_int[ntok]);
-		ctx->lc[cnum].last_token_type[ntok] = N_CHAR;
-		ctx->lc[cnum].last_token_int [ntok] = ctx->lc[pnum].last_token_int[ntok];
-		break;
+        case N_MATCH:
+            if (ntok >= ctx->lc[pnum].last_ntok) return -1;
+            switch (ctx->lc[pnum].last_token_type[ntok]) {
+            case N_CHAR:
+                if (len+1 >= name_len) return -1;
+                name[len++] = ctx->lc[pnum].last_token_int[ntok];
+                //fprintf(stderr, "Tok %d MATCH CHAR %c\n", ntok, ctx->lc[pnum].last_token_int[ntok]);
+                ctx->lc[cnum].last_token_type[ntok] = N_CHAR;
+                ctx->lc[cnum].last_token_int [ntok] = ctx->lc[pnum].last_token_int[ntok];
+                break;
 
-	    case N_ALPHA:
-		if (ctx->lc[pnum].last_token_int[ntok] < 0 ||
-		    len+ctx->lc[pnum].last_token_int[ntok] >= name_len) return -1;
-		memcpy(&name[len],
-		       &ctx->lc[pnum].last_name[ctx->lc[pnum].last_token_str[ntok]],
-		       ctx->lc[pnum].last_token_int[ntok]);
-		//fprintf(stderr, "Tok %d MATCH ALPHA %.*s\n", ntok, ctx->lc[pnum].last_token_int[ntok], &name[len]);
-		ctx->lc[cnum].last_token_type[ntok] = N_ALPHA;
-		ctx->lc[cnum].last_token_str [ntok] = len;
-		ctx->lc[cnum].last_token_int [ntok] = ctx->lc[pnum].last_token_int[ntok];
-		len += ctx->lc[pnum].last_token_int[ntok];
-		break;
+            case N_ALPHA:
+                if (ctx->lc[pnum].last_token_int[ntok] < 0 ||
+                    len+ctx->lc[pnum].last_token_int[ntok] >= name_len) return -1;
+                memcpy(&name[len],
+                       &ctx->lc[pnum].last_name[ctx->lc[pnum].last_token_str[ntok]],
+                       ctx->lc[pnum].last_token_int[ntok]);
+                //fprintf(stderr, "Tok %d MATCH ALPHA %.*s\n", ntok, ctx->lc[pnum].last_token_int[ntok], &name[len]);
+                ctx->lc[cnum].last_token_type[ntok] = N_ALPHA;
+                ctx->lc[cnum].last_token_str [ntok] = len;
+                ctx->lc[cnum].last_token_int [ntok] = ctx->lc[pnum].last_token_int[ntok];
+                len += ctx->lc[pnum].last_token_int[ntok];
+                break;
 
-	    case N_DIGITS:
-		if (len+20 >= name_len) return -1;
-		len += append_uint32_var(&name[len], ctx->lc[pnum].last_token_int[ntok]);
-		//fprintf(stderr, "Tok %d MATCH DIGITS %d\n", ntok, ctx->lc[pnum].last_token_int[ntok]);
-		ctx->lc[cnum].last_token_type[ntok] = N_DIGITS;
-		ctx->lc[cnum].last_token_int [ntok] = ctx->lc[pnum].last_token_int[ntok];
-		break;
+            case N_DIGITS:
+                if (len+20 >= name_len) return -1;
+                len += append_uint32_var(&name[len], ctx->lc[pnum].last_token_int[ntok]);
+                //fprintf(stderr, "Tok %d MATCH DIGITS %d\n", ntok, ctx->lc[pnum].last_token_int[ntok]);
+                ctx->lc[cnum].last_token_type[ntok] = N_DIGITS;
+                ctx->lc[cnum].last_token_int [ntok] = ctx->lc[pnum].last_token_int[ntok];
+                break;
 
-	    case N_DIGITS0:
-		if (len+ctx->lc[pnum].last_token_str[ntok] >= name_len) return -1;
-		len += append_uint32_fixed(&name[len], ctx->lc[pnum].last_token_int[ntok], ctx->lc[pnum].last_token_str[ntok]);
-		//fprintf(stderr, "Tok %d MATCH DIGITS %0*d\n", ntok, ctx->lc[pnum].last_token_str[ntok], ctx->lc[pnum].last_token_int[ntok]);
-		ctx->lc[cnum].last_token_type[ntok] = N_DIGITS0;
-		ctx->lc[cnum].last_token_int [ntok] = ctx->lc[pnum].last_token_int[ntok];
-		ctx->lc[cnum].last_token_str [ntok] = ctx->lc[pnum].last_token_str[ntok];
-		break;
+            case N_DIGITS0:
+                if (len+ctx->lc[pnum].last_token_str[ntok] >= name_len) return -1;
+                len += append_uint32_fixed(&name[len], ctx->lc[pnum].last_token_int[ntok], ctx->lc[pnum].last_token_str[ntok]);
+                //fprintf(stderr, "Tok %d MATCH DIGITS %0*d\n", ntok, ctx->lc[pnum].last_token_str[ntok], ctx->lc[pnum].last_token_int[ntok]);
+                ctx->lc[cnum].last_token_type[ntok] = N_DIGITS0;
+                ctx->lc[cnum].last_token_int [ntok] = ctx->lc[pnum].last_token_int[ntok];
+                ctx->lc[cnum].last_token_str [ntok] = ctx->lc[pnum].last_token_str[ntok];
+                break;
 
-	    default:
-		return -1;
-	    }
-	    break;
+            default:
+                return -1;
+            }
+            break;
 
-	default: // an elided N_END
-	case N_END:
-	    if (len+1 >= name_len) return -1;
-	    name[len++] = 0;
-	    ctx->lc[cnum].last_token_type[ntok] = N_END;
+        default: // an elided N_END
+        case N_END:
+            if (len+1 >= name_len) return -1;
+            name[len++] = 0;
+            ctx->lc[cnum].last_token_type[ntok] = N_END;
 
-	    ctx->lc[cnum].last_name = name;
-	    ctx->lc[cnum].last_ntok = ntok;
+            ctx->lc[cnum].last_name = name;
+            ctx->lc[cnum].last_ntok = ntok;
 
-	    return len;
-	}
+            return len;
+        }
     }
 
 
@@ -1157,7 +1157,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
 static int arith_encode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len, int method) {
     unsigned int olen = *out_len-6, nb;
     if (arith_compress_to(in, in_len, out+6, &olen, method) == NULL)
-	return -1;
+        return -1;
 
     nb = var_put_u32(out, out + *out_len, olen);
     memmove(out+nb, out+6, olen);
@@ -1175,7 +1175,7 @@ static int64_t arith_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t
     int nb = var_get_u32(in, in+in_len, &clen);
     //fprintf(stderr, "Arith decode %x\n", in[nb]);
     if (arith_uncompress_to(in+nb, in_len-nb, out, &olen) == NULL)
-	return -1;
+        return -1;
     //fprintf(stderr, "    Stored clen=%d\n", (int)clen);
     *out_len = olen;
     return clen+nb;
@@ -1184,7 +1184,7 @@ static int64_t arith_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t
 static int rans_encode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len, int method) {
     unsigned int olen = *out_len-6, nb;
     if (rans_compress_to_4x16(in, in_len, out+6, &olen, method) == NULL)
-	return -1;
+        return -1;
 
     nb = var_put_u32(out, out + *out_len, olen);
     memmove(out+nb, out+6, olen);
@@ -1202,14 +1202,14 @@ static int64_t rans_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t 
     int nb = var_get_u32(in, in+in_len, &clen);
     //fprintf(stderr, "Arith decode %x\n", in[nb]);
     if (rans_uncompress_to_4x16(in+nb, in_len-nb, out, &olen) == NULL)
-	return -1;
+        return -1;
     //fprintf(stderr, "    Stored clen=%d\n", (int)clen);
     *out_len = olen;
     return clen+nb;
 }
 
 static int compress(uint8_t *in, uint64_t in_len, int level, int use_arith,
-		    uint8_t *out, uint64_t *out_len) {
+                    uint8_t *out, uint64_t *out_len) {
     uint64_t best_sz = UINT64_MAX;
     int best = 0;
     uint64_t olen = *out_len;
@@ -1217,11 +1217,11 @@ static int compress(uint8_t *in, uint64_t in_len, int level, int use_arith,
     //fprintf(stderr, "=== try %d ===\n", (int)in_len);
 
     int m, rmethods[5][12] = {
-	{2,   0,      128},				      // 1
-	{2,   0,                         192+8},              // 3
-	{3,   0,  128,                   193+8},              // 5
-	{6,   0,1,    129,   65,    193, 193+8},              // 7
-	{9,   0,1,128,129,64,65,192,193, 193+8},              // 9
+        {2,   0,      128},                                   // 1
+        {2,   0,                         192+8},              // 3
+        {3,   0,  128,                   193+8},              // 5
+        {6,   0,1,    129,   65,    193, 193+8},              // 7
+        {9,   0,1,128,129,64,65,192,193, 193+8},              // 9
     };
 
     // 1-9 to 0-4
@@ -1230,32 +1230,32 @@ static int compress(uint8_t *in, uint64_t in_len, int level, int use_arith,
     if (level>4) level=4;
 
     for (m = 1; m <= rmethods[level][0]; m++) {
-	*out_len = olen;
+        *out_len = olen;
 
-	if (in_len % 4 != 0 && (rmethods[level][m] & 8))
-	    continue;
+        if (in_len % 4 != 0 && (rmethods[level][m] & 8))
+            continue;
 
-	if (use_arith) {
-	    if (arith_encode(in, in_len, out, out_len, rmethods[level][m]) < 0)
-		return -1;
-	} else {
-	    if (rans_encode(in, in_len, out, out_len, rmethods[level][m]) < 0)
-		return -1;
-	}
+        if (use_arith) {
+            if (arith_encode(in, in_len, out, out_len, rmethods[level][m]) < 0)
+                return -1;
+        } else {
+            if (rans_encode(in, in_len, out, out_len, rmethods[level][m]) < 0)
+                return -1;
+        }
 
-	if (best_sz > *out_len) {
-	    best_sz = *out_len;
-	    best = rmethods[level][m];
-	}
+        if (best_sz > *out_len) {
+            best_sz = *out_len;
+            best = rmethods[level][m];
+        }
     }
 
     *out_len = olen;
     if (use_arith) {
-	if (arith_encode(in, in_len, out, out_len, best) < 0)
-	    return -1;
+        if (arith_encode(in, in_len, out, out_len, best) < 0)
+            return -1;
     } else {
-	if (rans_encode(in, in_len, out, out_len, best) < 0)
-	    return -1;
+        if (rans_encode(in, in_len, out, out_len, best) < 0)
+            return -1;
     }
 
 //    uint64_t tmp;
@@ -1277,12 +1277,12 @@ static uint64_t uncompressed_size(uint8_t *in, uint64_t in_len) {
 }
 
 static int uncompress(int use_arith, uint8_t *in, uint64_t in_len,
-		      uint8_t *out, uint64_t *out_len) {
+                      uint8_t *out, uint64_t *out_len) {
     uint32_t clen;
     var_get_u32(in, in+in_len, &clen);
     return use_arith
-	? arith_decode(in, in_len, out, out_len)
-	: rans_decode(in, in_len, out, out_len);
+        ? arith_decode(in, in_len, out, out_len)
+        : rans_decode(in, in_len, out, out_len);
 }
 
 //-----------------------------------------------------------------------------
@@ -1297,61 +1297,61 @@ static int uncompress(int use_arith, uint8_t *in, uint64_t in_len,
  *         or NULL on failure
  */
 uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
-			   int *out_len, int *last_start_p) {
+                           int *out_len, int *last_start_p) {
     int last_start = 0, i, j, nreads;
 
     // Count lines
     for (nreads = i = 0; i < len; i++)
-	if (blk[i] <= '\n') // \n or \0 separated entries
-	    nreads++;
+        if (blk[i] <= '\n') // \n or \0 separated entries
+            nreads++;
 
     name_context *ctx = create_context(nreads);
     if (!ctx)
-	return NULL;
+        return NULL;
 
     // Construct trie
     int ctr = 0;
     for (i = j = 0; i < len; j=++i) {
-	while (i < len && blk[i] > '\n')
-	    i++;
-	if (i >= len)
-	    break;
+        while (i < len && blk[i] > '\n')
+            i++;
+        if (i >= len)
+            break;
 
-	//blk[i] = '\0';
-	last_start = i+1;
-	if (build_trie(ctx, &blk[j], i-j, ctr++) < 0) {
-	    free_context(ctx);
-	    return NULL;
-	}
+        //blk[i] = '\0';
+        last_start = i+1;
+        if (build_trie(ctx, &blk[j], i-j, ctr++) < 0) {
+            free_context(ctx);
+            return NULL;
+        }
     }
     if (last_start_p)
-	*last_start_p = last_start;
+        *last_start_p = last_start;
 
     //fprintf(stderr, "Processed %d of %d in block, line %d\n", last_start, len, ctr);
 
     // Encode name
     for (i = j = 0; i < len; j=++i) {
-	while (i < len && blk[i] > '\n')
-	    i++;
-	if (i >= len)
-	    break;
+        while (i < len && blk[i] > '\n')
+            i++;
+        if (i >= len)
+            break;
 
-	blk[i] = '\0';
-	// try both 0 and 1 and pick best?
-	if (encode_name(ctx, &blk[j], i-j, 1) < 0) {
-	    free_context(ctx);
-	    return NULL;
-	}
+        blk[i] = '\0';
+        // try both 0 and 1 and pick best?
+        if (encode_name(ctx, &blk[j], i-j, 1) < 0) {
+            free_context(ctx);
+            return NULL;
+        }
     }
 
 #if 0
     for (i = 0; i < ctx->max_tok*16; i++) {
-	char fn[1024];
-	if (!ctx->desc[i].buf_l) continue;
-	sprintf(fn, "_tok.%02d_%02d.%d", i>>4,i&15,i);
-	FILE *fp = fopen(fn, "w");
-	fwrite(ctx->desc[i].buf, 1, ctx->desc[i].buf_l, fp);
-	fclose(fp);
+        char fn[1024];
+        if (!ctx->desc[i].buf_l) continue;
+        sprintf(fn, "_tok.%02d_%02d.%d", i>>4,i&15,i);
+        FILE *fp = fopen(fn, "w");
+        fwrite(ctx->desc[i].buf, 1, ctx->desc[i].buf_l, fp);
+        fclose(fp);
     }
 #endif
 
@@ -1372,92 +1372,92 @@ uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
     // as we can regenerate these from the subsequent blocks types during
     // decode.
     for (i = 0; i < ctx->max_tok*16; i+=16) {
-	if (!ctx->desc[i].buf_l) continue;
+        if (!ctx->desc[i].buf_l) continue;
 
-	int z;
-	for (z=1; z<ctx->desc[i].buf_l; z++) {
-	    if (ctx->desc[i].buf[z] != N_MATCH)
-		break;
-	}
-	if (z == ctx->desc[i].buf_l) {
-	    int k;
-	    for (k=1; k<16; k++)
-		if (ctx->desc[i+k].buf_l)
-		    break;
+        int z;
+        for (z=1; z<ctx->desc[i].buf_l; z++) {
+            if (ctx->desc[i].buf[z] != N_MATCH)
+                break;
+        }
+        if (z == ctx->desc[i].buf_l) {
+            int k;
+            for (k=1; k<16; k++)
+                if (ctx->desc[i+k].buf_l)
+                    break;
 
-	    if (k < 16) {
-		ctx->desc[i].buf_l = 0;
-		free(ctx->desc[i].buf);
-		ctx->desc[i].buf = NULL;
-	    }
-	}
+            if (k < 16) {
+                ctx->desc[i].buf_l = 0;
+                free(ctx->desc[i].buf);
+                ctx->desc[i].buf = NULL;
+            }
+        }
     }
 
     // Serialise descriptors
     uint32_t tot_size = 9;
     int ndesc = 0;
     for (i = 0; i < ctx->max_tok*16; i++) {
-	if (!ctx->desc[i].buf_l) continue;
+        if (!ctx->desc[i].buf_l) continue;
 
-	ndesc++;
+        ndesc++;
 
-	int tnum = i>>4;
-	int ttype = i&15;
+        int tnum = i>>4;
+        int ttype = i&15;
 
-	uint64_t out_len = 1.5 * arith_compress_bound(ctx->desc[i].buf_l, 1); // guesswork
-	uint8_t *out = malloc(out_len);
-	if (!out) {
-	    free_context(ctx);
-	    return NULL;
-	}
+        uint64_t out_len = 1.5 * arith_compress_bound(ctx->desc[i].buf_l, 1); // guesswork
+        uint8_t *out = malloc(out_len);
+        if (!out) {
+            free_context(ctx);
+            return NULL;
+        }
 
-	if (compress(ctx->desc[i].buf, ctx->desc[i].buf_l, level, use_arith,
-		     out, &out_len) < 0) {
-	    free_context(ctx);
-	    return NULL;
-	}
+        if (compress(ctx->desc[i].buf, ctx->desc[i].buf_l, level, use_arith,
+                     out, &out_len) < 0) {
+            free_context(ctx);
+            return NULL;
+        }
 
-	free(ctx->desc[i].buf);
-	ctx->desc[i].buf = out;
-	ctx->desc[i].buf_l = out_len;
-	ctx->desc[i].tnum = tnum;
-	ctx->desc[i].ttype = ttype;
+        free(ctx->desc[i].buf);
+        ctx->desc[i].buf = out;
+        ctx->desc[i].buf_l = out_len;
+        ctx->desc[i].tnum = tnum;
+        ctx->desc[i].ttype = ttype;
 
-	// Find dups
-	int j;
-	for (j = 0; j < i; j++) {
-	    if (!ctx->desc[j].buf)
-		continue;
-	    if (ctx->desc[i].buf_l != ctx->desc[j].buf_l || ctx->desc[i].buf_l <= 4)
-		continue;
-	    if (memcmp(ctx->desc[i].buf, ctx->desc[j].buf, ctx->desc[i].buf_l) == 0)
-		break;
-	}
-	if (j < i) {
-	    ctx->desc[i].dup_from = j;
-	    tot_size += 3; // flag, dup_from, ttype
-	} else {
-	    ctx->desc[i].dup_from = 0;
-	    tot_size += out_len + 1; // ttype
-	}
+        // Find dups
+        int j;
+        for (j = 0; j < i; j++) {
+            if (!ctx->desc[j].buf)
+                continue;
+            if (ctx->desc[i].buf_l != ctx->desc[j].buf_l || ctx->desc[i].buf_l <= 4)
+                continue;
+            if (memcmp(ctx->desc[i].buf, ctx->desc[j].buf, ctx->desc[i].buf_l) == 0)
+                break;
+        }
+        if (j < i) {
+            ctx->desc[i].dup_from = j;
+            tot_size += 3; // flag, dup_from, ttype
+        } else {
+            ctx->desc[i].dup_from = 0;
+            tot_size += out_len + 1; // ttype
+        }
     }
 
 #if 0
     for (i = 0; i < ctx->max_tok*16; i++) {
-	char fn[1024];
-	if (!ctx->desc[i].buf_l && !ctx->desc[i].dup_from) continue;
-	sprintf(fn, "_tok.%02d_%02d.%d.comp", i>>4,i&15,i);
-	FILE *fp = fopen(fn, "w");
-	fwrite(ctx->desc[i].buf, 1, ctx->desc[i].buf_l, fp);
-	fclose(fp);
+        char fn[1024];
+        if (!ctx->desc[i].buf_l && !ctx->desc[i].dup_from) continue;
+        sprintf(fn, "_tok.%02d_%02d.%d.comp", i>>4,i&15,i);
+        FILE *fp = fopen(fn, "w");
+        fwrite(ctx->desc[i].buf, 1, ctx->desc[i].buf_l, fp);
+        fclose(fp);
     }
 #endif
 
     // Write
     uint8_t *out = malloc(tot_size+13);
     if (!out) {
-	free_context(ctx);
-	return NULL;
+        free_context(ctx);
+        return NULL;
     }
 
     uint8_t *cp = out;
@@ -1477,22 +1477,22 @@ uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
     //write(1, &nreads, 4);
     int last_tnum = -1;
     for (i = 0; i < ctx->max_tok*16; i++) {
-	if (!ctx->desc[i].buf_l) continue;
-	uint8_t ttype8 = ctx->desc[i].ttype;
-	if (ctx->desc[i].tnum != last_tnum) {
-	    ttype8 |= 128;
-	    last_tnum = ctx->desc[i].tnum;
-	}
-	if (ctx->desc[i].dup_from) {
-	    //fprintf(stderr, "Dup %d from %d, sz %d\n", i, ctx->desc[i].dup_from, ctx->desc[i].buf_l);
-	    *cp++ = ttype8 | 64;
-	    *cp++ = ctx->desc[i].dup_from >> 4;
-	    *cp++ = ctx->desc[i].dup_from & 15;
-	} else {
-	    *cp++ = ttype8;
-	    memcpy(cp, ctx->desc[i].buf, ctx->desc[i].buf_l);
-	    cp += ctx->desc[i].buf_l;
-	}
+        if (!ctx->desc[i].buf_l) continue;
+        uint8_t ttype8 = ctx->desc[i].ttype;
+        if (ctx->desc[i].tnum != last_tnum) {
+            ttype8 |= 128;
+            last_tnum = ctx->desc[i].tnum;
+        }
+        if (ctx->desc[i].dup_from) {
+            //fprintf(stderr, "Dup %d from %d, sz %d\n", i, ctx->desc[i].dup_from, ctx->desc[i].buf_l);
+            *cp++ = ttype8 | 64;
+            *cp++ = ctx->desc[i].dup_from >> 4;
+            *cp++ = ctx->desc[i].dup_from & 15;
+        } else {
+            *cp++ = ttype8;
+            memcpy(cp, ctx->desc[i].buf, ctx->desc[i].buf_l);
+            cp += ctx->desc[i].buf_l;
+        }
     }
 
     //assert(cp-out == tot_size);
@@ -1504,9 +1504,9 @@ uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
 
 // Deprecated interface; to remove when we next to an ABI breakage
 uint8_t *encode_names(char *blk, int len, int level, int use_arith,
-		      int *out_len, int *last_start_p) {
+                      int *out_len, int *last_start_p) {
     return tok3_encode_names(blk, len, level, use_arith, out_len,
-			     last_start_p);
+                             last_start_p);
 }
 
 /*
@@ -1517,20 +1517,20 @@ uint8_t *encode_names(char *blk, int len, int level, int use_arith,
  */
 uint8_t *tok3_decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
     if (sz < 9)
-	return NULL;
+        return NULL;
 
     int i, o = 9;
     //int ulen   = *(uint32_t *)in;
     int ulen   = (in[0]<<0) | (in[1]<<8) | (in[2]<<16) |
-	(((uint32_t)in[3])<<24);
+        (((uint32_t)in[3])<<24);
 
     if (ulen < 0 || ulen >= INT_MAX-1024)
-	return NULL;
+        return NULL;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     // Speed up fuzzing by blocking excessive sizes
     if (ulen > 100000)
-	return NULL;
+        return NULL;
 #endif
 
     //int nreads = *(uint32_t *)(in+4);
@@ -1538,129 +1538,129 @@ uint8_t *tok3_decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
     int use_arith = in[8];
     name_context *ctx = create_context(nreads);
     if (!ctx)
-	return NULL;
+        return NULL;
 
     // Unpack descriptors
     int tnum = -1;
     while (o < sz) {
-	uint8_t ttype = in[o++];
-	if (ttype & 64) {
-	    if (o+2 >= sz) goto err;
-	    int j = in[o++]<<4;
-	    j += in[o++];
-	    if (ttype & 128) {
-		tnum++;
-		if (tnum >= MAX_TOKENS)
-		    goto err;
-		ctx->max_tok = tnum+1;
-		memset(&ctx->desc[tnum<<4], 0, 16*sizeof(ctx->desc[tnum]));
-	    }
+        uint8_t ttype = in[o++];
+        if (ttype & 64) {
+            if (o+2 >= sz) goto err;
+            int j = in[o++]<<4;
+            j += in[o++];
+            if (ttype & 128) {
+                tnum++;
+                if (tnum >= MAX_TOKENS)
+                    goto err;
+                ctx->max_tok = tnum+1;
+                memset(&ctx->desc[tnum<<4], 0, 16*sizeof(ctx->desc[tnum]));
+            }
 
-	    if ((ttype & 15) != 0 && (ttype & 128)) {
-		if (tnum < 0) goto err;
-		ctx->desc[tnum<<4].buf = malloc(nreads);
-		if (!ctx->desc[tnum<<4].buf)
-		    goto err;
+            if ((ttype & 15) != 0 && (ttype & 128)) {
+                if (tnum < 0) goto err;
+                ctx->desc[tnum<<4].buf = malloc(nreads);
+                if (!ctx->desc[tnum<<4].buf)
+                    goto err;
 
-		ctx->desc[tnum<<4].buf_l = 0;
-		ctx->desc[tnum<<4].buf_a = nreads;
-		ctx->desc[tnum<<4].buf[0] = ttype&15;
-		memset(&ctx->desc[tnum<<4].buf[1], N_MATCH, nreads-1);
-	    }
+                ctx->desc[tnum<<4].buf_l = 0;
+                ctx->desc[tnum<<4].buf_a = nreads;
+                ctx->desc[tnum<<4].buf[0] = ttype&15;
+                memset(&ctx->desc[tnum<<4].buf[1], N_MATCH, nreads-1);
+            }
 
-	    if (tnum < 0) goto err;
-	    i = (tnum<<4) | (ttype&15);
-	    if (j >= i)
-		goto err;
+            if (tnum < 0) goto err;
+            i = (tnum<<4) | (ttype&15);
+            if (j >= i)
+                goto err;
             if (!ctx->desc[j].buf)
                 goto err; // Attempt to copy a non-existent stream
 
-	    ctx->desc[i].buf_l = 0;
-	    ctx->desc[i].buf_a = ctx->desc[j].buf_a;
-	    if (ctx->desc[i].buf) free(ctx->desc[i].buf);
-	    ctx->desc[i].buf = malloc(ctx->desc[i].buf_a);
-	    if (!ctx->desc[i].buf)
-		goto err;
+            ctx->desc[i].buf_l = 0;
+            ctx->desc[i].buf_a = ctx->desc[j].buf_a;
+            if (ctx->desc[i].buf) free(ctx->desc[i].buf);
+            ctx->desc[i].buf = malloc(ctx->desc[i].buf_a);
+            if (!ctx->desc[i].buf)
+                goto err;
 
-	    memcpy(ctx->desc[i].buf, ctx->desc[j].buf, ctx->desc[i].buf_a);
-	    //fprintf(stderr, "Copy ttype %d, i=%d,j=%d, size %d\n", ttype, i, j, (int)ctx->desc[i].buf_a);
-	    continue;
-	}
+            memcpy(ctx->desc[i].buf, ctx->desc[j].buf, ctx->desc[i].buf_a);
+            //fprintf(stderr, "Copy ttype %d, i=%d,j=%d, size %d\n", ttype, i, j, (int)ctx->desc[i].buf_a);
+            continue;
+        }
 
-	//if (ttype == 0)
-	if (ttype & 128) {
-	    tnum++;
-	    if (tnum >= MAX_TOKENS)
-		goto err;
-	    ctx->max_tok = tnum+1;
-	    memset(&ctx->desc[tnum<<4], 0, 16*sizeof(ctx->desc[tnum]));
-	}
+        //if (ttype == 0)
+        if (ttype & 128) {
+            tnum++;
+            if (tnum >= MAX_TOKENS)
+                goto err;
+            ctx->max_tok = tnum+1;
+            memset(&ctx->desc[tnum<<4], 0, 16*sizeof(ctx->desc[tnum]));
+        }
 
-	if ((ttype & 15) != 0 && (ttype & 128)) {
-	    if (tnum < 0) goto err;
-	    if (ctx->desc[tnum<<4].buf) free(ctx->desc[tnum<<4].buf);
-	    ctx->desc[tnum<<4].buf = malloc(nreads);
-	    if (!ctx->desc[tnum<<4].buf)
-		goto err;
-	    ctx->desc[tnum<<4].buf_l = 0;
-	    ctx->desc[tnum<<4].buf_a = nreads;
-	    ctx->desc[tnum<<4].buf[0] = ttype&15;
-	    memset(&ctx->desc[tnum<<4].buf[1], N_MATCH, nreads-1);
-	}
+        if ((ttype & 15) != 0 && (ttype & 128)) {
+            if (tnum < 0) goto err;
+            if (ctx->desc[tnum<<4].buf) free(ctx->desc[tnum<<4].buf);
+            ctx->desc[tnum<<4].buf = malloc(nreads);
+            if (!ctx->desc[tnum<<4].buf)
+                goto err;
+            ctx->desc[tnum<<4].buf_l = 0;
+            ctx->desc[tnum<<4].buf_a = nreads;
+            ctx->desc[tnum<<4].buf[0] = ttype&15;
+            memset(&ctx->desc[tnum<<4].buf[1], N_MATCH, nreads-1);
+        }
 
-	//fprintf(stderr, "Read %02x\n", c);
+        //fprintf(stderr, "Read %02x\n", c);
 
-	// Load compressed block
-	int64_t clen, ulen = uncompressed_size(&in[o], sz-o);
-	if (ulen < 0 || ulen >= INT_MAX)
-	    goto err;
-	if (tnum < 0) goto err;
-	i = (tnum<<4) | (ttype&15);
+        // Load compressed block
+        int64_t clen, ulen = uncompressed_size(&in[o], sz-o);
+        if (ulen < 0 || ulen >= INT_MAX)
+            goto err;
+        if (tnum < 0) goto err;
+        i = (tnum<<4) | (ttype&15);
 
-	if (i >= MAX_TBLOCKS || i < 0)
-	    goto err;
+        if (i >= MAX_TBLOCKS || i < 0)
+            goto err;
 
-	ctx->desc[i].buf_l = 0;
-	if (ctx->desc[i].buf) free(ctx->desc[i].buf);
-	ctx->desc[i].buf = malloc(ulen);
-	if (!ctx->desc[i].buf)
-	    goto err;
+        ctx->desc[i].buf_l = 0;
+        if (ctx->desc[i].buf) free(ctx->desc[i].buf);
+        ctx->desc[i].buf = malloc(ulen);
+        if (!ctx->desc[i].buf)
+            goto err;
 
-	ctx->desc[i].buf_a = ulen;
-	uint64_t usz = ctx->desc[i].buf_a; // convert from size_t for 32-bit sys
-	clen = uncompress(use_arith, &in[o], sz-o, ctx->desc[i].buf, &usz);
-	ctx->desc[i].buf_a = usz;
-	if (clen < 0 || ctx->desc[i].buf_a != ulen)
-	    goto err;
+        ctx->desc[i].buf_a = ulen;
+        uint64_t usz = ctx->desc[i].buf_a; // convert from size_t for 32-bit sys
+        clen = uncompress(use_arith, &in[o], sz-o, ctx->desc[i].buf, &usz);
+        ctx->desc[i].buf_a = usz;
+        if (clen < 0 || ctx->desc[i].buf_a != ulen)
+            goto err;
 
-	// fprintf(stderr, "%d: Decode tnum %d type %d clen %d ulen %d via %d\n",
-	// 	o, tnum, ttype, (int)clen, (int)ctx->desc[i].buf_a, ctx->desc[i].buf[0]);
+        // fprintf(stderr, "%d: Decode tnum %d type %d clen %d ulen %d via %d\n",
+        //      o, tnum, ttype, (int)clen, (int)ctx->desc[i].buf_a, ctx->desc[i].buf[0]);
 
-	o += clen;
+        o += clen;
 
-	// Encode tnum 0 type 0 ulen 100000 clen 12530 via 2
-	// Encode tnum 0 type 6 ulen 196800 clen 43928 via 3
-	// Encode tnum 0 type 7 ulen 203200 clen 17531 via 3
-	// Encode tnum 1 type 0 ulen 50800 clen 10 via 1
-	// Encode tnum 1 type 1 ulen 3 clen 5 via 0
-	// Encode tnum 2 type 0 ulen 50800 clen 10 via 1
-	// 	
+        // Encode tnum 0 type 0 ulen 100000 clen 12530 via 2
+        // Encode tnum 0 type 6 ulen 196800 clen 43928 via 3
+        // Encode tnum 0 type 7 ulen 203200 clen 17531 via 3
+        // Encode tnum 1 type 0 ulen 50800 clen 10 via 1
+        // Encode tnum 1 type 1 ulen 3 clen 5 via 0
+        // Encode tnum 2 type 0 ulen 50800 clen 10 via 1
+        //      
     }
 
     int ret;
     ulen += 1024; // for easy coding in decode_name.
     uint8_t *out = malloc(ulen);
     if (!out)
-	goto err;
+        goto err;
 
     size_t out_sz = 0;
     while ((ret = decode_name(ctx, (char *)out+out_sz, ulen)) > 0) {
-	out_sz += ret;
-	ulen -= ret;
+        out_sz += ret;
+        ulen -= ret;
     }
 
     if (ret < 0)
-	free(out);
+        free(out);
 
     free_context(ctx);
 

--- a/htscodecs/tokenise_name3.h
+++ b/htscodecs/tokenise_name3.h
@@ -48,7 +48,7 @@ extern "C" {
  *         or NULL on failure
  */
 uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
-			   int *out_len, int *last_start_p);
+                           int *out_len, int *last_start_p);
 
 /*
  * Decodes a compressed block of read names into \0 separated names.

--- a/htscodecs/utils.c
+++ b/htscodecs/utils.c
@@ -82,18 +82,18 @@ static pthread_key_t rans_key;
 static void htscodecs_tls_free_all(void *ptr) {
     tls_pool *tls = (tls_pool *)ptr;
     if (!tls)
-	return;
+        return;
 
     int i;
     for (i = 0; i < MAX_TLS_BUFS; i++) {
 #ifdef TLS_DEBUG
-	if (tls->bufs[i])
-	    fprintf(stderr, "Free %ld = %p\n", tls->sizes[i], tls->bufs[i]);
+        if (tls->bufs[i])
+            fprintf(stderr, "Free %ld = %p\n", tls->sizes[i], tls->bufs[i]);
 #endif
-	if (tls->used[i]) {
-	    fprintf(stderr, "Closing thread while TLS data is in use\n");
-	}
-	free(tls->bufs[i]);
+        if (tls->used[i]) {
+            fprintf(stderr, "Closing thread while TLS data is in use\n");
+        }
+        free(tls->bufs[i]);
     }
 
     free(tls);
@@ -123,38 +123,38 @@ void *htscodecs_tls_alloc(size_t size) {
     // Initialise tls_pool on first usage
     tls_pool *tls = pthread_getspecific(rans_key);
     if (!tls) {
-	if (!(tls = calloc(1, sizeof(*tls))))
-	    return NULL;
-	pthread_setspecific(rans_key, tls);
+        if (!(tls = calloc(1, sizeof(*tls))))
+            return NULL;
+        pthread_setspecific(rans_key, tls);
     }
 
     // Query pool for size
     int avail = -1;
     for (i = 0; i < MAX_TLS_BUFS; i++) {
-	if (!tls->used[i]) {
-	    if (size <= tls->sizes[i]) {
-		tls->used[i] = 1;
+        if (!tls->used[i]) {
+            if (size <= tls->sizes[i]) {
+                tls->used[i] = 1;
 #ifdef TLS_DEBUG
-		fprintf(stderr, "Reuse %d: %ld/%ld = %p\n",
-			i, size, tls->sizes[i], tls->bufs[i]);
+                fprintf(stderr, "Reuse %d: %ld/%ld = %p\n",
+                        i, size, tls->sizes[i], tls->bufs[i]);
 #endif
-		return tls->bufs[i];
-	    } else if (avail == -1) {
-		avail = i;
-	    }
-	}
+                return tls->bufs[i];
+            } else if (avail == -1) {
+                avail = i;
+            }
+        }
     }
 
     if (i == MAX_TLS_BUFS && avail == -1) {
-	// Shouldn't happen given our very limited use of this function
-	fprintf(stderr, "Error: out of rans_tls_alloc slots\n");
-	return NULL;
+        // Shouldn't happen given our very limited use of this function
+        fprintf(stderr, "Error: out of rans_tls_alloc slots\n");
+        return NULL;
     }
 
     if (tls->bufs[avail])
-	free(tls->bufs[avail]);
+        free(tls->bufs[avail]);
     if (!(tls->bufs[avail] = calloc(1, size)))
-	return NULL;
+        return NULL;
 #ifdef TLS_DEBUG
     fprintf(stderr, "Alloc %d: %ld = %p\n", avail, size, tls->bufs[avail]);
 #endif
@@ -176,27 +176,27 @@ void *htscodecs_tls_calloc(size_t nmemb, size_t size) {
 
 void htscodecs_tls_free(void *ptr) {
     if (!ptr)
-	return;
+        return;
 
     tls_pool *tls = pthread_getspecific(rans_key);
 
     int i;
     for (i = 0; i < MAX_TLS_BUFS; i++) {
-	if (tls->bufs[i] == ptr)
-	    break;
+        if (tls->bufs[i] == ptr)
+            break;
     }
 #ifdef TLS_DEBUG
     fprintf(stderr, "Fake free %d size %ld ptr %p\n",
-	    i, tls->sizes[i], tls->bufs[i]);
+            i, tls->sizes[i], tls->bufs[i]);
 #endif
     if (i == MAX_TLS_BUFS) {
-	fprintf(stderr, "Attempt to htscodecs_tls_free a buffer not allocated"
-		" with htscodecs_tls_alloc\n");
-	return;
+        fprintf(stderr, "Attempt to htscodecs_tls_free a buffer not allocated"
+                " with htscodecs_tls_alloc\n");
+        return;
     }
     if (!tls->used[i]) {
-	fprintf(stderr, "Attempt to htscodecs_tls_free a buffer twice\n");
-	return;
+        fprintf(stderr, "Attempt to htscodecs_tls_free a buffer twice\n");
+        return;
     }
     tls->used[i] = 0;
 }

--- a/htscodecs/utils.h
+++ b/htscodecs/utils.h
@@ -55,64 +55,64 @@ void  htscodecs_tls_free(void *ptr);
  * Tuned for specific common cases of N.
  */
 static inline void unstripe(unsigned char *out, unsigned char *outN,
-			    unsigned int ulen, unsigned int N,
-			    unsigned int idxN[256]) {
+                            unsigned int ulen, unsigned int N,
+                            unsigned int idxN[256]) {
     int j = 0, k;
 
     if (ulen >= N) {
-	switch (N) {
-	case 4:
+        switch (N) {
+        case 4:
 #define LLN 16
-	    if (ulen >= 4*LLN) {
-		while (j < ulen-4*LLN) {
-		    int l;
-		    for (l = 0; l < LLN; l++) {
-			for (k = 0; k < 4; k++)
-			    out[j+k+l*4] = outN[idxN[k]+l];
-		    }
-		    for (k = 0; k < 4; k++)
-			idxN[k] += LLN;
-		    j += 4*LLN;
-		}
-	    }
-	    while (j < ulen-4) {
-		for (k = 0; k < 4; k++)
-		    out[j++] = outN[idxN[k]++];
-	    }
+            if (ulen >= 4*LLN) {
+                while (j < ulen-4*LLN) {
+                    int l;
+                    for (l = 0; l < LLN; l++) {
+                        for (k = 0; k < 4; k++)
+                            out[j+k+l*4] = outN[idxN[k]+l];
+                    }
+                    for (k = 0; k < 4; k++)
+                        idxN[k] += LLN;
+                    j += 4*LLN;
+                }
+            }
+            while (j < ulen-4) {
+                for (k = 0; k < 4; k++)
+                    out[j++] = outN[idxN[k]++];
+            }
 #undef LLN
-	    break;
+            break;
 
-	case 2:
+        case 2:
 #define LLN 4
-	    if (ulen >= 2*LLN) {
-		while (j < ulen-2*LLN) {
-		    int l;
-		    for (l = 0; l < LLN; l++) {
-			for (k = 0; k < 2; k++)
-			    out[j++] = outN[idxN[k]+l];
-		    }
-		    for (k = 0; k < 2; k++)
-			idxN[k] += l;
-		}
-	    }
-	    while (j < ulen-2) {
-		for (k = 0; k < 2; k++)
-		    out[j++] = outN[idxN[k]++];
-	    }
+            if (ulen >= 2*LLN) {
+                while (j < ulen-2*LLN) {
+                    int l;
+                    for (l = 0; l < LLN; l++) {
+                        for (k = 0; k < 2; k++)
+                            out[j++] = outN[idxN[k]+l];
+                    }
+                    for (k = 0; k < 2; k++)
+                        idxN[k] += l;
+                }
+            }
+            while (j < ulen-2) {
+                for (k = 0; k < 2; k++)
+                    out[j++] = outN[idxN[k]++];
+            }
 #undef LLN
-	    break;
+            break;
 
-	default:
-	    // General case, around 25% slower overall decode
-	    while (j < ulen-N) {
-		for (k = 0; k < N; k++)
-		    out[j++] = outN[idxN[k]++];
-	    }
-	    break;
-	}
+        default:
+            // General case, around 25% slower overall decode
+            while (j < ulen-N) {
+                for (k = 0; k < N; k++)
+                    out[j++] = outN[idxN[k]++];
+            }
+            break;
+        }
     }
     for (k = 0; j < ulen; k++)
-	out[j++] = outN[idxN[k]++];
+        out[j++] = outN[idxN[k]++];
 }
 
 #define MAGIC 8
@@ -123,55 +123,55 @@ static inline void unstripe(unsigned char *out, unsigned char *outN,
 static inline
 void hist8(unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
     if (in_size > 500000) {
-	uint32_t *f0 = htscodecs_tls_calloc((65536+37)*3, sizeof(*f0));
-	uint32_t *f1 = f0 + 65536+37;
-	uint32_t *f2 = f1 + 65536+37;
+        uint32_t *f0 = htscodecs_tls_calloc((65536+37)*3, sizeof(*f0));
+        uint32_t *f1 = f0 + 65536+37;
+        uint32_t *f2 = f1 + 65536+37;
 
-	uint32_t i, i8 = in_size & ~15;
+        uint32_t i, i8 = in_size & ~15;
 
-	for (i = 0; i < i8; i+=16) {
-	    uint16_t i16a[4], i16b[4];
-	    memcpy(i16a, in+i, 8);
-	    f0[i16a[0]]++;
-	    f1[i16a[1]]++;
-	    f2[i16a[2]]++;
-	    f0[i16a[3]]++;
+        for (i = 0; i < i8; i+=16) {
+            uint16_t i16a[4], i16b[4];
+            memcpy(i16a, in+i, 8);
+            f0[i16a[0]]++;
+            f1[i16a[1]]++;
+            f2[i16a[2]]++;
+            f0[i16a[3]]++;
 
-	    memcpy(i16b, in+i+8, 8);
-	    f1[i16b[0]]++;
-	    f0[i16b[1]]++;
-	    f1[i16b[2]]++;
-	    f2[i16b[3]]++;
-	}
+            memcpy(i16b, in+i+8, 8);
+            f1[i16b[0]]++;
+            f0[i16b[1]]++;
+            f1[i16b[2]]++;
+            f2[i16b[3]]++;
+        }
 
-	while (i < in_size)
-	    F0[in[i++]]++;
+        while (i < in_size)
+            F0[in[i++]]++;
 
-	for (i = 0; i < 65536; i++) {
-	    F0[i & 0xff] += f0[i] + f1[i] + f2[i];
-	    F0[i >> 8  ] += f0[i] + f1[i] + f2[i];
-	}
-	htscodecs_tls_free(f0);
+        for (i = 0; i < 65536; i++) {
+            F0[i & 0xff] += f0[i] + f1[i] + f2[i];
+            F0[i >> 8  ] += f0[i] + f1[i] + f2[i];
+        }
+        htscodecs_tls_free(f0);
     } else {
-	uint32_t F1[256+MAGIC] = {0}, F2[256+MAGIC] = {0}, F3[256+MAGIC] = {0};
-	uint32_t i, i8 = in_size & ~7;
+        uint32_t F1[256+MAGIC] = {0}, F2[256+MAGIC] = {0}, F3[256+MAGIC] = {0};
+        uint32_t i, i8 = in_size & ~7;
 
-	for (i = 0; i < i8; i+=8) {
-	    F0[in[i+0]]++;
-	    F1[in[i+1]]++;
-	    F2[in[i+2]]++;
-	    F3[in[i+3]]++;
-	    F0[in[i+4]]++;
-	    F1[in[i+5]]++;
-	    F2[in[i+6]]++;
-	    F3[in[i+7]]++;
-	}
+        for (i = 0; i < i8; i+=8) {
+            F0[in[i+0]]++;
+            F1[in[i+1]]++;
+            F2[in[i+2]]++;
+            F3[in[i+3]]++;
+            F0[in[i+4]]++;
+            F1[in[i+5]]++;
+            F2[in[i+6]]++;
+            F3[in[i+7]]++;
+        }
 
-	while (i < in_size)
-	    F0[in[i++]]++;
+        while (i < in_size)
+            F0[in[i++]]++;
 
-	for (i = 0; i < 256; i++)
-	    F0[i] += F1[i] + F2[i] + F3[i];
+        for (i = 0; i < 256; i++)
+            F0[i] += F1[i] + F2[i] + F3[i];
     }
 }
 
@@ -190,25 +190,25 @@ double hist8e(unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
 
     unsigned int i, i8 = in_size & ~7;
     for (i = 0; i < i8; i+=8) {
-	F0[in[i+0]]++;
-	F1[in[i+1]]++;
-	F2[in[i+2]]++;
-	F3[in[i+3]]++;
-	F4[in[i+4]]++;
-	F5[in[i+5]]++;
-	F6[in[i+6]]++;
-	F7[in[i+7]]++;
+        F0[in[i+0]]++;
+        F1[in[i+1]]++;
+        F2[in[i+2]]++;
+        F3[in[i+3]]++;
+        F4[in[i+4]]++;
+        F5[in[i+5]]++;
+        F6[in[i+6]]++;
+        F7[in[i+7]]++;
     }
     while (i < in_size)
-	F0[in[i++]]++;
+        F0[in[i++]]++;
 
     for (i = 0; i < 256; i++) {
-	F0[i] += F1[i] + F2[i] + F3[i] + F4[i] + F5[i] + F6[i] + F7[i];
+        F0[i] += F1[i] + F2[i] + F3[i] + F4[i] + F5[i] + F6[i] + F7[i];
 #ifdef __GNUC__
-	e -= F0[i] * (32 - __builtin_clz(F0[i]|1) + in_size_r2);
+        e -= F0[i] * (32 - __builtin_clz(F0[i]|1) + in_size_r2);
 #else
-	extern double fast_log(double);
-	e -= F0[i] * (fast_log(F0[i]) + in_size_r2);
+        extern double fast_log(double);
+        e -= F0[i] * (fast_log(F0[i]) + in_size_r2);
 #endif
     }
 
@@ -224,27 +224,27 @@ double hist8e(unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
  */
 static inline
 void present8(unsigned char *in, unsigned int in_size,
-	      uint32_t F0[256]) {
+              uint32_t F0[256]) {
     uint32_t F1[256+MAGIC] = {0}, F2[256+MAGIC] = {0}, F3[256+MAGIC] = {0};
     uint32_t F4[256+MAGIC] = {0}, F5[256+MAGIC] = {0}, F6[256+MAGIC] = {0};
     uint32_t F7[256+MAGIC] = {0};
 
     unsigned int i, i8 = in_size & ~7;
     for (i = 0; i < i8; i+=8) {
-	F0[in[i+0]]=1;
-	F1[in[i+1]]=1;
-	F2[in[i+2]]=1;
-	F3[in[i+3]]=1;
-	F4[in[i+4]]=1;
-	F5[in[i+5]]=1;
-	F6[in[i+6]]=1;
-	F7[in[i+7]]=1;
+        F0[in[i+0]]=1;
+        F1[in[i+1]]=1;
+        F2[in[i+2]]=1;
+        F3[in[i+3]]=1;
+        F4[in[i+4]]=1;
+        F5[in[i+5]]=1;
+        F6[in[i+6]]=1;
+        F7[in[i+7]]=1;
     }
     while (i < in_size)
-	F0[in[i++]]=1;
+        F0[in[i++]]=1;
 
     for (i = 0; i < 256; i++)
-	F0[i] += F1[i] + F2[i] + F3[i] + F4[i] + F5[i] + F6[i] + F7[i];
+        F0[i] += F1[i] + F2[i] + F3[i] + F4[i] + F5[i] + F6[i] + F7[i];
 }
 
 /*
@@ -253,77 +253,77 @@ void present8(unsigned char *in, unsigned int in_size,
 #if 1
 static inline
 void hist1_4(unsigned char *in, unsigned int in_size,
-	     uint32_t F0[256][256], uint32_t *T0) {
+             uint32_t F0[256][256], uint32_t *T0) {
     unsigned char l = 0, c;
     unsigned char *in_end = in + in_size;
 
     unsigned char cc[5] = {0};
     if (in_size > 500000) {
-	uint32_t (*F1)[259] = htscodecs_tls_calloc(256, sizeof(*F1));
-	while (in < in_end-8) {
-	    memcpy(cc, in, 4); in += 4;
-	    F0[cc[4]][cc[0]]++;
-	    F1[cc[0]][cc[1]]++;
-	    F0[cc[1]][cc[2]]++;
-	    F1[cc[2]][cc[3]]++;
-	    cc[4] = cc[3];
+        uint32_t (*F1)[259] = htscodecs_tls_calloc(256, sizeof(*F1));
+        while (in < in_end-8) {
+            memcpy(cc, in, 4); in += 4;
+            F0[cc[4]][cc[0]]++;
+            F1[cc[0]][cc[1]]++;
+            F0[cc[1]][cc[2]]++;
+            F1[cc[2]][cc[3]]++;
+            cc[4] = cc[3];
 
-	    memcpy(cc, in, 4); in += 4;
-	    F0[cc[4]][cc[0]]++;
-	    F1[cc[0]][cc[1]]++;
-	    F0[cc[1]][cc[2]]++;
-	    F1[cc[2]][cc[3]]++;
-	    cc[4] = cc[3];
-	}
-	l = cc[3];
+            memcpy(cc, in, 4); in += 4;
+            F0[cc[4]][cc[0]]++;
+            F1[cc[0]][cc[1]]++;
+            F0[cc[1]][cc[2]]++;
+            F1[cc[2]][cc[3]]++;
+            cc[4] = cc[3];
+        }
+        l = cc[3];
 
-	while (in < in_end) {
-	    F0[l][c = *in++]++;
-	    l = c;
-	}
-	T0[l]++;
+        while (in < in_end) {
+            F0[l][c = *in++]++;
+            l = c;
+        }
+        T0[l]++;
 
-	int i, j;
-	for (i = 0; i < 256; i++) {
-	    int tt = 0;
-	    for (j = 0; j < 256; j++) {
-		F0[i][j] += F1[i][j];
-		tt += F0[i][j];
-	    }
-	    T0[i]+=tt;
-	}
-	htscodecs_tls_free(F1);
+        int i, j;
+        for (i = 0; i < 256; i++) {
+            int tt = 0;
+            for (j = 0; j < 256; j++) {
+                F0[i][j] += F1[i][j];
+                tt += F0[i][j];
+            }
+            T0[i]+=tt;
+        }
+        htscodecs_tls_free(F1);
     } else {
-	while (in < in_end-8) {
-	    memcpy(cc, in, 4); in += 4;
-	    F0[cc[4]][cc[0]]++;
-	    F0[cc[0]][cc[1]]++;
-	    F0[cc[1]][cc[2]]++;
-	    F0[cc[2]][cc[3]]++;
-	    cc[4] = cc[3];
+        while (in < in_end-8) {
+            memcpy(cc, in, 4); in += 4;
+            F0[cc[4]][cc[0]]++;
+            F0[cc[0]][cc[1]]++;
+            F0[cc[1]][cc[2]]++;
+            F0[cc[2]][cc[3]]++;
+            cc[4] = cc[3];
 
-	    memcpy(cc, in, 4); in += 4;
-	    F0[cc[4]][cc[0]]++;
-	    F0[cc[0]][cc[1]]++;
-	    F0[cc[1]][cc[2]]++;
-	    F0[cc[2]][cc[3]]++;
-	    cc[4] = cc[3];
-	}
-	l = cc[3];
+            memcpy(cc, in, 4); in += 4;
+            F0[cc[4]][cc[0]]++;
+            F0[cc[0]][cc[1]]++;
+            F0[cc[1]][cc[2]]++;
+            F0[cc[2]][cc[3]]++;
+            cc[4] = cc[3];
+        }
+        l = cc[3];
 
-	while (in < in_end) {
-	    F0[l][c = *in++]++;
-	    l = c;
-	}
-	T0[l]++;
+        while (in < in_end) {
+            F0[l][c = *in++]++;
+            l = c;
+        }
+        T0[l]++;
 
-	int i, j;
-	for (i = 0; i < 256; i++) {
-	    int tt = 0;
-	    for (j = 0; j < 256; j++)
-		tt += F0[i][j];
-	    T0[i]+=tt;
-	}
+        int i, j;
+        for (i = 0; i < 256; i++) {
+            int tt = 0;
+            for (j = 0; j < 256; j++)
+                tt += F0[i][j];
+            T0[i]+=tt;
+        }
     }
 }
 
@@ -335,7 +335,7 @@ void hist1_4(unsigned char *in, unsigned int in_size,
 // Kept here for posterity incase we need it again, as it's quick tricky.
 static inline
 void hist1_4(unsigned char *in, unsigned int in_size,
-	     uint32_t F0[256][256], uint32_t *T0) {
+             uint32_t F0[256][256], uint32_t *T0) {
     uint32_t f0[65536+MAGIC] = {0};
     uint32_t f1[65536+MAGIC] = {0};
 
@@ -343,9 +343,9 @@ void hist1_4(unsigned char *in, unsigned int in_size,
 
     T0[0]++; f0[in[0]<<8]++;
     for (i = 0; i < i8; i+=16) {
-	uint16_t i16a[16];
+        uint16_t i16a[16];
         memcpy(i16a,   in+i,   16); // faster in 2 as gcc recognises this
-	memcpy(i16a+8, in+i+1, 16); // faster in 2 as gcc recognises this
+        memcpy(i16a+8, in+i+1, 16); // faster in 2 as gcc recognises this
 
         f0[i16a[0]]++;
         f1[i16a[1]]++;
@@ -366,14 +366,14 @@ void hist1_4(unsigned char *in, unsigned int in_size,
     }
 
     while (i < in_size-1) {
-	F0[in[i]][in[i+1]]++;
-	T0[in[i+1]]++;
-	i++;
+        F0[in[i]][in[i+1]]++;
+        T0[in[i+1]]++;
+        i++;
     }
 
     for (i = 0; i < 65536; i++) {
         F0[i&0xff][i>>8] += f0[i] + f1[i];
-	T0[i>>8]         += f0[i] + f1[i];
+        T0[i>>8]         += f0[i] + f1[i];
     }
 }
 #endif

--- a/htscodecs/varint.h
+++ b/htscodecs/varint.h
@@ -70,19 +70,19 @@ int var_put_u64_safe(uint8_t *cp, const uint8_t *endp, uint64_t i) {
 
     // safe method when we're near end of buffer
     do {
-	s += 7;
-	X >>= 7;
+        s += 7;
+        X >>= 7;
     } while (X);
 
     if (endp && (endp-cp)*7 < s)
-	return 0;
+        return 0;
 
     int n;
     for (n = 0; n < 10; n++) {
-	s -= 7;
-	*cp++ = ((i>>s) & 0x7f) + (s?128:0);
-	if (!s)
-	    break;
+        s -= 7;
+        *cp++ = ((i>>s) & 0x7f) + (s?128:0);
+        if (!s)
+            break;
     }
 
     return cp-op;
@@ -94,83 +94,83 @@ int var_put_u64_safe(uint8_t *cp, const uint8_t *endp, uint64_t i) {
 static inline
 int var_put_u64(uint8_t *cp, const uint8_t *endp, uint64_t i) {
     if (endp && (endp-cp) < 10)
-	return var_put_u64_safe(cp, endp, i);
+        return var_put_u64_safe(cp, endp, i);
 
     // maximum of 10 bytes written
     if (i < (1<<7)) {
-	*cp = i;
-	return 1;
+        *cp = i;
+        return 1;
     } else if (i < (1<<14)) {
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 2;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 2;
     } else if (i < (1<<21)) {
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 3;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 3;
     } else if (i < (1<<28)) {
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 4;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 4;
     } else if (i < (1LL<<35)) {
-	*cp++ = ((i>>28) & 0x7f) | 128;
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 5;
+        *cp++ = ((i>>28) & 0x7f) | 128;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 5;
     } else if (i < (1LL<<42)) {
-	*cp++ = ((i>>35) & 0x7f) | 128;
-	*cp++ = ((i>>28) & 0x7f) | 128;
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 6;
+        *cp++ = ((i>>35) & 0x7f) | 128;
+        *cp++ = ((i>>28) & 0x7f) | 128;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 6;
     } else if (i < (1LL<<49)) {
-	*cp++ = ((i>>42) & 0x7f) | 128;
-	*cp++ = ((i>>35) & 0x7f) | 128;
-	*cp++ = ((i>>28) & 0x7f) | 128;
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 7;
+        *cp++ = ((i>>42) & 0x7f) | 128;
+        *cp++ = ((i>>35) & 0x7f) | 128;
+        *cp++ = ((i>>28) & 0x7f) | 128;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 7;
     } else if (i < (1LL<<56)) {
-	*cp++ = ((i>>49) & 0x7f) | 128;
-	*cp++ = ((i>>42) & 0x7f) | 128;
-	*cp++ = ((i>>35) & 0x7f) | 128;
-	*cp++ = ((i>>28) & 0x7f) | 128;
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 8;
+        *cp++ = ((i>>49) & 0x7f) | 128;
+        *cp++ = ((i>>42) & 0x7f) | 128;
+        *cp++ = ((i>>35) & 0x7f) | 128;
+        *cp++ = ((i>>28) & 0x7f) | 128;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 8;
     } else if (i < (1LL<<63)) {
-	*cp++ = ((i>>56) & 0x7f) | 128;
-	*cp++ = ((i>>49) & 0x7f) | 128;
-	*cp++ = ((i>>42) & 0x7f) | 128;
-	*cp++ = ((i>>35) & 0x7f) | 128;
-	*cp++ = ((i>>28) & 0x7f) | 128;
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 9;
+        *cp++ = ((i>>56) & 0x7f) | 128;
+        *cp++ = ((i>>49) & 0x7f) | 128;
+        *cp++ = ((i>>42) & 0x7f) | 128;
+        *cp++ = ((i>>35) & 0x7f) | 128;
+        *cp++ = ((i>>28) & 0x7f) | 128;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 9;
     } else {
-	*cp++ = ((i>>63) & 0x7f) | 128;
-	*cp++ = ((i>>56) & 0x7f) | 128;
-	*cp++ = ((i>>49) & 0x7f) | 128;
-	*cp++ = ((i>>42) & 0x7f) | 128;
-	*cp++ = ((i>>35) & 0x7f) | 128;
-	*cp++ = ((i>>28) & 0x7f) | 128;
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
+        *cp++ = ((i>>63) & 0x7f) | 128;
+        *cp++ = ((i>>56) & 0x7f) | 128;
+        *cp++ = ((i>>49) & 0x7f) | 128;
+        *cp++ = ((i>>42) & 0x7f) | 128;
+        *cp++ = ((i>>35) & 0x7f) | 128;
+        *cp++ = ((i>>28) & 0x7f) | 128;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
     }
 
     return 10;
@@ -184,19 +184,19 @@ int var_put_u32_safe(uint8_t *cp, const uint8_t *endp, uint32_t i) {
 
     // safe method when we're near end of buffer
     do {
-	s += 7;
-	X >>= 7;
+        s += 7;
+        X >>= 7;
     } while (X);
 
     if (endp && (endp-cp)*7 < s)
-	return 0;
+        return 0;
 
     int n;
     for (n = 0; n < 5; n++) {
-	s -= 7;
-	*cp++ = ((i>>s) & 0x7f) + (s?128:0);
-	if (!s)
-	    break;
+        s -= 7;
+        *cp++ = ((i>>s) & 0x7f) + (s?128:0);
+        if (!s)
+            break;
     }
 
     return cp-op;
@@ -205,32 +205,32 @@ int var_put_u32_safe(uint8_t *cp, const uint8_t *endp, uint32_t i) {
 static inline
 int var_put_u32(uint8_t *cp, const uint8_t *endp, uint32_t i) {
     if (endp && (endp-cp) < 5)
-	return var_put_u32_safe(cp, endp, i);
+        return var_put_u32_safe(cp, endp, i);
 
     if (i < (1<<7)) {
-	*cp = i;
-	return 1;
+        *cp = i;
+        return 1;
     } else if (i < (1<<14)) {
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 2;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 2;
     } else if (i < (1<<21)) {
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 3;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 3;
     } else if (i < (1<<28)) {
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
-	return 4;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
+        return 4;
     } else {
-	*cp++ = ((i>>28) & 0x7f) | 128;
-	*cp++ = ((i>>21) & 0x7f) | 128;
-	*cp++ = ((i>>14) & 0x7f) | 128;
-	*cp++ = ((i>> 7) & 0x7f) | 128;
-	*cp++ =   i      & 0x7f;
+        *cp++ = ((i>>28) & 0x7f) | 128;
+        *cp++ = ((i>>21) & 0x7f) | 128;
+        *cp++ = ((i>>14) & 0x7f) | 128;
+        *cp++ = ((i>> 7) & 0x7f) | 128;
+        *cp++ =   i      & 0x7f;
     }
 
     return 5;
@@ -242,21 +242,21 @@ int var_get_u64(uint8_t *cp, const uint8_t *endp, uint64_t *i) {
     uint64_t j = 0;
 
     if (!endp || endp - cp >= 10) {
-	int n = 10;
-	do {
-	    c = *cp++;
-	    j = (j<<7) | (c & 0x7f);
-	} while ((c & 0x80) && n-- > 0);
+        int n = 10;
+        do {
+            c = *cp++;
+            j = (j<<7) | (c & 0x7f);
+        } while ((c & 0x80) && n-- > 0);
     } else {
-	if (cp >= endp) {
-	    *i = 0;
-	    return 0;
-	}
+        if (cp >= endp) {
+            *i = 0;
+            return 0;
+        }
 
-	do {
-	    c = *cp++;
-	    j = (j<<7) | (c & 0x7f);
-	} while ((c & 0x80) && cp < endp);
+        do {
+            c = *cp++;
+            j = (j<<7) | (c & 0x7f);
+        } while ((c & 0x80) && cp < endp);
     }
 
     *i = j;
@@ -269,29 +269,29 @@ int var_get_u32(uint8_t *cp, const uint8_t *endp, uint32_t *i) {
     uint32_t j = 0;
 
     if (!endp || endp - cp >= 6) {
-	// Known maximum loop count helps optimiser.
-	// NB: this helps considerably at -O3 level, but may harm -O2.
-	// (However we optimise for those that want optimal code.)
-	int n = 5;
-	do {
-	    c = *cp++;
-	    j = (j<<7) | (c & 0x7f);
-	} while ((c & 0x80) && n-- > 0);
+        // Known maximum loop count helps optimiser.
+        // NB: this helps considerably at -O3 level, but may harm -O2.
+        // (However we optimise for those that want optimal code.)
+        int n = 5;
+        do {
+            c = *cp++;
+            j = (j<<7) | (c & 0x7f);
+        } while ((c & 0x80) && n-- > 0);
     } else {
-	if (cp >= endp) {
-	    *i = 0;
-	    return 0;
-	}
+        if (cp >= endp) {
+            *i = 0;
+            return 0;
+        }
 
-	if (*cp < 128) {
-	    *i = *cp;
-	    return 1;
-	}
+        if (*cp < 128) {
+            *i = *cp;
+            return 1;
+        }
 
-	do {
-	    c = *cp++;
-	    j = (j<<7) | (c & 0x7f);
-	} while ((c & 0x80) && cp < endp);
+        do {
+            c = *cp++;
+            j = (j<<7) | (c & 0x7f);
+        } while ((c & 0x80) && cp < endp);
     }
 
     *i = j;
@@ -309,17 +309,17 @@ static inline int var_put_u64(uint8_t *cp, const uint8_t *endp, uint64_t i) {
     uint8_t *op = cp;
 
     if (!endp || (endp-cp)*7 >= 10) {
-	// Unsafe or big-enough anyway
-	do {
-	    *cp++ = (i&0x7f) + ((i>=0x80)<<7);
-	    i >>= 7;
-	} while (i);
+        // Unsafe or big-enough anyway
+        do {
+            *cp++ = (i&0x7f) + ((i>=0x80)<<7);
+            i >>= 7;
+        } while (i);
     } else if (cp < endp) {
-	// End checked variant
-	do {
-	    *cp++ = (i&0x7f) + ((i>=0x80)<<7);
-	    i >>= 7;
-	} while (i && cp < endp);
+        // End checked variant
+        do {
+            *cp++ = (i&0x7f) + ((i>=0x80)<<7);
+            i >>= 7;
+        } while (i && cp < endp);
     }
 
     return cp-op;
@@ -329,17 +329,17 @@ static inline int var_put_u32(uint8_t *cp, const uint8_t *endp, uint32_t i) {
     uint8_t *op = cp;
 
     if (!endp || (endp-cp)*7 >= 5) {
-	// Unsafe or big-enough anyway
-	do {
-	    *cp++ = (i&0x7f) + ((i>=0x80)<<7);
-	    i >>= 7;
-	} while (i);
+        // Unsafe or big-enough anyway
+        do {
+            *cp++ = (i&0x7f) + ((i>=0x80)<<7);
+            i >>= 7;
+        } while (i);
     } else if (cp < endp) {
-	// End checked variant
-	do {
-	    *cp++ = (i&0x7f) + ((i>=0x80)<<7);
-	    i >>= 7;
-	} while (i && cp < endp);
+        // End checked variant
+        do {
+            *cp++ = (i&0x7f) + ((i>=0x80)<<7);
+            i >>= 7;
+        } while (i && cp < endp);
     }
 
     return cp-op;
@@ -350,24 +350,24 @@ static inline int var_get_u64(uint8_t *cp, const uint8_t *endp, uint64_t *i) {
     uint64_t j = 0, s = 0;
 
     if (endp) {
-	// Safe variant
-	if (cp >= endp) {
-	    *i = 0;
-	    return 0;
-	}
+        // Safe variant
+        if (cp >= endp) {
+            *i = 0;
+            return 0;
+        }
 
-	do {
-	    c = *cp++;
-	    j |= (c & 0x7f) << s;
-	    s += 7;
-	} while ((c & 0x80) && cp < endp);
+        do {
+            c = *cp++;
+            j |= (c & 0x7f) << s;
+            s += 7;
+        } while ((c & 0x80) && cp < endp);
     } else {
-	// Unsafe variant
-	do {
-	    c = *cp++;
-	    j |= (c & 0x7f) << s;
-	    s += 7;
-	} while ((c & 0x80));
+        // Unsafe variant
+        do {
+            c = *cp++;
+            j |= (c & 0x7f) << s;
+            s += 7;
+        } while ((c & 0x80));
     }
 
     *i = j;
@@ -379,24 +379,24 @@ static inline int var_get_u32(uint8_t *cp, const uint8_t *endp, uint32_t *i) {
     uint32_t j = 0, s = 0;
 
     if (endp) {
-	// Safe variant
-	if (cp >= endp) {
-	    *i = 0;
-	    return 0;
-	}
+        // Safe variant
+        if (cp >= endp) {
+            *i = 0;
+            return 0;
+        }
 
-	do {
-	    c = *cp++;
-	    j |= (c & 0x7f) << s;
-	    s += 7;
-	} while ((c & 0x80) && cp < endp);
+        do {
+            c = *cp++;
+            j |= (c & 0x7f) << s;
+            s += 7;
+        } while ((c & 0x80) && cp < endp);
     } else {
-	// Unsafe variant
-	do {
-	    c = *cp++;
-	    j |= (c & 0x7f) << s;
-	    s += 7;
-	} while ((c & 0x80));
+        // Unsafe variant
+        do {
+            c = *cp++;
+            j |= (c & 0x7f) << s;
+            s += 7;
+        } while ((c & 0x80));
     }
 
     *i = j;
@@ -429,8 +429,8 @@ static inline int var_get_s64(uint8_t *cp, const uint8_t *endp, int64_t *i) {
 static inline int var_size_u64(uint64_t v) {
     int i = 0;
     do {
-	i++;
-	v >>= 7;
+        i++;
+        v >>= 7;
     } while (v);
     return i;
 }

--- a/htscodecs/varint2.h
+++ b/htscodecs/varint2.h
@@ -99,7 +99,7 @@
 //     static char buf[1000];
 //     int i, o = 0;
 //     for (i = 0; i < n; i++)
-// 	o += sprintf(&buf[o], " %d", cp[i]);
+//      o += sprintf(&buf[o], " %d", cp[i]);
 //     return buf;
 // }
 
@@ -107,69 +107,69 @@ static inline int var_put_u64(uint8_t *cp, const uint8_t *endp, uint64_t x) {
     uint8_t *op = cp;
 
     if (x < 177) {
-	if (endp && endp - cp < 1) return 0;
-	// 0 to 176 in single byte as-is
-	*cp++ = x;
+        if (endp && endp - cp < 1) return 0;
+        // 0 to 176 in single byte as-is
+        *cp++ = x;
     } else if (x < 16561) {
-	if (endp && endp - cp < 2) return 0;
-	*cp++ = ((x-177)>>8)+177;
-	*cp++ = x-177;
+        if (endp && endp - cp < 2) return 0;
+        *cp++ = ((x-177)>>8)+177;
+        *cp++ = x-177;
     } else if (x < 540849) {
-	if (endp && endp - cp < 3) return 0;
-	*cp++ = ((x-16561)>>16)+241;
-	*cp++ = (x-16561)>>8;
-	*cp++ = x-16561;
+        if (endp && endp - cp < 3) return 0;
+        *cp++ = ((x-16561)>>16)+241;
+        *cp++ = (x-16561)>>8;
+        *cp++ = x-16561;
     } else if (x < (1<<24)) {
-	if (endp && endp - cp < 4) return 0;
-	*cp++ = 249;
-	*cp++ = x>>16;
-	*cp++ = x>>8;
-	*cp++ = x;
+        if (endp && endp - cp < 4) return 0;
+        *cp++ = 249;
+        *cp++ = x>>16;
+        *cp++ = x>>8;
+        *cp++ = x;
     } else if (x < (1LL<<32)) {
-	if (endp && endp - cp < 5) return 0;
-	*cp++ = 250;
-	*cp++ = x>>24;
-	*cp++ = x>>16;
-	*cp++ = x>>8;
-	*cp++ = x;
+        if (endp && endp - cp < 5) return 0;
+        *cp++ = 250;
+        *cp++ = x>>24;
+        *cp++ = x>>16;
+        *cp++ = x>>8;
+        *cp++ = x;
     } else if (x < (1LL<<40)) {
-	if (endp && endp - cp < 6) return 0;
-	*cp++ = 251;
-	*cp++ = x>>32;
-	*cp++ = x>>24;
-	*cp++ = x>>16;
-	*cp++ = x>>8;
-	*cp++ = x;
+        if (endp && endp - cp < 6) return 0;
+        *cp++ = 251;
+        *cp++ = x>>32;
+        *cp++ = x>>24;
+        *cp++ = x>>16;
+        *cp++ = x>>8;
+        *cp++ = x;
     } else if (x < (1LL<<48)) {
-	if (endp && endp - cp < 7) return 0;
-	*cp++ = 252;
-	*cp++ = x>>40;
-	*cp++ = x>>32;
-	*cp++ = x>>24;
-	*cp++ = x>>16;
-	*cp++ = x>>8;
-	*cp++ = x;
+        if (endp && endp - cp < 7) return 0;
+        *cp++ = 252;
+        *cp++ = x>>40;
+        *cp++ = x>>32;
+        *cp++ = x>>24;
+        *cp++ = x>>16;
+        *cp++ = x>>8;
+        *cp++ = x;
     } else if (x < (1LL<<56)) {
-	if (endp && endp - cp < 8) return 0;
-	*cp++ = 253;
-	*cp++ = x>>48;
-	*cp++ = x>>40;
-	*cp++ = x>>32;
-	*cp++ = x>>24;
-	*cp++ = x>>16;
-	*cp++ = x>>8;
-	*cp++ = x;
+        if (endp && endp - cp < 8) return 0;
+        *cp++ = 253;
+        *cp++ = x>>48;
+        *cp++ = x>>40;
+        *cp++ = x>>32;
+        *cp++ = x>>24;
+        *cp++ = x>>16;
+        *cp++ = x>>8;
+        *cp++ = x;
     } else {
-	if (endp && endp - cp < 9) return 0;
-	*cp++ = 254;
-	*cp++ = x>>56;
-	*cp++ = x>>48;
-	*cp++ = x>>40;
-	*cp++ = x>>32;
-	*cp++ = x>>24;
-	*cp++ = x>>16;
-	*cp++ = x>>8;
-	*cp++ = x;
+        if (endp && endp - cp < 9) return 0;
+        *cp++ = 254;
+        *cp++ = x>>56;
+        *cp++ = x>>48;
+        *cp++ = x>>40;
+        *cp++ = x>>32;
+        *cp++ = x>>24;
+        *cp++ = x>>16;
+        *cp++ = x>>8;
+        *cp++ = x;
     }
 
 //    fprintf(stderr, "Put64 %d (%s)\n", x, var_dump(op, cp-op));
@@ -181,31 +181,31 @@ static inline int var_put_u32(uint8_t *cp, const uint8_t *endp, uint32_t x) {
     uint8_t *op = cp;
 
     if (x < 177) {
-	if (endp && endp - cp < 1) abort();//return 0;
-	// 0 to 176 in single byte as-is
-	*cp++ = x;
+        if (endp && endp - cp < 1) abort();//return 0;
+        // 0 to 176 in single byte as-is
+        *cp++ = x;
     } else if (x < 16561) {
-	if (endp && endp - cp < 2) abort();//return 0;
-	*cp++ = ((x-177)>>8)+177;
-	*cp++ = x-177;
+        if (endp && endp - cp < 2) abort();//return 0;
+        *cp++ = ((x-177)>>8)+177;
+        *cp++ = x-177;
     } else if (x < 540849) {
-	if (endp && endp - cp < 3) abort();//return 0;
-	*cp++ = ((x-16561)>>16)+241;
-	*cp++ = (x-16561)>>8;
-	*cp++ = x-16561;
+        if (endp && endp - cp < 3) abort();//return 0;
+        *cp++ = ((x-16561)>>16)+241;
+        *cp++ = (x-16561)>>8;
+        *cp++ = x-16561;
     } else if (x < (1<<24)) {
-	if (endp && endp - cp < 4) abort();//return 0;
-	*cp++ = 249;
-	*cp++ = x>>16;
-	*cp++ = x>>8;
-	*cp++ = x;
+        if (endp && endp - cp < 4) abort();//return 0;
+        *cp++ = 249;
+        *cp++ = x>>16;
+        *cp++ = x>>8;
+        *cp++ = x;
     } else {
-	if (endp && endp - cp < 5) abort();//return 0;
-	*cp++ = 250;
-	*cp++ = x>>24;
-	*cp++ = x>>16;
-	*cp++ = x>>8;
-	*cp++ = x;
+        if (endp && endp - cp < 5) abort();//return 0;
+        *cp++ = 250;
+        *cp++ = x>>24;
+        *cp++ = x>>16;
+        *cp++ = x>>8;
+        *cp++ = x;
     }
 
 //    fprintf(stderr, "Put32 %d (%s)\n", x, var_dump(op, cp-op));
@@ -218,21 +218,21 @@ static inline int var_get_u64(uint8_t *cp, const uint8_t *endp, uint64_t *i) {
     uint64_t j = 0;
 
     if (endp && cp >= endp) {
-	*i = 0;
-	return 0;
+        *i = 0;
+        return 0;
     }
     if (*cp < 177) {
-	j = *cp++;
+        j = *cp++;
     } else if (*cp < 241) {
-	j = ((cp[0] - 177)<<8) + cp[1] + 177;
-	cp += 2;
+        j = ((cp[0] - 177)<<8) + cp[1] + 177;
+        cp += 2;
     } else if (*cp < 249) {
-	j = ((cp[0] - 241)<<16) + (cp[1]<<8) + cp[2] + 16561;
-	cp += 3;
+        j = ((cp[0] - 241)<<16) + (cp[1]<<8) + cp[2] + 16561;
+        cp += 3;
     } else {
-	int n = *cp++ - 249 + 3;
-	while (n--)
-	    j = (j<<8) + *cp++;
+        int n = *cp++ - 249 + 3;
+        while (n--)
+            j = (j<<8) + *cp++;
     }
 
 //    fprintf(stderr, "Get64 %ld (%s)\n", j, var_dump(op, cp-op));
@@ -246,21 +246,21 @@ static inline int var_get_u32(uint8_t *cp, const uint8_t *endp, uint32_t *i) {
     uint32_t j = 0;
 
     if (endp && cp >= endp) {
-	*i = 0;
-	return 0;
+        *i = 0;
+        return 0;
     }
     if (*cp < 177) {
-	j = *cp++;
+        j = *cp++;
     } else if (*cp < 241) {
-	j = ((cp[0] - 177)<<8) + cp[1] + 177;
-	cp += 2;
+        j = ((cp[0] - 177)<<8) + cp[1] + 177;
+        cp += 2;
     } else if (*cp < 249) {
-	j = ((cp[0] - 241)<<16) + (cp[1]<<8) + cp[2] + 16561;
-	cp += 3;
+        j = ((cp[0] - 241)<<16) + (cp[1]<<8) + cp[2] + 16561;
+        cp += 3;
     } else {
-	int n = *cp++ - 249 + 3;
-	while (n--)
-	    j = (j<<8) + *cp++;
+        int n = *cp++ - 249 + 3;
+        while (n--)
+            j = (j<<8) + *cp++;
     }
 
 //    fprintf(stderr, "Get32 %d (%s)\n", j, var_dump(op, cp-op));
@@ -292,16 +292,16 @@ static inline int var_get_s64(uint8_t *cp, const uint8_t *endp, int64_t *i) {
 
 static inline int var_size_u64(uint64_t v) {
     if (v < 177)
-	return 1;
+        return 1;
     else if (v < 16561)
-	return 2;
+        return 2;
     else if (v < 540849)
-	return 3;
+        return 3;
 
     int i = 0;
     do {
-	v >>= 8;
-	i++;
+        v >>= 8;
+        i++;
     } while (v);
 
 //    fprintf(stderr, "Size %ld (%d)\n", v, i+1);

--- a/tests/arith.test
+++ b/tests/arith.test
@@ -11,19 +11,19 @@ do
     cut -f 1 < $f | tr -d '\012' > $out/arith-nl
     for o in 0 1 64 65 128 129 192 193 8 9
     do
-	if [ ! -e "$comp.$o" ]
-	then
-	    continue
-	fi
+        if [ ! -e "$comp.$o" ]
+        then
+            continue
+        fi
         printf 'Testing arith_dynamic -r -o%s on %s\t' $o "$f"
 
-	# Round trip
+        # Round trip
         ./arith_dynamic -r -o$o $out/arith-nl $out/arith.comp 2>>$out/arith.stderr || exit 1
-	wc -c < $out/arith.comp
+        wc -c < $out/arith.comp
         ./arith_dynamic -r -d $out/arith.comp $out/arith.uncomp  2>>$out/arith.stderr || exit 1
         cmp $out/arith-nl $out/arith.uncomp || exit 1
 
-	# Precompressed data
+        # Precompressed data
         ./arith_dynamic -r -d $comp.$o $out/arith.uncomp  2>>$out/arith.stderr || exit 1
         cmp $out/arith-nl $out/arith.uncomp || exit 1
     done

--- a/tests/arith_dynamic_fuzz.c
+++ b/tests/arith_dynamic_fuzz.c
@@ -46,7 +46,7 @@ int LLVMFuzzerTestOneInput(uint8_t *in, size_t in_size) {
     unsigned int uncomp_size = 0;
     unsigned char *uncomp = arith_uncompress(in, in_size, &uncomp_size);
     if (uncomp)
-	free(uncomp);
+        free(uncomp);
     
     return 0;
 }
@@ -65,18 +65,18 @@ static unsigned char *load(char *fn, uint64_t *lenp) {
     int fd = open(fn, O_RDONLY);
 
     do {
-	if (dsize - dcurr < BS) {
-	    dsize = dsize ? dsize * 2 : BS;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BS) {
+            dsize = dsize ? dsize * 2 : BS;
+            data = realloc(data, dsize);
+        }
 
-	len = read(fd, data + dcurr, BS);
-	if (len > 0)
-	    dcurr += len;
+        len = read(fd, data + dcurr, BS);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("read");
+        perror("read");
     }
 
     close(fd);

--- a/tests/arith_dynamic_test.c
+++ b/tests/arith_dynamic_test.c
@@ -62,18 +62,18 @@ static unsigned char *load(FILE *infp, uint32_t *lenp) {
     signed int len;
 
     do {
-	if (dsize - dcurr < BLK_SIZE) {
-	    dsize = dsize ? dsize * 2 : BLK_SIZE;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BLK_SIZE) {
+            dsize = dsize ? dsize * 2 : BLK_SIZE;
+            data = realloc(data, dsize);
+        }
 
-	len = fread(data + dcurr, 1, BLK_SIZE, infp);
-	if (len > 0)
-	    dcurr += len;
+        len = fread(data + dcurr, 1, BLK_SIZE, infp);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("fread");
+        perror("fread");
     }
 
     *lenp = dcurr;
@@ -96,201 +96,201 @@ int main(int argc, char **argv) {
     extern int optind;
 
     while ((opt = getopt(argc, argv, "o:dtr")) != -1) {
-	switch (opt) {
-	case 'o': {
-	    char *optend;
-	    order = strtol(optarg, &optend, 0);
-	    if (*optend == '.')
-		order += atoi(optend+1)<<8;
-	    break;
-	}
+        switch (opt) {
+        case 'o': {
+            char *optend;
+            order = strtol(optarg, &optend, 0);
+            if (*optend == '.')
+                order += atoi(optend+1)<<8;
+            break;
+        }
 
-	case 'd':
-	    decode = 1;
-	    break;
-	    
-	case 't':
-	    test = 1;
-	    break;
+        case 'd':
+            decode = 1;
+            break;
+            
+        case 't':
+            test = 1;
+            break;
 
-	case 'r':
-	    raw = 1;
-	    break;
-	}
+        case 'r':
+            raw = 1;
+            break;
+        }
     }
 
     //order = order ? 1 : 0; // Only support O(0) and O(1)
 
     if (optind < argc) {
-	if (!(infp = fopen(argv[optind], "rb"))) {
-	    perror(argv[optind]);
-	    return 1;
-	}
-	optind++;
+        if (!(infp = fopen(argv[optind], "rb"))) {
+            perror(argv[optind]);
+            return 1;
+        }
+        optind++;
     }
 
     if (optind < argc) {
-	if (!(outfp = fopen(argv[optind], "wb"))) {
-	    perror(argv[optind]);
-	    return 1;
-	}
-	optind++;
+        if (!(outfp = fopen(argv[optind], "wb"))) {
+            perror(argv[optind]);
+            return 1;
+        }
+        optind++;
     }
 
     gettimeofday(&tv1, NULL);
 
     if (test) {
-	size_t len, in_sz = 0, out_sz = 0;
-	typedef struct {
-	    unsigned char *blk;
-	    uint32_t sz;
-	} blocks;
-	blocks *b = NULL, *bc = NULL, *bu = NULL;
-	int nb = 0, i;
-	
-	while ((len = fread(in_buf, 1, BLK_SIZE, infp)) != 0) {
-	    // inefficient, but it'll do for testing
-	    b = realloc(b, (nb+1)*sizeof(*b));
-	    bu = realloc(bu, (nb+1)*sizeof(*bu));
-	    bc = realloc(bc, (nb+1)*sizeof(*bc));
-	    b[nb].blk = malloc(len);
-	    b[nb].sz = len;
-	    memcpy(b[nb].blk, in_buf, len);
-	    bc[nb].sz = arith_compress_bound(BLK_SIZE, order);
-	    bc[nb].blk = malloc(bc[nb].sz);
-	    bu[nb].sz = len;
-	    bu[nb].blk = malloc(BLK_SIZE);
-	    nb++;
-	    in_sz += len;
-	}
-	fprintf(stderr, "Testing %d blocks\n", nb);
+        size_t len, in_sz = 0, out_sz = 0;
+        typedef struct {
+            unsigned char *blk;
+            uint32_t sz;
+        } blocks;
+        blocks *b = NULL, *bc = NULL, *bu = NULL;
+        int nb = 0, i;
+        
+        while ((len = fread(in_buf, 1, BLK_SIZE, infp)) != 0) {
+            // inefficient, but it'll do for testing
+            b = realloc(b, (nb+1)*sizeof(*b));
+            bu = realloc(bu, (nb+1)*sizeof(*bu));
+            bc = realloc(bc, (nb+1)*sizeof(*bc));
+            b[nb].blk = malloc(len);
+            b[nb].sz = len;
+            memcpy(b[nb].blk, in_buf, len);
+            bc[nb].sz = arith_compress_bound(BLK_SIZE, order);
+            bc[nb].blk = malloc(bc[nb].sz);
+            bu[nb].sz = len;
+            bu[nb].blk = malloc(BLK_SIZE);
+            nb++;
+            in_sz += len;
+        }
+        fprintf(stderr, "Testing %d blocks\n", nb);
 
 #ifndef NTRIALS
 #define NTRIALS 10
 #endif
-	int trials = NTRIALS;
-	while (trials--) {
-	    // Warmup
-	    for (i = 0; i < nb; i++) memset(bc[i].blk, 0, bc[i].sz);
+        int trials = NTRIALS;
+        while (trials--) {
+            // Warmup
+            for (i = 0; i < nb; i++) memset(bc[i].blk, 0, bc[i].sz);
 
-	    gettimeofday(&tv1, NULL);
+            gettimeofday(&tv1, NULL);
 
-	    out_sz = 0;
-	    for (i = 0; i < nb; i++) {
-		unsigned int csz = bc[i].sz;
-		bc[i].blk = arith_compress_to(b[i].blk, b[i].sz, bc[i].blk, &csz, order);
-		assert(csz <= bc[i].sz);
-		out_sz += 5 + csz;
-	    }
+            out_sz = 0;
+            for (i = 0; i < nb; i++) {
+                unsigned int csz = bc[i].sz;
+                bc[i].blk = arith_compress_to(b[i].blk, b[i].sz, bc[i].blk, &csz, order);
+                assert(csz <= bc[i].sz);
+                out_sz += 5 + csz;
+            }
 
-	    gettimeofday(&tv2, NULL);
-	    
-	    // Warmup
-	    for (i = 0; i < nb; i++) memset(bu[i].blk, 0, BLK_SIZE);
+            gettimeofday(&tv2, NULL);
+            
+            // Warmup
+            for (i = 0; i < nb; i++) memset(bu[i].blk, 0, BLK_SIZE);
 
-	    gettimeofday(&tv3, NULL);
+            gettimeofday(&tv3, NULL);
 
-	    for (i = 0; i < nb; i++)
-		bu[i].blk = arith_uncompress_to(bc[i].blk, bc[i].sz, bu[i].blk, &bu[i].sz);
+            for (i = 0; i < nb; i++)
+                bu[i].blk = arith_uncompress_to(bc[i].blk, bc[i].sz, bu[i].blk, &bu[i].sz);
 
-	    gettimeofday(&tv4, NULL);
+            gettimeofday(&tv4, NULL);
 
-	    for (i = 0; i < nb; i++) {
-		if (b[i].sz != bu[i].sz || memcmp(b[i].blk, bu[i].blk, b[i].sz))
-		    fprintf(stderr, "Mismatch in block %d, sz %d/%d\n", i, b[i].sz, bu[i].sz);
-		//free(bc[i].blk);
-		//free(bu[i].blk);
-	    }
+            for (i = 0; i < nb; i++) {
+                if (b[i].sz != bu[i].sz || memcmp(b[i].blk, bu[i].blk, b[i].sz))
+                    fprintf(stderr, "Mismatch in block %d, sz %d/%d\n", i, b[i].sz, bu[i].sz);
+                //free(bc[i].blk);
+                //free(bu[i].blk);
+            }
 
-	    fprintf(stderr, "%5.1f MB/s enc, %5.1f MB/s dec\t %ld bytes -> %ld bytes\n",
-		    (double)in_sz / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-				     tv2.tv_usec - tv1.tv_usec),
-		    (double)in_sz / ((long)(tv4.tv_sec - tv3.tv_sec)*1000000 +
-				     tv4.tv_usec - tv3.tv_usec),
-		    (long)in_sz, (long)out_sz);
-	}
+            fprintf(stderr, "%5.1f MB/s enc, %5.1f MB/s dec\t %ld bytes -> %ld bytes\n",
+                    (double)in_sz / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+                                     tv2.tv_usec - tv1.tv_usec),
+                    (double)in_sz / ((long)(tv4.tv_sec - tv3.tv_sec)*1000000 +
+                                     tv4.tv_usec - tv3.tv_usec),
+                    (long)in_sz, (long)out_sz);
+        }
 
-	exit(0);
-	
+        exit(0);
+        
     }
 
     if (raw) {
-	// One naked / raw block, to match the specification
-	uint32_t in_size, out_size;
-	unsigned char *in = load(infp, &in_size), *out;
-	if (!in) exit(1);
+        // One naked / raw block, to match the specification
+        uint32_t in_size, out_size;
+        unsigned char *in = load(infp, &in_size), *out;
+        if (!in) exit(1);
 
-	if (decode) {
-	    if (!(out = arith_uncompress(in, in_size, &out_size)))
-		exit(1);
+        if (decode) {
+            if (!(out = arith_uncompress(in, in_size, &out_size)))
+                exit(1);
 
-	    fwrite(out, 1, out_size, outfp);
-	    bytes = out_size;
-	} else {
-	    if (!(out = arith_compress(in, in_size, &out_size, order)))
-		exit(1);
+            fwrite(out, 1, out_size, outfp);
+            bytes = out_size;
+        } else {
+            if (!(out = arith_compress(in, in_size, &out_size, order)))
+                exit(1);
 
-	    fwrite(out, 1, out_size, outfp);
-	    bytes += in_size;
-	}
+            fwrite(out, 1, out_size, outfp);
+            bytes += in_size;
+        }
 
-	free(in);
-	free(out);
+        free(in);
+        free(out);
     } else {
-	// Block based, to permit arbitrarily large data sets.
-	if (decode) {
-	    for (;;) {
-		uint32_t in_size, out_size;
-		unsigned char *out;
+        // Block based, to permit arbitrarily large data sets.
+        if (decode) {
+            for (;;) {
+                uint32_t in_size, out_size;
+                unsigned char *out;
 
-		if (4 != fread(&in_size, 1, 4, infp))
-		    break;
-		if (in_size > BLK_SIZE)
-		    exit(1);
+                if (4 != fread(&in_size, 1, 4, infp))
+                    break;
+                if (in_size > BLK_SIZE)
+                    exit(1);
 
-		if (in_size != fread(in_buf, 1, in_size, infp)) {
-		    fprintf(stderr, "Truncated input\n");
-		    exit(1);
-		}
-		out = arith_uncompress(in_buf, in_size, &out_size);
-		if (!out)
-		    exit(1);
+                if (in_size != fread(in_buf, 1, in_size, infp)) {
+                    fprintf(stderr, "Truncated input\n");
+                    exit(1);
+                }
+                out = arith_uncompress(in_buf, in_size, &out_size);
+                if (!out)
+                    exit(1);
 
-		fwrite(out, 1, out_size, outfp);
-		fflush(outfp);
-		free(out);
+                fwrite(out, 1, out_size, outfp);
+                fflush(outfp);
+                free(out);
 
-		bytes += out_size;
-	    }
-	} else {
-	    for (;;) {
-		uint32_t in_size, out_size;
-		unsigned char *out;
+                bytes += out_size;
+            }
+        } else {
+            for (;;) {
+                uint32_t in_size, out_size;
+                unsigned char *out;
 
-		in_size = fread(in_buf, 1, BLK_SIZE, infp);
-		if (in_size <= 0)
-		    break;
+                in_size = fread(in_buf, 1, BLK_SIZE, infp);
+                if (in_size <= 0)
+                    break;
 
-		if (in_size < 4)
-		    order &= ~1;
+                if (in_size < 4)
+                    order &= ~1;
 
-		out = arith_compress(in_buf, in_size, &out_size, order);
+                out = arith_compress(in_buf, in_size, &out_size, order);
 
-		fwrite(&out_size, 1, 4, outfp);
-		fwrite(out, 1, out_size, outfp);
-		free(out);
+                fwrite(&out_size, 1, 4, outfp);
+                fwrite(out, 1, out_size, outfp);
+                free(out);
 
-		bytes += in_size;
-	    }
-	}
+                bytes += in_size;
+            }
+        }
     }
 
     gettimeofday(&tv2, NULL);
 
     fprintf(stderr, "Took %ld microseconds, %5.1f MB/s\n",
-	    (long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-	    tv2.tv_usec - tv1.tv_usec,
-	    (double)bytes / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-			     tv2.tv_usec - tv1.tv_usec));
+            (long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+            tv2.tv_usec - tv1.tv_usec,
+            (double)bytes / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+                             tv2.tv_usec - tv1.tv_usec));
     return 0;
 }

--- a/tests/fqzcomp.test
+++ b/tests/fqzcomp.test
@@ -13,13 +13,13 @@ do
     do
         printf 'Testing fqzcomp_qual -r -s %s on %s\t' $s "$f"
 
-	# Round trip
+        # Round trip
         ./fqzcomp_qual -r -s $s $out/fqz > $out/fqz.comp 2>>$out/fqz.stderr || exit 1
-	wc -c < $out/fqz.comp
+        wc -c < $out/fqz.comp
         ./fqzcomp_qual -r -d $out/fqz.comp > $out/fqz.uncomp  2>>$out/fqz.stderr || exit 1
         cmp $out/fqz $out/fqz.uncomp || exit 1
 
-	# Precompressed data
+        # Precompressed data
         ./fqzcomp_qual -r -d $comp.$s > $out/fqz.uncomp  2>>$out/fqz.stderr || exit 1
         cmp $out/fqz $out/fqz.uncomp || exit 1
     done

--- a/tests/fqzcomp_qual_fuzz.c
+++ b/tests/fqzcomp_qual_fuzz.c
@@ -47,7 +47,7 @@ int LLVMFuzzerTestOneInput(uint8_t *in, size_t in_size) {
     size_t uncomp_size;
     char *uncomp = fqz_decompress((char *)in, in_size, &uncomp_size, NULL, 0);
     if (uncomp)
-	free(uncomp);
+        free(uncomp);
     
     return 0;
 }
@@ -66,23 +66,23 @@ static unsigned char *load(char *fn, uint64_t *lenp) {
 
     int fd = open(fn, O_RDONLY);
     if (!fd) {
-	perror(fn);
-	return NULL;
+        perror(fn);
+        return NULL;
     }
 
     do {
-	if (dsize - dcurr < BS) {
-	    dsize = dsize ? dsize * 2 : BS;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BS) {
+            dsize = dsize ? dsize * 2 : BS;
+            data = realloc(data, dsize);
+        }
 
-	len = read(fd, data + dcurr, BS);
-	if (len > 0)
-	    dcurr += len;
+        len = read(fd, data + dcurr, BS);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("read");
+        perror("read");
     }
     close(fd);
 

--- a/tests/fqzcomp_qual_test.c
+++ b/tests/fqzcomp_qual_test.c
@@ -65,14 +65,14 @@ fqz_slice *fake_slice(size_t buf_len, int *len, int *r2, int *sel, int nlen) {
     assert(fixed_slice.num_records <= MAX_REC);
     int i;
     if (!fixed_slice.len)
-	fixed_slice.len = malloc(MAX_REC * sizeof(*fixed_slice.len));
+        fixed_slice.len = malloc(MAX_REC * sizeof(*fixed_slice.len));
     if (!fixed_slice.flags)
-	fixed_slice.flags = malloc(MAX_REC * sizeof(*fixed_slice.flags));
+        fixed_slice.flags = malloc(MAX_REC * sizeof(*fixed_slice.flags));
     for (i = 0; i < fixed_slice.num_records; i++) {
-	int idx = i < nlen ? i : nlen-1;
-	fixed_slice.len[i] = len[idx];
-	fixed_slice.flags[i] = r2 ? r2[idx]*FQZ_FREAD2 : 0;
-	fixed_slice.flags[i] |= sel ? (sel[idx]<<16) : 0;
+        int idx = i < nlen ? i : nlen-1;
+        fixed_slice.len[i] = len[idx];
+        fixed_slice.flags[i] = r2 ? r2[idx]*FQZ_FREAD2 : 0;
+        fixed_slice.flags[i] |= sel ? (sel[idx]<<16) : 0;
     }
 
     return &fixed_slice;
@@ -86,22 +86,22 @@ static int manual_nstrat = 0;
  */
 static inline
 int fqz_manual_parameters(fqz_gparams *gp,
-			  fqz_slice *s,
-			  unsigned char *in,
-			  size_t in_size) {
+                          fqz_slice *s,
+                          unsigned char *in,
+                          size_t in_size) {
     int i, p;
     int dsqr[] = {
-	0, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3,
-	4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5,
-	5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
-	6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7
+        0, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3,
+        4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5,
+        5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+        6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7
     };
 
     gp->vers = FQZ_VERS;
     gp->nparam = manual_nstrat;
     gp->gflags = GFLAG_MULTI_PARAM | GFLAG_HAVE_STAB;
     for (i = 0; i < 256; i++)
-	gp->stab[i] = 0;
+        gp->stab[i] = 0;
 
     // Fill these out later
     gp->max_sel = 0;
@@ -109,111 +109,111 @@ int fqz_manual_parameters(fqz_gparams *gp,
     gp->p = malloc(gp->nparam * sizeof(*gp->p));
 
     for (p = 0; p < gp->nparam; p++) {
-	fqz_param *pm = &gp->p[p];
-	uint64_t st = manual_strats[p];
+        fqz_param *pm = &gp->p[p];
+        uint64_t st = manual_strats[p];
 
-	pm->do_qa  = st & 15; st >>= 4;
-	pm->do_r2  = st & 15; st >>= 4;
-	pm->dloc   = st & 15; st >>= 4;
-	pm->ploc   = st & 15; st >>= 4;
-	pm->sloc   = st & 15; st >>= 4;
-	pm->qloc   = st & 15; st >>= 4;
-	pm->dshift = st & 15; st >>= 4;
-	pm->dbits  = st & 15; st >>= 4;
-	pm->pshift = st & 15; st >>= 4;
-	pm->pbits  = st & 15; st >>= 4;
-	pm->qshift = st & 15; st >>= 4;
-	pm->qbits  = st & 15; st >>= 4;
+        pm->do_qa  = st & 15; st >>= 4;
+        pm->do_r2  = st & 15; st >>= 4;
+        pm->dloc   = st & 15; st >>= 4;
+        pm->ploc   = st & 15; st >>= 4;
+        pm->sloc   = st & 15; st >>= 4;
+        pm->qloc   = st & 15; st >>= 4;
+        pm->dshift = st & 15; st >>= 4;
+        pm->dbits  = st & 15; st >>= 4;
+        pm->pshift = st & 15; st >>= 4;
+        pm->pbits  = st & 15; st >>= 4;
+        pm->qshift = st & 15; st >>= 4;
+        pm->qbits  = st & 15; st >>= 4;
 
-	// Gather some stats, as per qual_stats func.
-	// r in rec count.
-	// i = index to in[]
-	// j = index within this rec
-	uint32_t qhist[256] = {0};
+        // Gather some stats, as per qual_stats func.
+        // r in rec count.
+        // i = index to in[]
+        // j = index within this rec
+        uint32_t qhist[256] = {0};
 
-	// qual stats for seqs using this parameter only
-	fqz_qual_stats(s, in, in_size, pm, qhist, p);
-	int max_sel = pm->max_sel;
+        // qual stats for seqs using this parameter only
+        fqz_qual_stats(s, in, in_size, pm, qhist, p);
+        int max_sel = pm->max_sel;
 
-	// Update max_sel running total. Eg with 4 sub-params:
-	//
-	// sel    param no.   => new
-	// 0      0              0
-	// 0/1    1              1,2
-	// 0/1    2              3,4
-	// 0      3              5
-	for (i = gp->max_sel; i < gp->max_sel + max_sel+1; i++)
-	    gp->stab[i] = p;
-	gp->max_sel += max_sel+1;
+        // Update max_sel running total. Eg with 4 sub-params:
+        //
+        // sel    param no.   => new
+        // 0      0              0
+        // 0/1    1              1,2
+        // 0/1    2              3,4
+        // 0      3              5
+        for (i = gp->max_sel; i < gp->max_sel + max_sel+1; i++)
+            gp->stab[i] = p;
+        gp->max_sel += max_sel+1;
 
-	pm->fixed_len = pm->fixed_len > 0;
-	pm->use_qtab = 0;  // unused by current encoder
-	pm->store_qmap = pm->nsym <= 8;
+        pm->fixed_len = pm->fixed_len > 0;
+        pm->use_qtab = 0;  // unused by current encoder
+        pm->store_qmap = pm->nsym <= 8;
 
-	// Adjust parameters based on quality stats.
-	// FIXME:  dup from fqz_pick_parameters.
-	for (i = 0; i < sizeof(dsqr)/sizeof(*dsqr); i++)
-	    if (dsqr[i] > (1<<pm->dbits)-1)
-		dsqr[i] = (1<<pm->dbits)-1;
+        // Adjust parameters based on quality stats.
+        // FIXME:  dup from fqz_pick_parameters.
+        for (i = 0; i < sizeof(dsqr)/sizeof(*dsqr); i++)
+            if (dsqr[i] > (1<<pm->dbits)-1)
+                dsqr[i] = (1<<pm->dbits)-1;
 
-	if (pm->store_qmap) {
-	    int j;
-	    for (i = j = 0; i < 256; i++)
-		if (qhist[i])
-		    pm->qmap[i] = j++;
-		else
-		    pm->qmap[i] = INT_MAX;
-	    pm->max_sym = pm->nsym;
-	} else {
-	    pm->nsym = 255;
-	    for (i = 0; i < 256; i++)
-		pm->qmap[i] = i;
-	}
-	if (gp->max_sym < pm->max_sym)
-	    gp->max_sym = pm->max_sym;
+        if (pm->store_qmap) {
+            int j;
+            for (i = j = 0; i < 256; i++)
+                if (qhist[i])
+                    pm->qmap[i] = j++;
+                else
+                    pm->qmap[i] = INT_MAX;
+            pm->max_sym = pm->nsym;
+        } else {
+            pm->nsym = 255;
+            for (i = 0; i < 256; i++)
+                pm->qmap[i] = i;
+        }
+        if (gp->max_sym < pm->max_sym)
+            gp->max_sym = pm->max_sym;
 
-	// Produce ptab from pshift.
-	if (pm->qbits) {
-	    for (i = 0; i < 256; i++) {
-		pm->qtab[i] = i; // 1:1
+        // Produce ptab from pshift.
+        if (pm->qbits) {
+            for (i = 0; i < 256; i++) {
+                pm->qtab[i] = i; // 1:1
 
-		// Alternative mappings:
-		//qtab[i] = i > 30 ? MIN(max_sym,i)-15 : i/2;  // eg for 9827 BAM
-	    }
+                // Alternative mappings:
+                //qtab[i] = i > 30 ? MIN(max_sym,i)-15 : i/2;  // eg for 9827 BAM
+            }
 
-	}
-	pm->qmask = (1<<pm->qbits)-1;
+        }
+        pm->qmask = (1<<pm->qbits)-1;
 
-	if (pm->pbits) {
-	    for (i = 0; i < 1024; i++)
-		pm->ptab[i] = MIN((1<<pm->pbits)-1, i>>pm->pshift);
+        if (pm->pbits) {
+            for (i = 0; i < 1024; i++)
+                pm->ptab[i] = MIN((1<<pm->pbits)-1, i>>pm->pshift);
 
-	    // Alternatively via analysis of quality distributions we
-	    // may select a bunch of positions that are special and
-	    // have a non-uniform ptab[].
-	    // Manual experimentation on a NovaSeq run saved 2.8% here.
-	}
+            // Alternatively via analysis of quality distributions we
+            // may select a bunch of positions that are special and
+            // have a non-uniform ptab[].
+            // Manual experimentation on a NovaSeq run saved 2.8% here.
+        }
 
-	if (pm->dbits) {
-	    for (i = 0; i < 256; i++)
-		pm->dtab[i] = dsqr[MIN(sizeof(dsqr)/sizeof(*dsqr)-1, i>>pm->dshift)];
-	}
+        if (pm->dbits) {
+            for (i = 0; i < 256; i++)
+                pm->dtab[i] = dsqr[MIN(sizeof(dsqr)/sizeof(*dsqr)-1, i>>pm->dshift)];
+        }
 
-	pm->use_ptab = (pm->pbits > 0);
-	pm->use_dtab = (pm->dbits > 0);
+        pm->use_ptab = (pm->pbits > 0);
+        pm->use_dtab = (pm->dbits > 0);
 
-	pm->pflags =
-	    (pm->use_qtab   ?PFLAG_HAVE_QTAB :0)|
-	    (pm->use_dtab   ?PFLAG_HAVE_DTAB :0)|
-	    (pm->use_ptab   ?PFLAG_HAVE_PTAB :0)|
-	    (pm->do_sel     ?PFLAG_DO_SEL    :0)|
-	    (pm->fixed_len  ?PFLAG_DO_LEN    :0)|
-	    (pm->do_dedup   ?PFLAG_DO_DEDUP  :0)|
-	    (pm->store_qmap ?PFLAG_HAVE_QMAP :0);
+        pm->pflags =
+            (pm->use_qtab   ?PFLAG_HAVE_QTAB :0)|
+            (pm->use_dtab   ?PFLAG_HAVE_DTAB :0)|
+            (pm->use_ptab   ?PFLAG_HAVE_PTAB :0)|
+            (pm->do_sel     ?PFLAG_DO_SEL    :0)|
+            (pm->fixed_len  ?PFLAG_DO_LEN    :0)|
+            (pm->do_dedup   ?PFLAG_DO_DEDUP  :0)|
+            (pm->store_qmap ?PFLAG_HAVE_QMAP :0);
     }
 
     for (i = gp->max_sel; i < 256; i++)
-	gp->stab[i] = gp->stab[gp->max_sel-1];
+        gp->stab[i] = gp->stab[gp->max_sel-1];
 
     return 0;
 }
@@ -233,23 +233,23 @@ static unsigned char *load(char *fn, size_t *lenp) {
 
     int fd = open(fn, O_RDONLY | _O_BINARY);
     if (!fd) {
-	perror(fn);
-	return NULL;
+        perror(fn);
+        return NULL;
     }
 
     do {
-	if (dsize - dcurr < BS) {
-	    dsize = dsize ? dsize * 2 : BS;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BS) {
+            dsize = dsize ? dsize * 2 : BS;
+            data = realloc(data, dsize);
+        }
 
-	len = read(fd, data + dcurr, BS);
-	if (len > 0)
-	    dcurr += len;
+        len = read(fd, data + dcurr, BS);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("read");
+        perror("read");
     }
     close(fd);
 
@@ -265,51 +265,51 @@ int count_lines(unsigned char *in, size_t len) {
     int lines = 0;
 
     for (i = 0; i < len; i++)
-	if (in[i] == '\n')
-	    lines++;
+        if (in[i] == '\n')
+            lines++;
 
     return lines;
 }
 
 // QUAL [is_read2 [selector]]
 void parse_lines(unsigned char *in, size_t len,
-		 int *rec_len, int *rec_r2, int *rec_sel, size_t *new_len) {
+                 int *rec_len, int *rec_r2, int *rec_sel, size_t *new_len) {
     size_t i, j, start;
     int rec = 0;
 
     for (start = i = j = 0; i < len; i++) {
-	if (in[i] == '\n' || in[i] == ' ' || in[i] == '\t') {
-	    rec_len[rec] = i-start;
+        if (in[i] == '\n' || in[i] == ' ' || in[i] == '\t') {
+            rec_len[rec] = i-start;
 
-	    // Read2 marker
-	    while (i < len && in[i] != '\n' && isspace(in[i]))
-		i++;
+            // Read2 marker
+            while (i < len && in[i] != '\n' && isspace(in[i]))
+                i++;
 
-	    if (in[i] != '\n')
-		rec_r2[rec] = atoi((char *)&in[i]);
-	    else
-		rec_r2[rec] = 0;
+            if (in[i] != '\n')
+                rec_r2[rec] = atoi((char *)&in[i]);
+            else
+                rec_r2[rec] = 0;
 
-	    while (i < len && !isspace(in[i]))
-		i++;
+            while (i < len && !isspace(in[i]))
+                i++;
 
-	    // selector
-	    while (i < len && in[i] != '\n' && isspace(in[i]))
-		i++;
+            // selector
+            while (i < len && in[i] != '\n' && isspace(in[i]))
+                i++;
 
-	    if (in[i] != '\n')
-		rec_sel[rec] = atoi((char *)&in[i]);
-	    else
-		rec_sel[rec] = 0;
+            if (in[i] != '\n')
+                rec_sel[rec] = atoi((char *)&in[i]);
+            else
+                rec_sel[rec] = 0;
 
-	    while (i < len && in[i] != '\n')
-		i++;
+            while (i < len && in[i] != '\n')
+                i++;
 
-	    start = i+1;
-	    rec++;
-	} else {
-	    in[j++] = in[i]-33; // ASCII phred to qual
-	}
+            start = i+1;
+            rec++;
+        } else {
+            in[j++] = in[i]-33; // ASCII phred to qual
+        }
     }
     *new_len = j;
 }
@@ -332,135 +332,135 @@ int main(int argc, char **argv) {
     int opt;
 
     while ((opt = getopt(argc, argv, "ds:s:b:rx:")) != -1) {
-	switch (opt) {
-	case 'd':
-	    decomp = 1;
-	    break;
+        switch (opt) {
+        case 'd':
+            decomp = 1;
+            break;
 
-	case 'b':
-	    blk_size = atoi(optarg);
-	    if (blk_size > BLK_SIZE)
-		blk_size = BLK_SIZE;
-	    break;
+        case 'b':
+            blk_size = atoi(optarg);
+            if (blk_size > BLK_SIZE)
+                blk_size = BLK_SIZE;
+            break;
 
-	case 's':
-	    strat = atoi(optarg);
-	    break;
+        case 's':
+            strat = atoi(optarg);
+            break;
 
-	case 'x': {
-	    // Hex digits are:
-	    // qbits  qshift
-	    // pbits  pshift
-	    // dbits  dshift
-	    // qloc   sloc
-	    // ploc   dloc
-	    // do_r2  do_qavg
-	    //
-	    // Examples: -x 0x5570000d6e14 q40+dir =  3473340
-	    //           -x 0x8252120e8d04 q4      =  724989
-	    uint64_t x = strtol(optarg, NULL, 0);
-	    manual_strats[manual_nstrat++] = x;
+        case 'x': {
+            // Hex digits are:
+            // qbits  qshift
+            // pbits  pshift
+            // dbits  dshift
+            // qloc   sloc
+            // ploc   dloc
+            // do_r2  do_qavg
+            //
+            // Examples: -x 0x5570000d6e14 q40+dir =  3473340
+            //           -x 0x8252120e8d04 q4      =  724989
+            uint64_t x = strtol(optarg, NULL, 0);
+            manual_strats[manual_nstrat++] = x;
 
-	    gp = &gp_local;
-	    break;
-	}
-	case 'r':
-	    raw = 1;
-	    break;
-	}
+            gp = &gp_local;
+            break;
+        }
+        case 'r':
+            raw = 1;
+            break;
+        }
     }
 
     in = load(optind < argc ? argv[optind] : "/dev/stdin", &in_len);
     if (!in)
-	exit(1);
+        exit(1);
 
     if (raw)
-	blk_size = in_len;
+        blk_size = in_len;
 
     // Block based, for arbitrary sizes of input
     if (decomp) {
-	unsigned char *in2 = in;
-	while (in_len > 0) {
-	    // Read sizes as 32-bit
-	    size_t in2_len, out_len;
-	    if (raw) {
-		uint32_t u32;
-		var_get_u32(in2, in2+in_len, &u32);
-		out_len = u32;
-		in2_len = in_len;
-	    } else {
-		out_len = *(uint32_t *)in2;  in2 += 4;
-		in2_len = *(uint32_t *)in2;  in2 += 4;
-	    }
+        unsigned char *in2 = in;
+        while (in_len > 0) {
+            // Read sizes as 32-bit
+            size_t in2_len, out_len;
+            if (raw) {
+                uint32_t u32;
+                var_get_u32(in2, in2+in_len, &u32);
+                out_len = u32;
+                in2_len = in_len;
+            } else {
+                out_len = *(uint32_t *)in2;  in2 += 4;
+                in2_len = *(uint32_t *)in2;  in2 += 4;
+            }
 
-	    fprintf(stderr, "out_len %ld, in_len %ld\n", (long)out_len, (long)in2_len);
+            fprintf(stderr, "out_len %ld, in_len %ld\n", (long)out_len, (long)in2_len);
 
-	    int *lengths = malloc(MAX_REC * sizeof(int));
-	    out = (unsigned char *)fqz_decompress((char *)in2, in_len-(raw?0:8), &out_len, lengths, MAX_REC);
-	    if (!out) {
-		fprintf(stderr, "Failed to decompress\n");
-		return 1;
-	    }
+            int *lengths = malloc(MAX_REC * sizeof(int));
+            out = (unsigned char *)fqz_decompress((char *)in2, in_len-(raw?0:8), &out_len, lengths, MAX_REC);
+            if (!out) {
+                fprintf(stderr, "Failed to decompress\n");
+                return 1;
+            }
 
-	    // Convert from binary back to ASCII with newlines
-	    int i = 0, j = 0;
-	    while (j < out_len) {
-		int k;
-		char seq[MAX_SEQ];
-		for (k = 0; k < lengths[i]; k++)
-		    seq[k] = out[j+k]+33;
-		seq[k] = 0;
-		puts(seq);
-		j += lengths[i++];
-	    }
-	    free(out);
-	    in2 += in2_len;
-	    in_len -= in2_len+(raw?0:8);
+            // Convert from binary back to ASCII with newlines
+            int i = 0, j = 0;
+            while (j < out_len) {
+                int k;
+                char seq[MAX_SEQ];
+                for (k = 0; k < lengths[i]; k++)
+                    seq[k] = out[j+k]+33;
+                seq[k] = 0;
+                puts(seq);
+                j += lengths[i++];
+            }
+            free(out);
+            in2 += in2_len;
+            in_len -= in2_len+(raw?0:8);
 
-	    free(lengths);
+            free(lengths);
 
-	    break; // One cycle only until we fix blocking to be \n based
-	}
+            break; // One cycle only until we fix blocking to be \n based
+        }
     } else {
-	// Convert from ASCII newline separated file to binary block.
-	// We return an array of line lengths and optionally param selectors.
-	int nlines = count_lines(in, in_len);
-	fprintf(stderr, "nlines=%d\n", nlines);
-	int *rec_len = calloc(nlines, sizeof(*rec_len));
-	int *rec_r2  = calloc(nlines, sizeof(*rec_r2));
-	int *rec_sel = calloc(nlines, sizeof(*rec_sel));
-	parse_lines(in, in_len, rec_len, rec_r2, rec_sel, &in_len);
+        // Convert from ASCII newline separated file to binary block.
+        // We return an array of line lengths and optionally param selectors.
+        int nlines = count_lines(in, in_len);
+        fprintf(stderr, "nlines=%d\n", nlines);
+        int *rec_len = calloc(nlines, sizeof(*rec_len));
+        int *rec_r2  = calloc(nlines, sizeof(*rec_r2));
+        int *rec_sel = calloc(nlines, sizeof(*rec_sel));
+        parse_lines(in, in_len, rec_len, rec_r2, rec_sel, &in_len);
 
-	unsigned char *in2 = in;
-	long t_out = 0;
-	out = NULL;
-	while (in_len > 0) {
-	    // FIXME: blk_size no longer working in test.  One cycle only!
-	    size_t in2_len = in_len <= blk_size ? in_len : blk_size;
-	    fqz_slice *s = fake_slice(in2_len, rec_len, rec_r2, rec_sel, nlines);
-	    if (gp == &gp_local)
-		if (fqz_manual_parameters(gp, s, in2, in2_len) < 0)
-		    return 1;
-	    out = (unsigned char *)fqz_compress(vers, s, (char *)in2, in2_len, &out_len, strat, gp);
+        unsigned char *in2 = in;
+        long t_out = 0;
+        out = NULL;
+        while (in_len > 0) {
+            // FIXME: blk_size no longer working in test.  One cycle only!
+            size_t in2_len = in_len <= blk_size ? in_len : blk_size;
+            fqz_slice *s = fake_slice(in2_len, rec_len, rec_r2, rec_sel, nlines);
+            if (gp == &gp_local)
+                if (fqz_manual_parameters(gp, s, in2, in2_len) < 0)
+                    return 1;
+            out = (unsigned char *)fqz_compress(vers, s, (char *)in2, in2_len, &out_len, strat, gp);
 
-	    // Write out 32-bit sizes.
-	    if (!raw) {
-		uint32_t u32;
-		u32 = in2_len; if (write(1, &u32, 4) != 4) return 1;
-		u32 = out_len; if (write(1, &u32, 4) != 4) return 1;
-	    }
-	    if (write(1, out, out_len) < 0) return 1;
-	    in_len -= in2_len;
-	    in2 += in2_len;
-	    t_out += out_len + (raw?0:8);
+            // Write out 32-bit sizes.
+            if (!raw) {
+                uint32_t u32;
+                u32 = in2_len; if (write(1, &u32, 4) != 4) return 1;
+                u32 = out_len; if (write(1, &u32, 4) != 4) return 1;
+            }
+            if (write(1, out, out_len) < 0) return 1;
+            in_len -= in2_len;
+            in2 += in2_len;
+            t_out += out_len + (raw?0:8);
 
-	    break; // One cycle only until we fix blocking to be \n based
-	}
-	free(out);
-	free(rec_len);
-	free(rec_r2);
-	free(rec_sel);
-	fprintf(stderr, "Total output = %ld\n", t_out);
+            break; // One cycle only until we fix blocking to be \n based
+        }
+        free(out);
+        free(rec_len);
+        free(rec_r2);
+        free(rec_sel);
+        fprintf(stderr, "Total output = %ld\n", t_out);
     }
 
     free(in);

--- a/tests/rANS_static4x16pr_fuzz.c
+++ b/tests/rANS_static4x16pr_fuzz.c
@@ -106,18 +106,18 @@ static unsigned char *load(char *fn, uint64_t *lenp) {
     int fd = open(fn, O_RDONLY);
 
     do {
-	if (dsize - dcurr < BS) {
-	    dsize = dsize ? dsize * 2 : BS;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BS) {
+            dsize = dsize ? dsize * 2 : BS;
+            data = realloc(data, dsize);
+        }
 
-	len = read(fd, data + dcurr, BS);
-	if (len > 0)
-	    dcurr += len;
+        len = read(fd, data + dcurr, BS);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("read");
+        perror("read");
     }
 
     close(fd);

--- a/tests/rANS_static4x16pr_test.c
+++ b/tests/rANS_static4x16pr_test.c
@@ -62,18 +62,18 @@ static unsigned char *load(FILE *infp, uint32_t *lenp) {
     signed int len;
 
     do {
-	if (dsize - dcurr < BLK_SIZE) {
-	    dsize = dsize ? dsize * 2 : BLK_SIZE;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BLK_SIZE) {
+            dsize = dsize ? dsize * 2 : BLK_SIZE;
+            data = realloc(data, dsize);
+        }
 
-	len = fread(data + dcurr, 1, BLK_SIZE, infp);
-	if (len > 0)
-	    dcurr += len;
+        len = fread(data + dcurr, 1, BLK_SIZE, infp);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("fread");
+        perror("fread");
     }
 
     *lenp = dcurr;
@@ -99,236 +99,236 @@ int main(int argc, char **argv) {
     extern void rans_disable_avx2(void);
 
     while ((opt = getopt(argc, argv, "o:dtrc:")) != -1) {
-	switch (opt) {
-	case 'o': {
-	    char *optend;
-	    order = strtol(optarg, &optend, 0);
-	    // 8.2 means 2-way stripe
-	    if (*optend == '.')
-		order += atoi(optend+1)<<8;
-	    break;
-	}
+        switch (opt) {
+        case 'o': {
+            char *optend;
+            order = strtol(optarg, &optend, 0);
+            // 8.2 means 2-way stripe
+            if (*optend == '.')
+                order += atoi(optend+1)<<8;
+            break;
+        }
 
-	case 'c':
-	    rans_set_cpu(strtol(optarg, NULL, 0));
-	    break;
+        case 'c':
+            rans_set_cpu(strtol(optarg, NULL, 0));
+            break;
 
-	case 'd':
-	    decode = 1;
-	    break;
-	    
-	case 't':
-	    test = 1;
-	    break;
+        case 'd':
+            decode = 1;
+            break;
+            
+        case 't':
+            test = 1;
+            break;
 
-	case 'r':
-	    raw = 1;
-	    break;
-	}
+        case 'r':
+            raw = 1;
+            break;
+        }
     }
 
     if (optind < argc) {
-	if (!(infp = fopen(argv[optind], "rb"))) {
-	    perror(argv[optind]);
-	    return 1;
-	}
-	optind++;
+        if (!(infp = fopen(argv[optind], "rb"))) {
+            perror(argv[optind]);
+            return 1;
+        }
+        optind++;
     }
 
     if (optind < argc) {
-	if (!(outfp = fopen(argv[optind], "wb"))) {
-	    perror(argv[optind]);
-	    return 1;
-	}
-	optind++;
+        if (!(outfp = fopen(argv[optind], "wb"))) {
+            perror(argv[optind]);
+            return 1;
+        }
+        optind++;
     }
 
     gettimeofday(&tv1, NULL);
 
     if (test) {
-	size_t len, in_sz = 0, out_sz = 0;
-	typedef struct {
-	    unsigned char *blk;
-	    uint32_t sz;
-	} blocks;
-	blocks *b = NULL, *bc = NULL, *bu = NULL;
-	int nb = 0, i;
+        size_t len, in_sz = 0, out_sz = 0;
+        typedef struct {
+            unsigned char *blk;
+            uint32_t sz;
+        } blocks;
+        blocks *b = NULL, *bc = NULL, *bu = NULL;
+        int nb = 0, i;
 
-	uint32_t blk_size = BLK_SIZE;
-	if (raw) {
-	    b = malloc(sizeof(*b));
-	    bu = malloc(sizeof(*bu));
-	    bc = malloc(sizeof(*bc));
-	    b[0].blk = load(infp, &blk_size);
+        uint32_t blk_size = BLK_SIZE;
+        if (raw) {
+            b = malloc(sizeof(*b));
+            bu = malloc(sizeof(*bu));
+            bc = malloc(sizeof(*bc));
+            b[0].blk = load(infp, &blk_size);
 
-	    // Deliberately realloc down to in_size so we can use address
-	    // sanitizer to check for input buffer overruns.
-	    b[0].blk = realloc(b[0].blk, blk_size);
+            // Deliberately realloc down to in_size so we can use address
+            // sanitizer to check for input buffer overruns.
+            b[0].blk = realloc(b[0].blk, blk_size);
 
-	    b[0].sz = blk_size;
-	    bc[0].sz = rans_compress_bound_4x16(blk_size, order);
-	    bc[0].blk = malloc(bc[0].sz);
-	    bu[0].sz = blk_size;
-	    bu[0].blk = malloc(blk_size);
-	    nb = 1;
-	    in_sz = blk_size;
-	} else {
-	    while ((len = fread(in_buf, 1, blk_size, infp)) != 0) {
-		// inefficient, but it'll do for testing
-		b = realloc(b, (nb+1)*sizeof(*b));
-		bu = realloc(bu, (nb+1)*sizeof(*bu));
-		bc = realloc(bc, (nb+1)*sizeof(*bc));
-		b[nb].blk = malloc(len);
-		b[nb].sz = len;
-		memcpy(b[nb].blk, in_buf, len);
-		bc[nb].sz = rans_compress_bound_4x16(blk_size, order);
-		bc[nb].blk = malloc(bc[nb].sz);
-		bu[nb].sz = len;
-		bu[nb].blk = malloc(blk_size);
-		nb++;
-		in_sz += len;
-	    }
-	}
-	fprintf(stderr, "Testing %d blocks\n", nb);
+            b[0].sz = blk_size;
+            bc[0].sz = rans_compress_bound_4x16(blk_size, order);
+            bc[0].blk = malloc(bc[0].sz);
+            bu[0].sz = blk_size;
+            bu[0].blk = malloc(blk_size);
+            nb = 1;
+            in_sz = blk_size;
+        } else {
+            while ((len = fread(in_buf, 1, blk_size, infp)) != 0) {
+                // inefficient, but it'll do for testing
+                b = realloc(b, (nb+1)*sizeof(*b));
+                bu = realloc(bu, (nb+1)*sizeof(*bu));
+                bc = realloc(bc, (nb+1)*sizeof(*bc));
+                b[nb].blk = malloc(len);
+                b[nb].sz = len;
+                memcpy(b[nb].blk, in_buf, len);
+                bc[nb].sz = rans_compress_bound_4x16(blk_size, order);
+                bc[nb].blk = malloc(bc[nb].sz);
+                bu[nb].sz = len;
+                bu[nb].blk = malloc(blk_size);
+                nb++;
+                in_sz += len;
+            }
+        }
+        fprintf(stderr, "Testing %d blocks\n", nb);
 
 #ifndef NTRIALS
 #define NTRIALS 10
 #endif
-	int trials = NTRIALS;
-	while (trials--) {
-	    // Warmup
-	    for (i = 0; i < nb; i++) memset(bc[i].blk, 0, bc[i].sz);
+        int trials = NTRIALS;
+        while (trials--) {
+            // Warmup
+            for (i = 0; i < nb; i++) memset(bc[i].blk, 0, bc[i].sz);
 
-	    gettimeofday(&tv1, NULL);
+            gettimeofday(&tv1, NULL);
 
-	    out_sz = 0;
-	    for (i = 0; i < nb; i++) {
-		unsigned int csz = bc[i].sz;
-		bc[i].blk = rans_compress_to_4x16(b[i].blk, b[i].sz, bc[i].blk, &csz, order);
-		assert(csz <= bc[i].sz);
-		out_sz += 5 + csz;
-	    }
+            out_sz = 0;
+            for (i = 0; i < nb; i++) {
+                unsigned int csz = bc[i].sz;
+                bc[i].blk = rans_compress_to_4x16(b[i].blk, b[i].sz, bc[i].blk, &csz, order);
+                assert(csz <= bc[i].sz);
+                out_sz += 5 + csz;
+            }
 
-	    gettimeofday(&tv2, NULL);
-	    
-	    // Warmup
-	    for (i = 0; i < nb; i++) memset(bu[i].blk, 0, blk_size);
+            gettimeofday(&tv2, NULL);
+            
+            // Warmup
+            for (i = 0; i < nb; i++) memset(bu[i].blk, 0, blk_size);
 
-	    gettimeofday(&tv3, NULL);
+            gettimeofday(&tv3, NULL);
 
-	    for (i = 0; i < nb; i++)
-		bu[i].blk = rans_uncompress_to_4x16(bc[i].blk, bc[i].sz, bu[i].blk, &bu[i].sz);
+            for (i = 0; i < nb; i++)
+                bu[i].blk = rans_uncompress_to_4x16(bc[i].blk, bc[i].sz, bu[i].blk, &bu[i].sz);
 
-	    gettimeofday(&tv4, NULL);
+            gettimeofday(&tv4, NULL);
 
-	    for (i = 0; i < nb; i++) {
-		if (b[i].sz != bu[i].sz || memcmp(b[i].blk, bu[i].blk, b[i].sz)) {
-		    int z;
-		    for (z = 0; z < b[i].sz; z++)
-			if (b[i].blk[z] != bu[i].blk[z])
-			    break;
-		    fprintf(stderr, "Mismatch in block %d, sz %d/%d, pos %d, got %d wanted %d\n", i, b[i].sz, bu[i].sz, z, b[i].blk[z], bu[i].blk[z]);
-		}
-		//free(bc[i].blk);
-		//free(bu[i].blk);
-	    }
+            for (i = 0; i < nb; i++) {
+                if (b[i].sz != bu[i].sz || memcmp(b[i].blk, bu[i].blk, b[i].sz)) {
+                    int z;
+                    for (z = 0; z < b[i].sz; z++)
+                        if (b[i].blk[z] != bu[i].blk[z])
+                            break;
+                    fprintf(stderr, "Mismatch in block %d, sz %d/%d, pos %d, got %d wanted %d\n", i, b[i].sz, bu[i].sz, z, b[i].blk[z], bu[i].blk[z]);
+                }
+                //free(bc[i].blk);
+                //free(bu[i].blk);
+            }
 
-	    fprintf(stderr, "%5.1f MB/s enc, %5.1f MB/s dec\t %ld bytes -> %ld bytes\n",
-		    (double)in_sz / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-				     tv2.tv_usec - tv1.tv_usec),
-		    (double)in_sz / ((long)(tv4.tv_sec - tv3.tv_sec)*1000000 +
-				     tv4.tv_usec - tv3.tv_usec),
-		    (long)in_sz, (long)out_sz);
-	}
+            fprintf(stderr, "%5.1f MB/s enc, %5.1f MB/s dec\t %ld bytes -> %ld bytes\n",
+                    (double)in_sz / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+                                     tv2.tv_usec - tv1.tv_usec),
+                    (double)in_sz / ((long)(tv4.tv_sec - tv3.tv_sec)*1000000 +
+                                     tv4.tv_usec - tv3.tv_usec),
+                    (long)in_sz, (long)out_sz);
+        }
 
-	exit(0);
-	
+        exit(0);
+        
     }
 
     if (raw) {
-	// One naked / raw block, to match the specification
-	uint32_t in_size, out_size;
-	unsigned char *in = load(infp, &in_size), *out;
-	if (!in) exit(1);
+        // One naked / raw block, to match the specification
+        uint32_t in_size, out_size;
+        unsigned char *in = load(infp, &in_size), *out;
+        if (!in) exit(1);
 
-	// Deliberately realloc down to in_size so we can use address
-	// sanitizer to check for input buffer overruns.
-	in = realloc(in, in_size);
+        // Deliberately realloc down to in_size so we can use address
+        // sanitizer to check for input buffer overruns.
+        in = realloc(in, in_size);
 
-	if (decode) {
-	    if (!(out = rans_uncompress_4x16(in, in_size, &out_size)))
-		exit(1);
+        if (decode) {
+            if (!(out = rans_uncompress_4x16(in, in_size, &out_size)))
+                exit(1);
 
-	    fwrite(out, 1, out_size, outfp);
-	    bytes = out_size;
-	} else {
-	    if (!(out = rans_compress_4x16(in, in_size, &out_size, order)))
-		exit(1);
+            fwrite(out, 1, out_size, outfp);
+            bytes = out_size;
+        } else {
+            if (!(out = rans_compress_4x16(in, in_size, &out_size, order)))
+                exit(1);
 
-	    fwrite(out, 1, out_size, outfp);
-	    bytes += in_size;
-	}
+            fwrite(out, 1, out_size, outfp);
+            bytes += in_size;
+        }
 
-	free(in);
-	free(out);
+        free(in);
+        free(out);
     } else {
-	if (decode) {
-	    // Only used in some test implementations of RC_GetFreq()
-	    //RC_init();
-	    //RC_init2();
+        if (decode) {
+            // Only used in some test implementations of RC_GetFreq()
+            //RC_init();
+            //RC_init2();
 
-	    for (;;) {
-		uint32_t in_size, out_size;
-		unsigned char *out;
+            for (;;) {
+                uint32_t in_size, out_size;
+                unsigned char *out;
 
-		if (4 != fread(&in_size, 1, 4, infp))
-		    break;
-		if (in_size > BLK_SIZE)
-		    exit(1);
+                if (4 != fread(&in_size, 1, 4, infp))
+                    break;
+                if (in_size > BLK_SIZE)
+                    exit(1);
 
-		if (in_size != fread(in_buf, 1, in_size, infp)) {
-		    fprintf(stderr, "Truncated input\n");
-		    exit(1);
-		}
-		out = rans_uncompress_4x16(in_buf, in_size, &out_size);
-		if (!out)
-		    exit(1);
+                if (in_size != fread(in_buf, 1, in_size, infp)) {
+                    fprintf(stderr, "Truncated input\n");
+                    exit(1);
+                }
+                out = rans_uncompress_4x16(in_buf, in_size, &out_size);
+                if (!out)
+                    exit(1);
 
-		fwrite(out, 1, out_size, outfp);
-		fflush(outfp);
-		free(out);
+                fwrite(out, 1, out_size, outfp);
+                fflush(outfp);
+                free(out);
 
-		bytes += out_size;
-	    }
-	} else {
-	    for (;;) {
-		uint32_t in_size, out_size;
-		unsigned char *out;
+                bytes += out_size;
+            }
+        } else {
+            for (;;) {
+                uint32_t in_size, out_size;
+                unsigned char *out;
 
-		in_size = fread(in_buf, 1, BLK_SIZE, infp);
-		if (in_size <= 0)
-		    break;
+                in_size = fread(in_buf, 1, BLK_SIZE, infp);
+                if (in_size <= 0)
+                    break;
 
-		if (in_size < 4)
-		    order &= ~1;
+                if (in_size < 4)
+                    order &= ~1;
 
-		out = rans_compress_4x16(in_buf, in_size, &out_size, order);
+                out = rans_compress_4x16(in_buf, in_size, &out_size, order);
 
-		fwrite(&out_size, 1, 4, outfp);
-		fwrite(out, 1, out_size, outfp);
-		free(out);
+                fwrite(&out_size, 1, 4, outfp);
+                fwrite(out, 1, out_size, outfp);
+                free(out);
 
-		bytes += in_size;
-	    }
-	}
+                bytes += in_size;
+            }
+        }
     }
 
     gettimeofday(&tv2, NULL);
 
     fprintf(stderr, "Took %ld microseconds, %5.1f MB/s\n",
-	    (long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-	    tv2.tv_usec - tv1.tv_usec,
-	    (double)bytes / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-			     tv2.tv_usec - tv1.tv_usec));
+            (long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+            tv2.tv_usec - tv1.tv_usec,
+            (double)bytes / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+                             tv2.tv_usec - tv1.tv_usec));
     return 0;
 }

--- a/tests/rANS_static_fuzz.c
+++ b/tests/rANS_static_fuzz.c
@@ -71,7 +71,7 @@ int LLVMFuzzerTestOneInput(uint8_t *in, size_t in_size) {
     unsigned int uncomp_size;
     unsigned char *uncomp = rans_uncompress(in, in_size, &uncomp_size);
     if (uncomp)
-	free(uncomp);
+        free(uncomp);
     
     return 0;
 }
@@ -90,18 +90,18 @@ static unsigned char *load(char *fn, uint64_t *lenp) {
     int fd = open(fn, O_RDONLY);
 
     do {
-	if (dsize - dcurr < BS) {
-	    dsize = dsize ? dsize * 2 : BS;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BS) {
+            dsize = dsize ? dsize * 2 : BS;
+            data = realloc(data, dsize);
+        }
 
-	len = read(fd, data + dcurr, BS);
-	if (len > 0)
-	    dcurr += len;
+        len = read(fd, data + dcurr, BS);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("read");
+        perror("read");
     }
 
     close(fd);
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
     unsigned int uncomp_size;
     unsigned char *uncomp = rans_uncompress(in, in_size, &uncomp_size);
     if (uncomp)
-	free(uncomp);
+        free(uncomp);
 
     free(in);
     

--- a/tests/rANS_static_test.c
+++ b/tests/rANS_static_test.c
@@ -59,18 +59,18 @@ static unsigned char *load(FILE *infp, uint32_t *lenp) {
     signed int len;
 
     do {
-	if (dsize - dcurr < BLK_SIZE) {
-	    dsize = dsize ? dsize * 2 : BLK_SIZE;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BLK_SIZE) {
+            dsize = dsize ? dsize * 2 : BLK_SIZE;
+            data = realloc(data, dsize);
+        }
 
-	len = fread(data + dcurr, 1, BLK_SIZE, infp);
-	if (len > 0)
-	    dcurr += len;
+        len = fread(data + dcurr, 1, BLK_SIZE, infp);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("fread");
+        perror("fread");
     }
 
     *lenp = dcurr;
@@ -108,183 +108,183 @@ int main(int argc, char **argv) {
     extern int optind;
 
     while ((opt = getopt(argc, argv, "o:dtr")) != -1) {
-	switch (opt) {
-	case 'o':
-	    order = atoi(optarg);
-	    break;
+        switch (opt) {
+        case 'o':
+            order = atoi(optarg);
+            break;
 
-	case 'd':
-	    decode = 1;
-	    break;
-	    
-	case 't':
-	    test = 1;
-	    break;
+        case 'd':
+            decode = 1;
+            break;
+            
+        case 't':
+            test = 1;
+            break;
 
-	case 'r':
-	    raw = 1;
-	    break;
-	}
+        case 'r':
+            raw = 1;
+            break;
+        }
     }
 
     order = order ? 1 : 0; // Only support O(0) and O(1)
 
     if (optind < argc) {
-	if (!(infp = fopen(argv[optind], "rb"))) {
-	    perror(argv[optind]);
-	    return 1;
-	}
-	optind++;
+        if (!(infp = fopen(argv[optind], "rb"))) {
+            perror(argv[optind]);
+            return 1;
+        }
+        optind++;
     }
 
     if (optind < argc) {
-	if (!(outfp = fopen(argv[optind], "wb"))) {
-	    perror(argv[optind]);
-	    return 1;
-	}
-	optind++;
+        if (!(outfp = fopen(argv[optind], "wb"))) {
+            perror(argv[optind]);
+            return 1;
+        }
+        optind++;
     }
 
     gettimeofday(&tv1, NULL);
 
     if (test) {
-	size_t len, in_sz = 0, out_sz = 0;
-	typedef struct {
-	    unsigned char *blk;
-	    uint32_t sz;
-	} blocks;
-	blocks *b = NULL, *bc, *bu;
-	int nb = 0, i;
-	
-	while ((len = fread(in_buf, 1, BLK_SIZE, infp)) != 0) {
-	    // inefficient, but it'll do for testing
-	    b = realloc(b, (nb+1)*sizeof(*b));
-	    b[nb].blk = malloc(len);
-	    b[nb].sz = len;
-	    memcpy(b[nb].blk, in_buf, len);
-	    nb++;
-	    in_sz += len;
-	}
+        size_t len, in_sz = 0, out_sz = 0;
+        typedef struct {
+            unsigned char *blk;
+            uint32_t sz;
+        } blocks;
+        blocks *b = NULL, *bc, *bu;
+        int nb = 0, i;
+        
+        while ((len = fread(in_buf, 1, BLK_SIZE, infp)) != 0) {
+            // inefficient, but it'll do for testing
+            b = realloc(b, (nb+1)*sizeof(*b));
+            b[nb].blk = malloc(len);
+            b[nb].sz = len;
+            memcpy(b[nb].blk, in_buf, len);
+            nb++;
+            in_sz += len;
+        }
 
-	int trials = 5;
-	while (trials--) {
-	    bc = malloc(nb*sizeof(*bc));
-	    bu = malloc(nb*sizeof(*bu));
+        int trials = 5;
+        while (trials--) {
+            bc = malloc(nb*sizeof(*bc));
+            bu = malloc(nb*sizeof(*bu));
 
-	    gettimeofday(&tv1, NULL);
+            gettimeofday(&tv1, NULL);
 
-	    out_sz = 0;
-	    for (i = 0; i < nb; i++) {
-		bc[i].blk = rans_compress(b[i].blk, b[i].sz, &bc[i].sz, order);
-		out_sz += 5 + bc[i].sz;
-		bc[i].blk = realloc(bc[i].blk, bc[i].sz);
-	    }
-	
-	    gettimeofday(&tv2, NULL);
+            out_sz = 0;
+            for (i = 0; i < nb; i++) {
+                bc[i].blk = rans_compress(b[i].blk, b[i].sz, &bc[i].sz, order);
+                out_sz += 5 + bc[i].sz;
+                bc[i].blk = realloc(bc[i].blk, bc[i].sz);
+            }
+        
+            gettimeofday(&tv2, NULL);
 
-	    for (i = 0; i < nb; i++) {
-		bu[i].blk = rans_uncompress(bc[i].blk, bc[i].sz, &bu[i].sz);
-	    }
+            for (i = 0; i < nb; i++) {
+                bu[i].blk = rans_uncompress(bc[i].blk, bc[i].sz, &bu[i].sz);
+            }
 
-	    gettimeofday(&tv3, NULL);
+            gettimeofday(&tv3, NULL);
 
-	    for (i = 0; i < nb; i++) {
-		if (b[i].sz != bu[i].sz || memcmp(b[i].blk, bu[i].blk, b[i].sz))
-		    fprintf(stderr, "Mismatch in block %d\n", i);
-		free(bc[i].blk);
-		free(bu[i].blk);
-	    }
-	    free(bc);
-	    free(bu);
+            for (i = 0; i < nb; i++) {
+                if (b[i].sz != bu[i].sz || memcmp(b[i].blk, bu[i].blk, b[i].sz))
+                    fprintf(stderr, "Mismatch in block %d\n", i);
+                free(bc[i].blk);
+                free(bu[i].blk);
+            }
+            free(bc);
+            free(bu);
 
-	    fprintf(stderr, "%5.1f MB/s enc, %5.1f MB/s dec\t %ld bytes -> %ld bytes\n",
-		    (double)in_sz / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-				     tv2.tv_usec - tv1.tv_usec),
-		    (double)in_sz / ((long)(tv3.tv_sec - tv2.tv_sec)*1000000 +
-				     tv3.tv_usec - tv2.tv_usec),
-		    (long)in_sz, (long)out_sz);
-	}
+            fprintf(stderr, "%5.1f MB/s enc, %5.1f MB/s dec\t %ld bytes -> %ld bytes\n",
+                    (double)in_sz / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+                                     tv2.tv_usec - tv1.tv_usec),
+                    (double)in_sz / ((long)(tv3.tv_sec - tv2.tv_sec)*1000000 +
+                                     tv3.tv_usec - tv2.tv_usec),
+                    (long)in_sz, (long)out_sz);
+        }
 
-	exit(0);
-	
+        exit(0);
+        
     }
 
     if (raw) {
-	// One naked / raw block, to match the specification
-	uint32_t in_size, out_size;
-	unsigned char *in = load(infp, &in_size), *out;
-	if (!in) exit(1);
+        // One naked / raw block, to match the specification
+        uint32_t in_size, out_size;
+        unsigned char *in = load(infp, &in_size), *out;
+        if (!in) exit(1);
 
-	if (decode) {
-	    if (!(out = rans_uncompress(in, in_size, &out_size)))
-		exit(1);
+        if (decode) {
+            if (!(out = rans_uncompress(in, in_size, &out_size)))
+                exit(1);
 
-	    fwrite(out, 1, out_size, outfp);
-	    bytes = out_size;
-	} else {
-	    if (!(out = rans_compress(in, in_size, &out_size, order)))
-		exit(1);
+            fwrite(out, 1, out_size, outfp);
+            bytes = out_size;
+        } else {
+            if (!(out = rans_compress(in, in_size, &out_size, order)))
+                exit(1);
 
-	    fwrite(out, 1, out_size, outfp);
-	    bytes += in_size;
-	}
+            fwrite(out, 1, out_size, outfp);
+            bytes += in_size;
+        }
 
-	free(in);
-	free(out);
+        free(in);
+        free(out);
     } else {
-	if (decode) {
-	    // Only used in some test implementations of RC_GetFreq()
-	    //RC_init();
-	    //RC_init2();
+        if (decode) {
+            // Only used in some test implementations of RC_GetFreq()
+            //RC_init();
+            //RC_init2();
 
-	    for (;;) {
-		uint32_t in_size, out_size;
-		unsigned char *out;
+            for (;;) {
+                uint32_t in_size, out_size;
+                unsigned char *out;
 
-		order = fgetc(infp);
-		if (4 != fread(&in_size, 1, 4, infp))
-		    break;
-		if (in_size != fread(in_buf, 1, in_size, infp)) {
-		    fprintf(stderr, "Truncated input\n");
-		    exit(1);
-		}
-		out = rans_uncompress(in_buf, in_size, &out_size);
-		if (!out)
-		    abort();
+                order = fgetc(infp);
+                if (4 != fread(&in_size, 1, 4, infp))
+                    break;
+                if (in_size != fread(in_buf, 1, in_size, infp)) {
+                    fprintf(stderr, "Truncated input\n");
+                    exit(1);
+                }
+                out = rans_uncompress(in_buf, in_size, &out_size);
+                if (!out)
+                    abort();
 
-		fwrite(out, 1, out_size, outfp);
-		free(out);
+                fwrite(out, 1, out_size, outfp);
+                free(out);
 
-		bytes += out_size;
-	    }
-	} else {
-	    for (;;) {
-		uint32_t in_size, out_size;
-		unsigned char *out;
+                bytes += out_size;
+            }
+        } else {
+            for (;;) {
+                uint32_t in_size, out_size;
+                unsigned char *out;
 
-		in_size = fread(in_buf, 1, BLK_SIZE, infp);
-		if (in_size <= 0)
-		    break;
+                in_size = fread(in_buf, 1, BLK_SIZE, infp);
+                if (in_size <= 0)
+                    break;
 
-		out = rans_compress(in_buf, in_size, &out_size,
-				    order && in_size >= 4);
+                out = rans_compress(in_buf, in_size, &out_size,
+                                    order && in_size >= 4);
 
-		fputc(order && in_size >= 4, outfp);
-		fwrite(&out_size, 1, 4, outfp);
-		fwrite(out, 1, out_size, outfp);
-		free(out);
+                fputc(order && in_size >= 4, outfp);
+                fwrite(&out_size, 1, 4, outfp);
+                fwrite(out, 1, out_size, outfp);
+                free(out);
 
-		bytes += in_size;
-	    }
-	}
+                bytes += in_size;
+            }
+        }
     }
 
     gettimeofday(&tv2, NULL);
 
     fprintf(stderr, "Took %ld microseconds, %5.1f MB/s\n",
-	    (long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-	    tv2.tv_usec - tv1.tv_usec,
-	    (double)bytes / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
-			     tv2.tv_usec - tv1.tv_usec));
+            (long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+            tv2.tv_usec - tv1.tv_usec,
+            (double)bytes / ((long)(tv2.tv_sec - tv1.tv_sec)*1000000 +
+                             tv2.tv_usec - tv1.tv_usec));
     return 0;
 }

--- a/tests/rans4x16.test
+++ b/tests/rans4x16.test
@@ -11,19 +11,19 @@ do
     cut -f 1 < $f | tr -d '\012' > $out/r4x16-nl
     for o in 0 1 64 65 128 129 192 193 68 69 132 133 196 197 8 9
     do
-	if [ ! -e "$comp.$o" ]
-	then
-	    continue
-	fi
+        if [ ! -e "$comp.$o" ]
+        then
+            continue
+        fi
         printf 'Testing rans4x16 -r -o%s on %s\t' $o "$f"
 
-	# Round trip
+        # Round trip
         ./rans4x16pr -r -o$o  $out/r4x16-nl $out/r4x16.comp 2>>$out/r4x16.stderr || exit 1
-	wc -c < $out/r4x16.comp
+        wc -c < $out/r4x16.comp
         ./rans4x16pr -r -d $out/r4x16.comp $out/r4x16.uncomp  2>>$out/r4x16.stderr || exit 1
         cmp $out/r4x16-nl $out/r4x16.uncomp || exit 1
 
-	# Precompressed data
+        # Precompressed data
         ./rans4x16pr -r -d $comp.$o $out/r4x16.uncomp  2>>$out/r4x16.stderr || exit 1
         cmp $out/r4x16-nl $out/r4x16.uncomp || exit 1
     done
@@ -33,36 +33,36 @@ do
     do
         printf 'Testing rans4x16 -r -o%s on %s\t' $o "$f"
 
-	# Round trip
-	# SIMD vs SIMD (auto)
+        # Round trip
+        # SIMD vs SIMD (auto)
         ./rans4x16pr -r -o$o $out/r4x16-nl $out/r4x16.comp 2>>$out/r4x16.stderr || exit 1
-	wc -c < $out/r4x16.comp
+        wc -c < $out/r4x16.comp
         ./rans4x16pr -r -d $out/r4x16.comp $out/r4x16.uncomp  2>>$out/r4x16.stderr || exit 1
         cmp $out/r4x16-nl $out/r4x16.uncomp || exit 1
 
-	# Scalar vs scalar
+        # Scalar vs scalar
         ./rans4x16pr -r -o$o -c 0 $out/r4x16-nl $out/r4x16.comp 2>>$out/r4x16.stderr || exit 1
-	wc -c < $out/r4x16.comp
+        wc -c < $out/r4x16.comp
         ./rans4x16pr -r -d -o$o -c 0 $out/r4x16.comp $out/r4x16.uncomp  2>>$out/r4x16.stderr || exit 1
         cmp $out/r4x16-nl $out/r4x16.uncomp || exit 1
 
-	# Scalar vs SIMD
+        # Scalar vs SIMD
         ./rans4x16pr -r -o$o -c 0 $out/r4x16-nl $out/r4x16.comp 2>>$out/r4x16.stderr || exit 1
-	wc -c < $out/r4x16.comp
+        wc -c < $out/r4x16.comp
         ./rans4x16pr -r -d -o$o $out/r4x16.comp $out/r4x16.uncomp  2>>$out/r4x16.stderr || exit 1
         cmp $out/r4x16-nl $out/r4x16.uncomp || exit 1
 
-	# SIMD vs Scalar
+        # SIMD vs Scalar
         ./rans4x16pr -r -o$o  $out/r4x16-nl $out/r4x16.comp 2>>$out/r4x16.stderr || exit 1
-	wc -c < $out/r4x16.comp
+        wc -c < $out/r4x16.comp
         ./rans4x16pr -r -d -o$o -c 0 $out/r4x16.comp $out/r4x16.uncomp  2>>$out/r4x16.stderr || exit 1
         cmp $out/r4x16-nl $out/r4x16.uncomp || exit 1
 
-#	# Precompressed data
-	if [ ! -e "$comp.$o" ]
-	then
-	    continue
-	fi
+#       # Precompressed data
+        if [ ! -e "$comp.$o" ]
+        then
+            continue
+        fi
         ./rans4x16pr -r -d $comp.$o $out/r4x16.uncomp  2>>$out/r4x16.stderr || exit 1
         cmp $out/r4x16-nl $out/r4x16.uncomp || exit 1
     done

--- a/tests/rans4x8.test
+++ b/tests/rans4x8.test
@@ -13,13 +13,13 @@ do
     do
         printf 'Testing rans4x8 -r -o%s on %s\t' $o "$f"
 
-	# Round trip
+        # Round trip
         ./rans4x8 -r -o$o $out/r4x8-nl $out/r4x8.comp 2>>$out/r4x8.stderr || exit 1
-	wc -c < $out/r4x8.comp
+        wc -c < $out/r4x8.comp
         ./rans4x8 -r -d $out/r4x8.comp $out/r4x8.uncomp  2>>$out/r4x8.stderr || exit 1
         cmp $out/r4x8-nl $out/r4x8.uncomp || exit 1
 
-	# Precompressed data
+        # Precompressed data
         ./rans4x8 -r -d $comp.$o $out/r4x8.uncomp  2>>$out/r4x8.stderr || exit 1
         cmp $out/r4x8-nl $out/r4x8.uncomp || exit 1
     done

--- a/tests/tok3.test
+++ b/tests/tok3.test
@@ -12,15 +12,15 @@ do
     do
         printf 'Testing tokenise_name3 -r -%s on %s\t' $lvl "$f"
 
-	# Round trip
-	./tokenise_name3 -r -$lvl < $f > $out/tok3.comp
-	wc -c < $out/tok3.comp
-	./tokenise_name3 -d -r < $out/tok3.comp | tr '\000' '\012' > $out/tok3.uncomp
-	cmp $f $out/tok3.uncomp || exit 1
+        # Round trip
+        ./tokenise_name3 -r -$lvl < $f > $out/tok3.comp
+        wc -c < $out/tok3.comp
+        ./tokenise_name3 -d -r < $out/tok3.comp | tr '\000' '\012' > $out/tok3.uncomp
+        cmp $f $out/tok3.uncomp || exit 1
 
-	# Precompressed data
-	./tokenise_name3 -d -r < $comp.$lvl | tr '\000' '\012' > $out/tok3.uncomp
-	cmp $f $out/tok3.uncomp || exit 1
+        # Precompressed data
+        ./tokenise_name3 -d -r < $comp.$lvl | tr '\000' '\012' > $out/tok3.uncomp
+        cmp $f $out/tok3.uncomp || exit 1
     done
     echo
 done

--- a/tests/tokenise_name3_fuzz.c
+++ b/tests/tokenise_name3_fuzz.c
@@ -46,7 +46,7 @@ int LLVMFuzzerTestOneInput(uint8_t *in, size_t in_size) {
     unsigned int uncomp_size;
     unsigned char *uncomp = tok3_decode_names(in, in_size, &uncomp_size);
     if (uncomp)
-	free(uncomp);
+        free(uncomp);
     
     return 0;
 }
@@ -65,18 +65,18 @@ static unsigned char *load(char *fn, uint64_t *lenp) {
     int fd = open(fn, O_RDONLY);
 
     do {
-	if (dsize - dcurr < BS) {
-	    dsize = dsize ? dsize * 2 : BS;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BS) {
+            dsize = dsize ? dsize * 2 : BS;
+            data = realloc(data, dsize);
+        }
 
-	len = read(fd, data + dcurr, BS);
-	if (len > 0)
-	    dcurr += len;
+        len = read(fd, data + dcurr, BS);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("read");
+        perror("read");
     }
 
     close(fd);

--- a/tests/tokenise_name3_test.c
+++ b/tests/tokenise_name3_test.c
@@ -65,18 +65,18 @@ static unsigned char *load(FILE *infp, uint32_t *lenp) {
     signed int len;
 
     do {
-	if (dsize - dcurr < BLK_SIZE) {
-	    dsize = dsize ? dsize * 2 : BLK_SIZE;
-	    data = realloc(data, dsize);
-	}
+        if (dsize - dcurr < BLK_SIZE) {
+            dsize = dsize ? dsize * 2 : BLK_SIZE;
+            data = realloc(data, dsize);
+        }
 
-	len = fread(data + dcurr, 1, BLK_SIZE, infp);
-	if (len > 0)
-	    dcurr += len;
+        len = fread(data + dcurr, 1, BLK_SIZE, infp);
+        if (len > 0)
+            dcurr += len;
     } while (len > 0);
 
     if (len == -1) {
-	perror("fread");
+        perror("fread");
     }
 
     *lenp = dcurr;
@@ -90,74 +90,74 @@ static int encode(int argc, char **argv) {
     int raw = 0;
 
     while (argc > 1 && argv[1][0] == '-') {
-	if (strcmp(argv[1], "-r") == 0) {
-	    raw = 1;
-	    argc--;
-	    argv++;
-	}
+        if (strcmp(argv[1], "-r") == 0) {
+            raw = 1;
+            argc--;
+            argv++;
+        }
 
-	else if (argv[1][1] >= '0' && argv[1][1] <= '9') {
-	    level = atoi(argv[1]+1);
-	    if (level > 10) {
-		level -= 10;
-		use_arith = 1;
-	    }
-	    argc--;
-	    argv++;
-	}
+        else if (argv[1][1] >= '0' && argv[1][1] <= '9') {
+            level = atoi(argv[1]+1);
+            if (level > 10) {
+                level -= 10;
+                use_arith = 1;
+            }
+            argc--;
+            argv++;
+        }
 
-	else
-	    exit(1);
+        else
+            exit(1);
     }
 
     if (argc > 1) {
-	fp = fopen(argv[1], "r");
-	if (!fp) {
-	    perror(argv[1]);
-	    return 1;
-	}
+        fp = fopen(argv[1], "r");
+        if (!fp) {
+            perror(argv[1]);
+            return 1;
+        }
     } else {
-	fp = stdin;
+        fp = stdin;
     }
 
     if (raw) {
-	// One naked / raw block, to match the specification
-	uint32_t in_len;
-	int out_len;
-	unsigned char *in = load(fp, &in_len), *out;
-	if (!in) exit(1);
-	out = tok3_encode_names((char *)in, in_len, level, use_arith,
-				&out_len, NULL);
-	if (!out || write(1, out, out_len) < out_len) exit(1);   // encoded data
-	free(in);
-	free(out);
+        // One naked / raw block, to match the specification
+        uint32_t in_len;
+        int out_len;
+        unsigned char *in = load(fp, &in_len), *out;
+        if (!in) exit(1);
+        out = tok3_encode_names((char *)in, in_len, level, use_arith,
+                                &out_len, NULL);
+        if (!out || write(1, out, out_len) < out_len) exit(1);   // encoded data
+        free(in);
+        free(out);
     } else {
-	// Block based, to permit arbitrarily large files for benchmarking
-	int blk_offset = 0;
-	for (;;) {
-	    int last_start = 0;
+        // Block based, to permit arbitrarily large files for benchmarking
+        int blk_offset = 0;
+        for (;;) {
+            int last_start = 0;
 
-	    len = fread(blk+blk_offset, 1, BLK_SIZE-blk_offset, fp);
-	    if (len <= 0)
-		break;
-	    len += blk_offset;
+            len = fread(blk+blk_offset, 1, BLK_SIZE-blk_offset, fp);
+            if (len <= 0)
+                break;
+            len += blk_offset;
 
-	    int out_len;
-	    uint8_t *out = tok3_encode_names(blk, len, level, use_arith,
-					     &out_len, &last_start);
-	    if (write(1, &out_len, 4) < 4) exit(1);
-	    if (write(1, out, out_len) < out_len) exit(1);   // encoded data
-	    free(out);
+            int out_len;
+            uint8_t *out = tok3_encode_names(blk, len, level, use_arith,
+                                             &out_len, &last_start);
+            if (write(1, &out_len, 4) < 4) exit(1);
+            if (write(1, out, out_len) < out_len) exit(1);   // encoded data
+            free(out);
 
-	    if (len > last_start)
-		memmove(blk, &blk[last_start], len - last_start);
-	    blk_offset = len - last_start;
-	}
+            if (len > last_start)
+                memmove(blk, &blk[last_start], len - last_start);
+            blk_offset = len - last_start;
+        }
     }
 
     if (fclose(fp) < 0) {
-	perror("closing file");
-	return 1;
+        perror("closing file");
+        return 1;
     }
 
     return 0;
@@ -168,45 +168,45 @@ static int decode(int argc, char **argv) {
     int raw = 0;
 
     if (argc > 1 && strcmp(argv[1], "-r") == 0) {
-	raw = 1;
-	argc--;
-	argv++;
+        raw = 1;
+        argc--;
+        argv++;
     }
 
     if (raw) {
-	// One naked / raw block, to match the specification
-	uint32_t in_len;
-	unsigned char *in = load(stdin, &in_len), *out;
-	if (!in) exit(1);
+        // One naked / raw block, to match the specification
+        uint32_t in_len;
+        unsigned char *in = load(stdin, &in_len), *out;
+        if (!in) exit(1);
 
-	if ((out = tok3_decode_names(in, in_len, &out_sz)) == NULL)
-	    exit(1);
-	if (write(1, out, out_sz) != out_sz)
-	    exit(1);
+        if ((out = tok3_decode_names(in, in_len, &out_sz)) == NULL)
+            exit(1);
+        if (write(1, out, out_sz) != out_sz)
+            exit(1);
 
-	free(in);
-	free(out);
+        free(in);
+        free(out);
     } else {
-	while (fread(&in_sz, 1, 4, stdin) == 4) {
-	    uint8_t *in = malloc(in_sz), *out;
-	    if (!in)
-		return -1;
+        while (fread(&in_sz, 1, 4, stdin) == 4) {
+            uint8_t *in = malloc(in_sz), *out;
+            if (!in)
+                return -1;
 
-	    if (fread(in, 1, in_sz, stdin) != in_sz) {
-		free(in);
-		return -1;
-	    }
+            if (fread(in, 1, in_sz, stdin) != in_sz) {
+                free(in);
+                return -1;
+            }
 
-	    if ((out = tok3_decode_names(in, in_sz, &out_sz)) == NULL) {
-		free(in);
-		return -1;
-	    }
+            if ((out = tok3_decode_names(in, in_sz, &out_sz)) == NULL) {
+                free(in);
+                return -1;
+            }
 
-	    if (write(1, out, out_sz) < out_sz) exit(1);
+            if (write(1, out, out_sz) < out_sz) exit(1);
 
-	    free(in);
-	    free(out);
-	}
+            free(in);
+            free(out);
+        }
     }
 
     return 0;
@@ -219,7 +219,7 @@ int main(int argc, char **argv) {
 #endif
 
     if (argc > 1 && strcmp(argv[1], "-d") == 0)
-	return decode(argc-1, argv+1);
+        return decode(argc-1, argv+1);
     else
-	return encode(argc, argv);
+        return encode(argc, argv);
 }

--- a/tests/varint_test.c
+++ b/tests/varint_test.c
@@ -55,7 +55,7 @@ typedef struct signed_test {
 
 void dump_encoding(size_t sz, const uint8_t *buffer) {
     size_t byte;
-    for	(byte = 0; byte < sz; byte++) {
+    for (byte = 0; byte < sz; byte++) {
         printf("%s0x%02x", byte ? " " : "", buffer[byte]);
     }
 }


### PR DESCRIPTION
This avoids errors with people using editors with strange definitions of tab stops.

A mammoth change, but `git diff -w HEAD~1` reveals no output and it passes the tests.