### PR TITLE
Fix big-endian rans_compress_O0_32x16() to match little-endian

### DIFF
--- a/htscodecs/rANS_static32x16pr.c
+++ b/htscodecs/rANS_static32x16pr.c
@@ -221,11 +221,11 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
                 ptr16[-1] = rp[3-2]; ptr16 -= c2;
                 ptr16[-1] = rp[3-3]; ptr16 -= c3;
 #else
-                ((uint8_t *)&ptr16[-1])[0] = rp[3-0];
-                ((uint8_t *)&ptr16[-1])[1] = rp[3-0]>>8;
+                ((uint8_t *)&ptr16[-1])[0] = rp[3-2];
+                ((uint8_t *)&ptr16[-1])[1] = rp[3-2]>>8;
                 ptr16 -= c2;
-                ((uint8_t *)&ptr16[-1])[0] = rp[3-1];
-                ((uint8_t *)&ptr16[-1])[1] = rp[3-1]>>8;
+                ((uint8_t *)&ptr16[-1])[0] = rp[3-3];
+                ((uint8_t *)&ptr16[-1])[1] = rp[3-3]>>8;
                 ptr16 -= c3;
 #endif
                 rp[3-2] = c2 ? rp[3-2]>>16 : rp[3-2];

--- a/tests/entropy.c
+++ b/tests/entropy.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv) {
                     break;
                 }
 
-                if (usize != in_size || memcmp(in, uncomp, usize) != 0) {
+                if (usize != in_size || uncomp == NULL || memcmp(in, uncomp, usize) != 0) {
                     printf("\tFAIL\n");
                     result = EXIT_FAILURE;
                 } else {


### PR DESCRIPTION
Correct `rp[]` indexes so they match those in the `HTSCODECS_LITTLE_ENDIAN` version of the code just above — this appear to have been a copy/paste error from the previous big endian code block. With this fix, all tests pass on s390x, which is big endian.

In _tests/entropy.c_, decompressing data produced with the incorrect code eventually led to `rans_uncompress_4x16()` returning NULL. Improve the test harness so that it prints FAIL rather than segfaulting in `memcmp()`. This segfault can be observed on little-endian hosts by breaking the little-endian version of the code snippet similarly:

```diff
--- a/htscodecs/rANS_static32x16pr.c
+++ b/htscodecs/rANS_static32x16pr.c
@@ -218,8 +218,8 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
                 int c2  = rp[3-2] > sy[2]->x_max;
                 int c3  = rp[3-3] > sy[3]->x_max;
 #ifdef HTSCODECS_LITTLE_ENDIAN
-                ptr16[-1] = rp[3-2]; ptr16 -= c2;
-                ptr16[-1] = rp[3-3]; ptr16 -= c3;
+                ptr16[-1] = rp[3-0]; ptr16 -= c2;
+                ptr16[-1] = rp[3-1]; ptr16 -= c3;
 #else
                 ((uint8_t *)&ptr16[-1])[0] = rp[3-0];
                 ((uint8_t *)&ptr16[-1])[1] = rp[3-0]>>8;
```