### PR TITLE
Small tweak to compiler detection.

### DIFF
--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -821,8 +821,8 @@ void rans_set_cpu(int opts) {
     rans_cpu = opts;
 }
 
-#if defined(__GNUC__) && defined(__x86_64__)
-// Icc and Clang both also set __GNUC__
+#if (defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
+// Icc and Clang both also set __GNUC__ on linux, but not on Windows.
 #include <cpuid.h>
 
 #if defined(__clang__) && defined(__has_attribute)


### PR DESCRIPTION
Windows versions of Intel ICX (based on clang) don't define __GNUC__.
Suggested fix reported by Eugene Shelwien.