### PR TITLE
Check pthread_once() return value and print diagnostic

### DIFF
--- a/htscodecs/rANS_static.c
+++ b/htscodecs/rANS_static.c
@@ -92,7 +92,10 @@ unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
     ptr = out_end = out_buf + (uint32_t)(1.05*in_size) + 257*257*3 + 9;
 
     // Compute statistics
-    hist8(in, in_size, (uint32_t *)F);
+    if (hist8(in, in_size, (uint32_t *)F) < 0) {
+        free(out_buf);
+        return NULL;
+    }
     tr = ((uint64_t)TOTFREQ<<31)/in_size + (1<<30)/in_size;
 
  normalise_harder:
@@ -404,7 +407,11 @@ unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
     out_end = out_buf + (uint32_t)(1.05*in_size) + 257*257*3 + 9;
     cp = out_buf+9;
 
-    hist1_4(in, in_size, (uint32_t (*)[256])F, (uint32_t *)T);
+    if (hist1_4(in, in_size, (uint32_t (*)[256])F, (uint32_t *)T) < 0) {
+        free(out_buf);
+        out_buf = NULL;
+        goto cleanup;
+    }
 
     F[0][in[1*(in_size>>2)]]++;
     F[0][in[2*(in_size>>2)]]++;

--- a/htscodecs/rANS_static16_int.h
+++ b/htscodecs/rANS_static16_int.h
@@ -322,7 +322,8 @@ static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
         return -1;
     uint32_t T[256+MAGIC] = {0};
     int isz4 = in_size/Nway;
-    hist1_4(in, in_size, F, T);
+    if (hist1_4(in, in_size, F, T) < 0)
+        goto err;
     for (z = 1; z < Nway; z++)
         F[0][in[z*isz4]]++;
     T[0]+=Nway-1;

--- a/htscodecs/rANS_static32x16pr.c
+++ b/htscodecs/rANS_static32x16pr.c
@@ -96,7 +96,6 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
     // Compute statistics
     double e = hist8e(in, in_size, F);
     int low_ent = e < 2;
-    //hist8(in, in_size, F); int low_ent = 0;
 
     // Normalise so frequences sum to power of 2
     uint32_t fsum = in_size;

--- a/htscodecs/rANS_static32x16pr_avx2.c
+++ b/htscodecs/rANS_static32x16pr_avx2.c
@@ -157,7 +157,8 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
         goto empty;
 
     // Compute statistics
-    hist8(in, in_size, F);
+    if (hist8(in, in_size, F) < 0)
+        return NULL;
 
     // Normalise so frequences sum to power of 2
     uint32_t fsum = in_size;

--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -85,7 +85,8 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
         goto empty;
 
     // Compute statistics
-    hist8(in, in_size, F);
+    if (hist8(in, in_size, F) < 0)
+        return NULL;
 
     // Normalise so frequences sum to power of 2
     uint32_t fsum = in_size;

--- a/htscodecs/rANS_static32x16pr_neon.c
+++ b/htscodecs/rANS_static32x16pr_neon.c
@@ -104,7 +104,8 @@ unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
         goto empty;
 
     // Compute statistics
-    hist8(in, in_size, F);
+    if (hist8(in, in_size, F) < 0)
+        return NULL;
 
     // Normalise so frequences sum to power of 2
     uint32_t fsum = in_size;

--- a/htscodecs/rANS_static32x16pr_sse4.c
+++ b/htscodecs/rANS_static32x16pr_sse4.c
@@ -235,8 +235,8 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
         goto empty;
 
     // Compute statistics
-    hist8(in, in_size, F);
-    //hist8(in, in_size, F); int low_ent = 0;
+    if (hist8(in, in_size, F) < 0)
+        return NULL;
 
     // Normalise so frequences sum to power of 2
     uint32_t fsum = in_size;

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -136,7 +136,8 @@ unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
         goto empty;
 
     // Compute statistics
-    hist8(in, in_size, F);
+    if (hist8(in, in_size, F) < 0)
+        return NULL;
 
     // Normalise so frequences sum to power of 2
     uint32_t fsum = in_size;

--- a/htscodecs/utils.c
+++ b/htscodecs/utils.c
@@ -35,6 +35,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <inttypes.h>
 
 #include "utils.h"
@@ -118,7 +119,12 @@ static void htscodecs_tls_init(void) {
 void *htscodecs_tls_alloc(size_t size) {
     int i;
 
-    pthread_once(&rans_once, htscodecs_tls_init);
+    int err = pthread_once(&rans_once, htscodecs_tls_init);
+    if (err != 0) {
+        fprintf(stderr, "Initialising TLS data failed: pthread_once: %s\n",
+                strerror(err));
+        return NULL;
+    }
 
     // Initialise tls_pool on first usage
     tls_pool *tls = pthread_getspecific(rans_key);

--- a/tests/entropy.c
+++ b/tests/entropy.c
@@ -180,9 +180,15 @@ int main(int argc, char **argv) {
                     printf("%10s-o%d      \t", codec[j], order);
                 printf("%10d uncomp, %10d comp", in_size, csize);
 
+                if (comp == NULL) {
+                    printf("\tFAIL (comp)\n");
+                    result = EXIT_FAILURE;
+                    continue;
+                }
+
                 if (comp0) {
                     if (csize != csize0 || memcmp(comp, comp0, csize) != 0) {
-                        printf("\tFAIL (comp)\n");
+                        printf("\tFAIL (comp cmp)\n");
                         result = EXIT_FAILURE;
                     }
                 } else {


### PR DESCRIPTION
While building htscodecs on FreeBSD, I found that most of the tests were failing due to a segfault in `htscodecs_tls_free()` due to `tls` being NULL. After much debugging, it turned out that `pthread_once()` was not working and `htscodecs_tls_init()` was never called.

Checking the return code from `pthread_once()` and printing a diagnostic provides a chance to diagnose this situation quickly rather than just being presented with the eventual segfault.

It turns out that on FreeBSD if you neglect to link with `-lpthread` or `-lthr`, libc provides versions of the pthread functions including a [`pthread_once()` stub that just doesn't work](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=150959). So the cause of these test failures was neglecting to link with `‑lthr` or another threading library.

This was caused by htscodecs's _configure.ac_ check picking up the libc pthread stubs on FreeBSD:

```
dnl Checks for library functions.
AC_SEARCH_LIBS([pthread_join], [pthread])

…

checking for library containing pthread_join... none required
```

This can be worked around with `./configure LIBS=-lthr` or similar, but ideally _configure.ac_ would use `AX_PTHREAD` or some other more comprehensive pthread test.