### PR TITLE
Detect Neon capability at runtime

### DIFF
--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1006,6 +1006,35 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
 }
 
 #elif defined(__ARM_NEON)
+
+#if defined(__linux__) || defined(__FreeBSD__)
+#include <sys/auxv.h>
+#elif defined(_WIN32)
+#include <processthreadsapi.h>
+#endif
+
+static inline int have_neon() {
+#if defined(__linux__) && defined(__arm__)
+    return (getauxval(AT_HWCAP) & HWCAP_NEON) != 0;
+#elif defined(__linux__) && defined(__aarch64__)
+    return (getauxval(AT_HWCAP) & HWCAP_ASIMD) != 0;
+#elif defined(__APPLE__)
+    return 1;
+#elif defined(__FreeBSD__) && defined(__arm__)
+    u_long cap;
+    if (elf_aux_info(AT_HWCAP, &cap, sizeof cap) != 0) return 0;
+    return (cap & HWCAP_NEON) != 0;
+#elif defined(__FreeBSD__) && defined(__aarch64__)
+    u_long cap;
+    if (elf_aux_info(AT_HWCAP, &cap, sizeof cap) != 0) return 0;
+    return (cap & HWCAP_ASIMD) != 0;
+#elif defined(_WIN32)
+    return IsProcessorFeaturePresent(PF_ARM_V8_INSTRUCTIONS_AVAILABLE) != 0;
+#else
+    return 0;
+#endif
+}
+
 static inline
 unsigned char *(*rans_enc_func(int do_simd, int order))
     (unsigned char *in,
@@ -1014,7 +1043,7 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
      unsigned int *out_size) {
 
     if (do_simd) {
-        if (rans_cpu & RANS_CPU_ENC_NEON)
+        if ((rans_cpu & RANS_CPU_ENC_NEON) && have_neon())
             return order & 1
                 ? rans_compress_O1_32x16_neon
                 : rans_compress_O0_32x16_neon;
@@ -1037,7 +1066,7 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
      unsigned int out_size) {
 
     if (do_simd) {
-        if (rans_cpu & RANS_CPU_DEC_NEON)
+        if ((rans_cpu & RANS_CPU_DEC_NEON) && have_neon())
             return order & 1
                 ? rans_uncompress_O1_32x16_neon
                 : rans_uncompress_O0_32x16_neon;


### PR DESCRIPTION
As discussed on [debian-med](https://lists.debian.org/debian-med/2022/10/msg00011.html) (thread starts [in September](https://lists.debian.org/debian-med/2022/09/threads.html#00049)), while all ARMv8-A CPUs provide Neon so it is (currently) safe to assume that 64-bit ARM aarch64 programs have Neon available, there exist 32-bit ARM (eg Linux) platforms that do not provide Neon. As well as the obscure platform in the linked Firefox bug report, some Raspberry Pi models do not provide Neon but do run Linux.

So at least when compiled for 32-bit ARM, `rans_enc_func()` and `rans_dec_func()` need to check for Neon at runtime, as they do for SSE/AVX/etc on x86 using `cpuid` etc. And they might as well on aarch64 as well — I think I read somewhere that ARMv9-A might make Neon optional again in future.

On ARM, detecting processor capabilities is a privileged operation. So unlike x86's `cpuid()` intrinsics, we must query support via OS-specific API functions provided by the operating system. This PR implements this check for various operating systems using the techniques that web searches and stack overflow suggest:

* Linux: via `getauxval()`
* FreeBSD: via the similar `elf_aux_info()`
* macOS: all Apple Silicon machines support Neon (so far)
* Windows: via `IsProcessorFeaturePresent()`

I've tested this on 64-bit ARM Linux and FreeBSD. Unfortunately I don't have any 32-bit installations handy, or any ARM Windows machine.

It might be worth probing for `<sys/auxv.h>`, `getauxval()`, and `elf_aux_info()` in _configure.ac_ and conditionalising these further.