### PR TITLE
Update hts_pack to operate in line with the spec.

### DIFF
--- a/htscodecs/arith_dynamic.c
+++ b/htscodecs/arith_dynamic.c
@@ -842,7 +842,7 @@ unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
         int pmeta_len;
         uint64_t packed_len;
         packed = hts_pack(in, in_size, out+c_meta_len, &pmeta_len, &packed_len);
-        if (!packed || (pmeta_len == 1 && out[c_meta_len] > 16)) {
+        if (!packed) {
             out[0] &= ~X_PACK;
             do_pack = 0;
             free(packed);

--- a/htscodecs/pack.c
+++ b/htscodecs/pack.c
@@ -57,9 +57,6 @@ uint8_t *hts_pack(uint8_t *data, int64_t len,
                   uint8_t *out_meta, int *out_meta_len, uint64_t *out_len) {
     int p[256] = {0}, n;
     uint64_t i, j;
-    uint8_t *out = malloc(len+1);
-    if (!out)
-        return NULL;
 
     // count syms
     for (i = 0; i < len; i++)
@@ -75,13 +72,12 @@ uint8_t *hts_pack(uint8_t *data, int64_t len,
     j = n+1;
 
     // 1 value per byte
-    if (n > 16) {
-        *out_meta_len = 1;
-        // FIXME shortcut this by returning data and checking later.
-        memcpy(out, data, len);
-        *out_len = len;
-        return out;
-    }
+    if (n > 16)
+        return NULL;
+
+    uint8_t *out = malloc(len+1);
+    if (!out)
+        return NULL;
 
     // Work out how many values per byte to encode.
     int val_per_byte;

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1264,7 +1264,7 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
         int pmeta_len;
         uint64_t packed_len;
         packed = hts_pack(in, in_size, out+c_meta_len, &pmeta_len, &packed_len);
-        if (!packed || (pmeta_len == 1 && out[c_meta_len] > 16)) {
+        if (!packed) {
             out[0] &= ~RANS_ORDER_PACK;
             do_pack = 0;
             free(packed);


### PR DESCRIPTION
Previously when too many symbols were present, we still returned packed data but with 1 byte per symbol.  It was then up to the caller to reject this as inappropriate use of pack.  This meant that hts_pack was a transparent transform that always gives back something even if it's actually just growing the data by 1 byte.

However the CRAMcodecs spec states this scenario is illegal.

The checks in rANS_static4x16pr.c were bugged for nsym==256 as there wasn't a check of "|| out[c_meta_len] == 0", but now it's a moot point as NULL will be returned.

Fixes #65