### PR TITLE
Fix bug with RANS_ORDER_STRIPE on large blocks.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
-Release 1.3.0: 19th July 2022
------------------------------
+Release 1.3.0: 9th August 2022
+------------------------------
 
 The primary change in this release is a new SIMD enabled rANS codec.
 
@@ -48,6 +48,8 @@ Bug fixes
 - Fixed an issue with encoding data blocks close to 2GB in size.
   (Additionally blocks above 2GB now error, rather than crashing or
   returning incorrect results.)
+
+- Fix encode error with large blocks using RANS_ORDER_STRIPE.
 
 
 Release 1.2.2: 1st April 2022

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -97,7 +97,7 @@ unsigned int rans_compress_bound_4x16(unsigned int size, int order) {
         ((order & RANS_ORDER_PACK) ? 1 : 0) +
         ((order & RANS_ORDER_RLE) ? 1 + 257*3+4: 0) + 20 +
         ((order & RANS_ORDER_X32) ? (32-4)*4 : 0) +
-        ((order & RANS_ORDER_STRIPE) ? 1 + 5*N: 0);
+        ((order & RANS_ORDER_STRIPE) ? 7 + 5*N: 0);
     return sz + (sz&1) + 2; // make this even so buffers are word aligned
 }
 
@@ -1181,7 +1181,7 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
         unsigned char *out_best = NULL;
         unsigned int out_best_len = 0;
 
-        out2_start = out2 = out+2+5*N; // shares a buffer with c_meta
+        out2_start = out2 = out+7+5*N; // shares a buffer with c_meta
         for (i = 0; i < N; i++) {
             // Brute force try all methods.
             int j, m[] = {1,64,128,0}, best_j = 0, best_sz = in_size+10;


### PR DESCRIPTION
The meta-data is 2 bytes for order + N, ? bytes for original size, and
`4*N` bytes for the N compressed sizes.  We forgot about the original
size so only left room for `2+5*N` (with 5 being the maximum size of a
32-bit var int).  So blocks larger than 2^28 risked not fitting in the
allocated meta-data size.

Reported by Divon Lan.