### PR TITLE
Various speed improvements to rANS codecs.

### DIFF
--- a/htscodecs/rANS_byte.h
+++ b/htscodecs/rANS_byte.h
@@ -20,6 +20,8 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include "utils.h"
+
 #ifdef assert
 #define RansAssert assert
 #else
@@ -294,7 +296,8 @@ static inline void RansEncPutSymbol(RansState* r, uint8_t** pptr, RansEncSymbol 
     ptr[-1] = x & 0xff;
     ptr -= o;
     x >>= o*8;
-    if (x >= x_max) {
+
+    if (unlikely(x >= x_max)) {
         *--ptr = (uint8_t) (x & 0xff);
         x >>= 8;
     }

--- a/htscodecs/rANS_static32x16pr.c
+++ b/htscodecs/rANS_static32x16pr.c
@@ -369,7 +369,7 @@ unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
     }
 
     // Safe loop
-    for (; i < likely(out_end); i+=NX) {
+    for (; i < out_end; i+=NX) {
         for (z = 0; z < NX; z+=4) {
             uint32_t S[4];
             S[0] = s3[R[z+0] & mask];

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -299,6 +299,9 @@ unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
         for (j = 0; j < 8; j+=4) {
             RansState m0 = RansDecGet(&R[0], TF_SHIFT);
             RansState m1 = RansDecGet(&R[1], TF_SHIFT);
+            out[i+j+0] = ssym[m0];
+            out[i+j+1] = ssym[m1];
+
             R[0] = sfreq[m0] * (R[0] >> TF_SHIFT) + sbase[m0];
             R[1] = sfreq[m1] * (R[1] >> TF_SHIFT) + sbase[m1];
 
@@ -311,13 +314,11 @@ unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
             R[2] = sfreq[m2] * (R[2] >> TF_SHIFT) + sbase[m2];
             R[3] = sfreq[m3] * (R[3] >> TF_SHIFT) + sbase[m3];
 
-            out[i+j+0] = ssym[m0];
-            out[i+j+1] = ssym[m1];
-            out[i+j+2] = ssym[m2];
-            out[i+j+3] = ssym[m3];
-
             RansDecRenorm(&R[2], &cp);
             RansDecRenorm(&R[3], &cp);
+
+            out[i+j+2] = ssym[m2];
+            out[i+j+3] = ssym[m3];
         }
     }
 

--- a/htscodecs/rANS_word.h
+++ b/htscodecs/rANS_word.h
@@ -449,10 +449,11 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr)
 {
     // renormalize, branchless
     uint32_t x = *r;
-    int cmp = (x < RANS_BYTE_L);
+    int cmp = (x < RANS_BYTE_L)*2;
     uint32_t y = (*pptr)[0] + ((*pptr)[1]<<8);
-    x = cmp ? (x << 16) | y : x;
-    (*pptr) += 2*cmp;
+    uint32_t x2 = (x << 16) | y;
+    x = cmp ? x2 : x;
+    (*pptr) += cmp;
     *r = x;
 
 //    // renormalize, branched.  Faster on low-complexity data, but generally

--- a/htscodecs/rANS_word.h
+++ b/htscodecs/rANS_word.h
@@ -299,23 +299,14 @@ static inline void RansEncPutSymbol(RansState* r, uint8_t** pptr, RansEncSymbol 
     // is poor.
     //
     // Note the bit-packing and RLE modes are more likely to be used on
-    // low entropy data, making this assertion generally true.
-    // TODO: maybe have two different variants, and a detection mechanism
-    // based on freq table to work out which method would be most efficient?
-    int c = x > x_max;
+    // low entropy data, making this assertion generally true.  See
+    // RansEncPutSymbol_branched for a low-entropy optimised function.
 
-    // This can sometimes be better, eg with clang 7.x
-    // uint16_t* ptr = (uint16_t *)*pptr;
-    // ptr[-1] = x & 0xffff;
-    // x >>= c*16;
-    // *pptr = (uint8_t *)(ptr-c);
-
-    // But overall this seems to be the faster code.
-    // Neither have the aliasing issues of earlier versions
+    // NB: "(x > x_max)*2" turns back into branched code with gcc.
+    int c = (x > x_max); c*=2;
     memcpy(*pptr-2, &x, 2);
-    x >>= c*16;
-    *pptr = *pptr - (c<<1);
-
+    x >>= c*8;
+    *pptr = *pptr - c;
 #else
     if (x > x_max) {
         uint8_t* ptr = *pptr;

--- a/htscodecs/utils.h
+++ b/htscodecs/utils.h
@@ -38,6 +38,21 @@
 #include <stdlib.h>
 #include <math.h>
 
+#if defined(__GNUC__) || defined(__clang__)
+#  if !defined(__clang__) && __GNUC__ >= 100
+     // better still on gcc10 for O1 decode of old rans 4x8
+     // gcc 10=246/205 11=243/205 12=230/197
+#    define likely(x)      __builtin_expect_with_probability((x), 1, 0.99)
+#  else
+     // gcc 10=193/168 11=195/161 12=199/176
+#    define likely(x)      __builtin_expect((x), 1)
+#  endif
+#  define unlikely(x)     __builtin_expect((x), 0)
+#else
+#  define likely(x)   (x)
+#  define unlikely(x) (x)
+#endif
+
 /*
  * Allocates size bytes from the global Thread Local Storage pool.
  * This is shared by all subsequent calls within this thread.

--- a/tests/rANS_static4x16pr_test.c
+++ b/tests/rANS_static4x16pr_test.c
@@ -150,6 +150,7 @@ int main(int argc, char **argv) {
         typedef struct {
             unsigned char *blk;
             uint32_t sz;
+            uint32_t csz;
         } blocks;
         blocks *b = NULL, *bc = NULL, *bu = NULL;
         int nb = 0, i;
@@ -192,7 +193,7 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Testing %d blocks\n", nb);
 
 #ifndef NTRIALS
-#define NTRIALS 10
+#define NTRIALS 5
 #endif
         int trials = NTRIALS;
         while (trials--) {
@@ -206,6 +207,7 @@ int main(int argc, char **argv) {
                 unsigned int csz = bc[i].sz;
                 bc[i].blk = rans_compress_to_4x16(b[i].blk, b[i].sz, bc[i].blk, &csz, order);
                 assert(csz <= bc[i].sz);
+                bc[i].csz = csz;
                 out_sz += 5 + csz;
             }
 
@@ -217,7 +219,7 @@ int main(int argc, char **argv) {
             gettimeofday(&tv3, NULL);
 
             for (i = 0; i < nb; i++)
-                bu[i].blk = rans_uncompress_to_4x16(bc[i].blk, bc[i].sz, bu[i].blk, &bu[i].sz);
+                bu[i].blk = rans_uncompress_to_4x16(bc[i].blk, bc[i].csz, bu[i].blk, &bu[i].sz);
 
             gettimeofday(&tv4, NULL);
 


### PR DESCRIPTION
The changes are a combination of likely / unlikely macros and some
code structure tweaking after extensive profiling with different
compilers on low and high-entropy data.

It's almost impossible to gain speed in all cases, and optimisations
like this usually favour one system over another.

On a modern intel system (Xeon(R) Gold 6142), a few specific compiler
versions and optimisations had issues before.  The main winners are
rans4x8 clang13 -O3 encode and gcc11 / gcc12 decodes (both 4x8 and
4x16), both often by 10-20% faster.  The biggest loss is rans4x8 clang
7.0 encode, by 5-7% slower.

On an older Intel (Xeon E5-2660), the loser is clang 10.0 rans4x8,
which is up to 5% slower.  The biggest wins are rans4x8 decode, on a
mix of compilers: gcc 7, 10, 11 and all clang.