### PR TITLE
Tidy includes, and a couple of other small improvements

### DIFF
--- a/htscodecs/rANS_static32x16pr.c
+++ b/htscodecs/rANS_static32x16pr.c
@@ -36,19 +36,15 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <assert.h>
 #include <string.h>
-#include <sys/time.h>
 #include <limits.h>
-#include <math.h>
 
 #include "rANS_word.h"
 #include "rANS_static4x16.h"
 #include "rANS_static16_int.h"
 #include "varint.h"
-#include "pack.h"
-#include "rle.h"
+#include "utils.h"
 
 #define TF_SHIFT 12
 #define TOTFREQ (1<<TF_SHIFT)

--- a/htscodecs/rANS_static32x16pr.c
+++ b/htscodecs/rANS_static32x16pr.c
@@ -73,7 +73,7 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
     RansState ransN[NX];
     uint8_t* ptr;
     uint32_t F[256+MAGIC] = {0};
-    int i, j, tab_size = 0, rle, x, z;
+    int i, j, tab_size = 0, x, z;
     // -20 for order/size/meta
     unsigned int bound = rans_compress_bound_4x16(in_size,0)-20;
 
@@ -121,7 +121,7 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
     }
 
     // Encode statistics.
-    for (x = rle = j = 0; j < 256; j++) {
+    for (x = j = 0; j < 256; j++) {
         if (F[j]) {
             RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
             x += F[j];

--- a/htscodecs/rANS_static32x16pr.h
+++ b/htscodecs/rANS_static32x16pr.h
@@ -79,7 +79,7 @@ unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
 
 //----------------------------------------------------------------------
 // Intel SSE4 implementation.  Only the O0 decoder for now
-#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
+#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
 unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,

--- a/htscodecs/rANS_static32x16pr_avx2.c
+++ b/htscodecs/rANS_static32x16pr_avx2.c
@@ -136,7 +136,7 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
     RansState ransN[NX] __attribute__((aligned(32)));
     uint8_t* ptr;
     uint32_t F[256+MAGIC] = {0};
-    int i, j, tab_size = 0, rle, x, z;
+    int i, j, tab_size = 0, x, z;
     // -20 for order/size/meta
     int bound = rans_compress_bound_4x16(in_size,0)-20;
 
@@ -178,7 +178,7 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
         return NULL;
 
     // Encode statistics.
-    for (x = rle = j = 0; j < 256; j++) {
+    for (x = j = 0; j < 256; j++) {
         if (F[j]) {
             RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
             x += F[j];

--- a/htscodecs/rANS_static32x16pr_avx2.c
+++ b/htscodecs/rANS_static32x16pr_avx2.c
@@ -38,12 +38,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
-#include <assert.h>
 #include <string.h>
-#include <sys/time.h>
 #include <limits.h>
-#include <math.h>
 #include <x86intrin.h>
 
 #include "rANS_word.h"
@@ -51,8 +47,6 @@
 #define ROT32_SIMD
 #include "rANS_static16_int.h"
 #include "varint.h"
-#include "pack.h"
-#include "rle.h"
 #include "utils.h"
 #include "permute.h"
 

--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -44,12 +44,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
-#include <assert.h>
 #include <string.h>
-#include <sys/time.h>
 #include <limits.h>
-#include <math.h>
 #include <x86intrin.h>
 
 #include "rANS_word.h"
@@ -57,8 +53,6 @@
 #define ROT32_SIMD
 #include "rANS_static16_int.h"
 #include "varint.h"
-#include "pack.h"
-#include "rle.h"
 #include "utils.h"
 
 unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,

--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -64,7 +64,7 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
     RansState ransN[32] __attribute__((aligned(64)));
     uint8_t* ptr;
     uint32_t F[256+MAGIC] = {0};
-    int i, j, tab_size = 0, rle, x, z;
+    int i, j, tab_size = 0, x, z;
     // -20 for order/size/meta
     int bound = rans_compress_bound_4x16(in_size,0)-20;
 
@@ -107,7 +107,7 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
 
     // Encode statistics and build lookup tables for SIMD encoding.
     uint32_t SB[256], SA[256], SD[256], SC[256];
-    for (x = rle = j = 0; j < 256; j++) {
+    for (x = j = 0; j < 256; j++) {
         if (F[j]) {
             RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
             SB[j] = syms[j].x_max;

--- a/htscodecs/rANS_static32x16pr_neon.c
+++ b/htscodecs/rANS_static32x16pr_neon.c
@@ -36,13 +36,12 @@
 #include <arm_neon.h>
 
 #include <limits.h>
+#include <assert.h>
 
 #include "rANS_word.h"
 #include "rANS_static4x16.h"
 #include "rANS_static16_int.h"
 #include "varint.h"
-#include "pack.h"
-#include "rle.h"
 #include "utils.h"
 
 #define NX 32

--- a/htscodecs/rANS_static32x16pr_neon.c
+++ b/htscodecs/rANS_static32x16pr_neon.c
@@ -83,7 +83,7 @@ unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
     RansState R[NX];
     uint8_t* ptr;
     uint32_t F[256+MAGIC] = {0};
-    int i, j, tab_size = 0, rle, x, z;
+    int i, j, tab_size = 0, x, z;
     int bound = rans_compress_bound_4x16(in_size,0)-20; // -20 for order/size/meta
 
     if (!out) {
@@ -124,7 +124,7 @@ unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
         return NULL;
 
     // Encode statistics.
-    for (x = rle = j = 0; j < 256; j++) {
+    for (x = j = 0; j < 256; j++) {
         if (F[j]) {
             RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
             x += F[j];

--- a/htscodecs/rANS_static32x16pr_sse4.c
+++ b/htscodecs/rANS_static32x16pr_sse4.c
@@ -38,20 +38,14 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <unistd.h>
-#include <assert.h>
 #include <string.h>
-#include <sys/time.h>
 #include <limits.h>
-#include <math.h>
 #include <x86intrin.h>
 
 #include "rANS_word.h"
 #include "rANS_static4x16.h"
 #include "rANS_static16_int.h"
 #include "varint.h"
-#include "pack.h"
-#include "rle.h"
 #include "utils.h"
 
 /* Uses: SSE, SSE2, SSSE3, SSE4.1 and POPCNT

--- a/htscodecs/rANS_static32x16pr_sse4.c
+++ b/htscodecs/rANS_static32x16pr_sse4.c
@@ -214,7 +214,7 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
     RansState ransN[NX];
     uint8_t* ptr;
     uint32_t F[256+MAGIC] = {0};
-    int i, j, tab_size = 0, rle, x, z;
+    int i, j, tab_size = 0, x, z;
     int bound = rans_compress_bound_4x16(in_size,0)-20; // -20 for order/size/meta
 
     if (!out) {
@@ -256,7 +256,7 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
         return NULL;
 
     // Encode statistics.
-    for (x = rle = j = 0; j < 256; j++) {
+    for (x = j = 0; j < 256; j++) {
         if (F[j]) {
             RansEncSymbolInit(&syms[j], x, F[j], TF_SHIFT);
             x += F[j];

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -900,7 +900,7 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
         if (have_avx2)
             return rans_compress_O1_32x16_avx2;
 #endif
-#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
+#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
         if (have_sse4_1) 
             return rans_compress_O1_32x16;
 #endif
@@ -914,7 +914,7 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
         if (have_avx2)
             return rans_compress_O0_32x16_avx2;
 #endif
-#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
+#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
         if (have_sse4_1)
             return rans_compress_O0_32x16;
 #endif
@@ -984,7 +984,7 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
         if (have_avx2)
             return rans_uncompress_O1_32x16_avx2;
 #endif
-#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
+#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
         if (have_sse4_1)
             return rans_uncompress_O1_32x16_sse4;
 #endif
@@ -998,7 +998,7 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
         if (have_avx2)
             return rans_uncompress_O0_32x16_avx2;
 #endif
-#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3)
+#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
         if (have_sse4_1)
             return rans_uncompress_O0_32x16_sse4;
 #endif


### PR DESCRIPTION
* Remove some redundant #include lines to simplify dependencies, but also add a couple that were previously found indirectly via other header files, to remove false dependencies.

* Remove a set but not used variable, before the compiler notices and complains about it.

* Consistently check for `HAVE_POPCNT` along with `HAVE_SSE4_1` and `HAVE_SSSE3`.  Ensures that if any of these macros is missing, the build will still work.
