### PR TITLE
Fix more aliasing issues with rANS codec.

### DIFF
--- a/htscodecs/rANS_static32x16pr_avx2.c
+++ b/htscodecs/rANS_static32x16pr_avx2.c
@@ -234,10 +234,11 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
 #define m128_to_256 _mm256_castsi128_si256
             __m256i t0, t1, t2, t3;
             __m128i *s0, *s1, *s2, *s3;
-            s0 = (__m128i *)((int *)syms + 4*in[Z+0]);
-            s1 = (__m128i *)((int *)syms + 4*in[Z+4]);
-            s2 = (__m128i *)((int *)syms + 4*in[Z+1]);
-            s3 = (__m128i *)((int *)syms + 4*in[Z+5]);
+            s0 = (__m128i *)(&syms[in[Z+0]]);
+            s1 = (__m128i *)(&syms[in[Z+4]]);
+            s2 = (__m128i *)(&syms[in[Z+1]]);
+            s3 = (__m128i *)(&syms[in[Z+5]]);
+
             // FIXME: try load instead of loadu, as 128-bit aligned.
             t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0xE4);
             t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0xE4);
@@ -247,10 +248,11 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
             sh[z+0] = _mm256_permute2x128_si256(t0, t1, 0x20);
             sh[z+1] = _mm256_permute2x128_si256(t2, t3, 0x20);
 
-            s0 = (__m128i *)((int *)syms + 4*in[Z+2]);
-            s1 = (__m128i *)((int *)syms + 4*in[Z+6]);
-            s2 = (__m128i *)((int *)syms + 4*in[Z+3]);
-            s3 = (__m128i *)((int *)syms + 4*in[Z+7]);
+            s0 = (__m128i *)(&syms[in[Z+2]]);
+            s1 = (__m128i *)(&syms[in[Z+6]]);
+            s2 = (__m128i *)(&syms[in[Z+3]]);
+            s3 = (__m128i *)(&syms[in[Z+7]]);
+
             t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0x4E);
             t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0x4E);
             t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x39);
@@ -787,10 +789,11 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
 #define m128_to_256 _mm256_castsi128_si256
             __m256i t0, t1, t2, t3;
             __m128i *s0, *s1, *s2, *s3;
-            s0 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+0]] + lN[Z+0]));
-            s1 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+4]] + lN[Z+4]));
-            s2 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+1]] + lN[Z+1]));
-            s3 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+5]] + lN[Z+5]));
+            s0 = (__m128i *)(&syms[in[iN[Z+0]]][lN[Z+0]]);
+            s1 = (__m128i *)(&syms[in[iN[Z+4]]][lN[Z+4]]);
+            s2 = (__m128i *)(&syms[in[iN[Z+1]]][lN[Z+1]]);
+            s3 = (__m128i *)(&syms[in[iN[Z+5]]][lN[Z+5]]);
+
             t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0xE4);
             t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0xE4);
             t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x93);
@@ -804,10 +807,11 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
             sh[z+0] = _mm256_permute2x128_si256(t0, t1, 0x20);
             sh[z+1] = _mm256_permute2x128_si256(t2, t3, 0x20);
 
-            s0 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+2]] + lN[Z+2]));
-            s1 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+6]] + lN[Z+6]));
-            s2 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+3]] + lN[Z+3]));
-            s3 = (__m128i *)((int *)syms + 4*(256*in[iN[Z+7]] + lN[Z+7]));
+            s0 = (__m128i *)(&syms[in[iN[Z+2]]][lN[Z+2]]);
+            s1 = (__m128i *)(&syms[in[iN[Z+6]]][lN[Z+6]]);
+            s2 = (__m128i *)(&syms[in[iN[Z+3]]][lN[Z+3]]);
+            s3 = (__m128i *)(&syms[in[iN[Z+7]]][lN[Z+7]]);
+
             t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0x4E);
             t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0x4E);
             t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x39);

--- a/htscodecs/rANS_word.h
+++ b/htscodecs/rANS_word.h
@@ -356,7 +356,7 @@ static inline void RansEncPutSymbol_branched(RansState* r, uint8_t** pptr, RansE
     // The old non-branchless method
     if (x > x_max) {
         (*pptr) -= 2;
-        **(uint16_t **)pptr = x;
+        memcpy(*pptr, &x, 2);
         x >>= 16;
     }
 #else
@@ -425,7 +425,7 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr) {
     // clang 730/608   717/467
     // gcc8  733/588   737/458
     uint32_t  x   = *r;
-    uint16_t  *ptr = *(uint16_t **)pptr;
+    uint8_t  *ptr = *pptr;
     __asm__ ("movzwl (%0),  %%eax\n\t"
              "mov    %1,    %%edx\n\t"
              "shl    $0x10, %%edx\n\t"


### PR DESCRIPTION
I'm not sure why I ever had the manual pointer arithmetic in the first place for syms[] / syms[][], but doing it the sensible way is actually a bit faster with some gccs too (about 12% faster encode for gcc 7.5 on ubuntu 18.04).