### PR TITLE
Configure and automake improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,36 +106,75 @@ dnl 	LIBS="-lbsc $LIBS"
 dnl 	AC_DEFINE([HAVE_LIBBSC],1,[Define to 1 if you have the libbsc library.])])
 
 dnl Check if we can use our SSSE3 implementations of rANS 32x16 codec.
-AX_CHECK_COMPILE_FLAG([-Werror -mssse3], [
+AX_CHECK_COMPILE_FLAG([-mssse3], [
         MSSSE3=-mssse3
 	AC_SUBST(MSSSE3)
-        AC_DEFINE([HAVE_SSSE3],1,[Defined to 1 if the compiler can issue SSSE3 instructions.])])
+        AC_DEFINE([HAVE_SSSE3],1,[Defined to 1 if the compiler can issue SSSE3 instructions.])
+], [], [], [AC_LANG_PROGRAM([[
+	  #include "x86intrin.h"
+	]],[[
+	  __m128i a = _mm_set_epi32(1, 2, 3, 4), b = _mm_set_epi32(4, 3, 2, 1);
+	  __m128i c = _mm_shuffle_epi8(a, b);
+	  return *((char *) &c);
+	]])
+])
 
 dnl Check if we can use popcnt instructions
-AX_CHECK_COMPILE_FLAG([-Werror -mpopcnt], [
+AX_CHECK_COMPILE_FLAG([-mpopcnt], [
         MPOPCNT=-mpopcnt
 	AC_SUBST(MPOPCNT)
-        AC_DEFINE([HAVE_POPCNT],1,[Defined to 1 if the compiler can issue popcnt instructions.])])
+        AC_DEFINE([HAVE_POPCNT],1,[Defined to 1 if the compiler can issue popcnt instructions.])
+], [], [], [AC_LANG_PROGRAM([[
+	  #include "x86intrin.h"
+	]],[[
+	  unsigned int i = _mm_popcnt_u32(1);
+	  return i != 1;
+	]])
+])
 
 dnl Check if we can use our SSE4.1 too.  This *may* always imply SSSE3?
 dnl It may be easier just to target an old era of cpu than -mssse3 -msse4.1
 dnl -mpopcnt.  Eg -march=nehalem.  I don't know how wide spread that is.
-AX_CHECK_COMPILE_FLAG([-Werror -msse4.1], [
-        MSSSE3=-msse4.1
+AX_CHECK_COMPILE_FLAG([-msse4.1], [
+        MSSE4_1=-msse4.1
 	AC_SUBST(MSSE4_1)
-        AC_DEFINE([HAVE_SSE4_1],1,[Defined to 1 if the compiler can issue SSE4.1 instructions.])])
+        AC_DEFINE([HAVE_SSE4_1],1,[Defined to 1 if the compiler can issue SSE4.1 instructions.])
+], [], [], [AC_LANG_PROGRAM([[
+	  #include "x86intrin.h"
+	]],[[
+	  __m128i a = _mm_set_epi32(1, 2, 3, 4), b = _mm_set_epi32(4, 3, 2, 1);
+	  __m128i c = _mm_max_epu32(a, b);
+	  return *((char *) &c);
+	]])
+])
 
 dnl Check if we can use our AVX2 implementations.
-AX_CHECK_COMPILE_FLAG([-Werror -mavx2], [
+AX_CHECK_COMPILE_FLAG([-mavx2], [
         MAVX2=-mavx2
 	AC_SUBST(MAVX2)
-        AC_DEFINE([HAVE_AVX2],1,[Defined to 1 if the compiler can issue AVX2 instructions.])])
+        AC_DEFINE([HAVE_AVX2],1,[Defined to 1 if the compiler can issue AVX2 instructions.])
+], [], [], [AC_LANG_PROGRAM([[
+	  #include "x86intrin.h"
+	]],[[
+	  __m256i a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
+	  __m256i b = _mm256_add_epi32(a, a);
+	  return *((char *) &b);
+	]])
+])
 
 dnl Check also if we have AVX512.  If so this overrides AVX2
-AX_CHECK_COMPILE_FLAG([-Werror -mavx512f], [
+AX_CHECK_COMPILE_FLAG([-mavx512f], [
         MAVX512=-mavx512f
 	AC_SUBST(MAVX512)
-        AC_DEFINE([HAVE_AVX512],1,[Defined to 1 if the compiler can issue AVX512F instructions.])])
+        AC_DEFINE([HAVE_AVX512],1,[Defined to 1 if the compiler can issue AVX512F instructions.])
+], [], [], [AC_LANG_PROGRAM([[
+	  #include "x86intrin.h"
+	]],[[
+	  __m512i a = _mm512_set1_epi32(1);
+	  __m512i b = _mm512_add_epi32(a, a);
+	  return *((char *) &b);
+	]])
+])
 
 AX_LIBDEFLATE
 

--- a/configure.ac
+++ b/configure.ac
@@ -105,10 +105,14 @@ dnl AC_CHECK_LIB([bsc], [bsc_compress], [
 dnl 	LIBS="-lbsc $LIBS"
 dnl 	AC_DEFINE([HAVE_LIBBSC],1,[Define to 1 if you have the libbsc library.])])
 
+dnl Count parts needed to build rANS_static32x16pr_sse4.c
+sse4_prerequisites=""
+
 dnl Check if we can use our SSSE3 implementations of rANS 32x16 codec.
 AX_CHECK_COMPILE_FLAG([-mssse3], [
         MSSSE3=-mssse3
-	AC_SUBST(MSSSE3)
+	sse4_prerequisites="o$sse4_prerequisites"
+	AC_SUBST([MSSSE3])
         AC_DEFINE([HAVE_SSSE3],1,[Defined to 1 if the compiler can issue SSSE3 instructions.])
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
@@ -122,7 +126,8 @@ AX_CHECK_COMPILE_FLAG([-mssse3], [
 dnl Check if we can use popcnt instructions
 AX_CHECK_COMPILE_FLAG([-mpopcnt], [
         MPOPCNT=-mpopcnt
-	AC_SUBST(MPOPCNT)
+	sse4_prerequisites="o$sse4_prerequisites"
+	AC_SUBST([MPOPCNT])
         AC_DEFINE([HAVE_POPCNT],1,[Defined to 1 if the compiler can issue popcnt instructions.])
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
@@ -137,7 +142,8 @@ dnl It may be easier just to target an old era of cpu than -mssse3 -msse4.1
 dnl -mpopcnt.  Eg -march=nehalem.  I don't know how wide spread that is.
 AX_CHECK_COMPILE_FLAG([-msse4.1], [
         MSSE4_1=-msse4.1
-	AC_SUBST(MSSE4_1)
+	sse4_prerequisites="o$sse4_prerequisites"
+	AC_SUBST([MSSE4_1])
         AC_DEFINE([HAVE_SSE4_1],1,[Defined to 1 if the compiler can issue SSE4.1 instructions.])
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
@@ -147,11 +153,12 @@ AX_CHECK_COMPILE_FLAG([-msse4.1], [
 	  return *((char *) &c);
 	]])
 ])
+AM_CONDITIONAL([RANS_32x16_SSE4],[test "x$sse4_prerequisites" = "xooo"])
 
 dnl Check if we can use our AVX2 implementations.
 AX_CHECK_COMPILE_FLAG([-mavx2], [
         MAVX2=-mavx2
-	AC_SUBST(MAVX2)
+	AC_SUBST([MAVX2])
         AC_DEFINE([HAVE_AVX2],1,[Defined to 1 if the compiler can issue AVX2 instructions.])
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
@@ -161,11 +168,12 @@ AX_CHECK_COMPILE_FLAG([-mavx2], [
 	  return *((char *) &b);
 	]])
 ])
+AM_CONDITIONAL([RANS_32x16_AVX2],[test "x$MAVX2" != "x"])
 
 dnl Check also if we have AVX512.  If so this overrides AVX2
 AX_CHECK_COMPILE_FLAG([-mavx512f], [
         MAVX512=-mavx512f
-	AC_SUBST(MAVX512)
+	AC_SUBST([MAVX512])
         AC_DEFINE([HAVE_AVX512],1,[Defined to 1 if the compiler can issue AVX512F instructions.])
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
@@ -175,6 +183,21 @@ AX_CHECK_COMPILE_FLAG([-mavx512f], [
 	  return *((char *) &b);
 	]])
 ])
+AM_CONDITIONAL([RANS_32x16_AVX512],[test "x$MAVX512" != "x"])
+
+dnl Detect ARM Neon availability
+AC_CACHE_CHECK([whether C compiler supports ARM Neon], [htscodecs_cv_have_neon], [
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+      #include "arm_neon.h"
+    ]], [[
+      int32x4_t a = vdupq_n_s32(1);
+      int32x4_t b = vaddq_s32(a, a);
+      return *((char *) &b);
+    ]])], [htscodecs_cv_have_neon=yes], [htscodecs_cv_have_neon=no])])
+AM_CONDITIONAL([RANS_32x16_NEON],[test "$htscodecs_cv_have_neon" = yes])
+
+AC_SUBST([HTSCODECS_SIMD_SRC])
 
 AX_LIBDEFLATE
 

--- a/htscodecs/Makefile.am
+++ b/htscodecs/Makefile.am
@@ -62,12 +62,21 @@ libhtscodecs_base_src = \
 	utils.c \
 	utils.h
 
-libhtscodecs_simd_src = rANS_static32x16pr_sse4.c \
-	rANS_static32x16pr_avx2.c \
-	rANS_static32x16pr_avx512.c \
-	rANS_static32x16pr_neon.c
+libhtscodecs_la_SOURCES = $(libhtscodecs_base_src)
 
-libhtscodecs_la_SOURCES = $(libhtscodecs_base_src) $(libhtscodecs_simd_src)
+# SIMD optional extras
+if RANS_32x16_SSE4
+libhtscodecs_la_SOURCES += rANS_static32x16pr_sse4.c
+endif
+if RANS_32x16_AVX2
+libhtscodecs_la_SOURCES += rANS_static32x16pr_avx2.c
+endif
+if RANS_32x16_AVX512
+libhtscodecs_la_SOURCES += rANS_static32x16pr_avx512.c
+endif
+if RANS_32x16_NEON
+libhtscodecs_la_SOURCES += rANS_static32x16pr_neon.c
+endif
 
 libhtscodecs_la_LDFLAGS = -version-info @VERS_CURRENT@:@VERS_REVISION@:@VERS_AGE@ 
 libhtscodecs_la_LIBADD = @LIBZ@ -lm

--- a/htscodecs/Makefile.am
+++ b/htscodecs/Makefile.am
@@ -63,31 +63,34 @@ libhtscodecs_base_src = \
 	utils.h
 
 libhtscodecs_la_SOURCES = $(libhtscodecs_base_src)
+libhtscodecs_la_LIBADD =
+noinst_LTLIBRARIES =
 
 # SIMD optional extras
 if RANS_32x16_SSE4
-libhtscodecs_la_SOURCES += rANS_static32x16pr_sse4.c
+noinst_LTLIBRARIES += librANS_static32x16pr_sse4.la
+librANS_static32x16pr_sse4_la_SOURCES = rANS_static32x16pr_sse4.c
+librANS_static32x16pr_sse4_la_CFLAGS = @MSSE4_1@ @MSSSE3@ @MPOPCNT@
+libhtscodecs_la_LIBADD += librANS_static32x16pr_sse4.la
 endif
 if RANS_32x16_AVX2
-libhtscodecs_la_SOURCES += rANS_static32x16pr_avx2.c
+noinst_LTLIBRARIES += librANS_static32x16pr_avx2.la
+librANS_static32x16pr_avx2_la_SOURCES = rANS_static32x16pr_avx2.c
+librANS_static32x16pr_avx2_la_CFLAGS = @MAVX2@
+libhtscodecs_la_LIBADD += librANS_static32x16pr_avx2.la
 endif
 if RANS_32x16_AVX512
-libhtscodecs_la_SOURCES += rANS_static32x16pr_avx512.c
+noinst_LTLIBRARIES += librANS_static32x16pr_avx512.la
+librANS_static32x16pr_avx512_la_SOURCES = rANS_static32x16pr_avx512.c
+librANS_static32x16pr_avx512_la_CFLAGS = @MAVX512@
+libhtscodecs_la_LIBADD += librANS_static32x16pr_avx512.la
 endif
 if RANS_32x16_NEON
 libhtscodecs_la_SOURCES += rANS_static32x16pr_neon.c
 endif
 
 libhtscodecs_la_LDFLAGS = -version-info @VERS_CURRENT@:@VERS_REVISION@:@VERS_AGE@ 
-libhtscodecs_la_LIBADD = @LIBZ@ -lm
-
-# AM_CFLAGS so users can override CFLAGS without breaking the build.
-rANS_static32x16pr_sse4.o:     AM_CFLAGS+=@MSSE4_1@ @MSSSE3@ @MPOPCNT@
-rANS_static32x16pr_sse4.lo:    AM_CFLAGS+=@MSSE4_1@ @MSSSE3@ @MPOPCNT@
-rANS_static32x16pr_avx2.o:     AM_CFLAGS+=@MAVX2@
-rANS_static32x16pr_avx2.lo:    AM_CFLAGS+=@MAVX2@
-rANS_static32x16pr_avx512.o:   AM_CFLAGS+=@MAVX512@
-rANS_static32x16pr_avx512.lo:  AM_CFLAGS+=@MAVX512@
+libhtscodecs_la_LIBADD += @LIBZ@ -lm
 
 # Fuzz testing version of the library.  This is build using -fsanitize=fuzzer
 # and defines FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION to prevent things like


### PR DESCRIPTION
The first commit here improves the configure checks for compiler options like `-mavx512` by adding test source code.  It makes the tests less likely to be defeated by compilers that accept the `-m` option, but don't really support it.

The second fixes warnings about empty translation units from the MacOS linker, and `gcc` when using `-pedantic`.  It uses [`AM_CONDITIONAL`](https://www.gnu.org/software/automake/manual/html_node/Conditional-Sources.html) to remove any source files that would be empty following the results of the configure run.

The third changes how compiler options are set for the object files that require specific SIMD flags.  This was done using target-specific variables, which are only supported by GNU make.  They are removed, and replaced with the [automake way of doing this](https://www.gnu.org/software/automake/manual/html_node/Per_002dObject-Flags.html) which involves [making convenience libraries](https://www.gnu.org/software/automake/manual/html_node/Libtool-Convenience-Libraries.html) and setting specific flags for them.