### PR TITLE
Fix a subtle inefficiency with CRAM 3.1 O1 freq encoding.

### DIFF
--- a/htscodecs/rANS_static.c
+++ b/htscodecs/rANS_static.c
@@ -420,6 +420,12 @@ unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
         if (T[i] == 0)
             continue;
 
+        if (T[i] == 1 && in[in_size-1] == i) {
+            // last symbol can be ignored as it doesn't have following
+            // contexts.
+            continue;
+        }
+
         //uint64_t p = (TOTFREQ * TOTFREQ) / t;
         double p = ((double)TOTFREQ)/T[i];
     normalise_harder:


### PR DESCRIPTION
For order-1 we always encode a value Q in the context of the previous value P, so the frequency table needs to have an array for F[P][0..255]. Given the next value will be in the context of Q, this means we nearly always have F[P] and F[Q] arrays filled out.  However in the rare scenario that symbol Q appears once only and that is the very last byte, then F[Q][0..255] is a full array of zeros and doesn't need to be in the frequency table output.

In reality, it's largely irrelevant because this scenario is extremely rare and even when it is triggered it's totally harmless as it's just a case of storing additional meta-data that's never accessed.

However it came up in a code review, so here is a fix.

See https://github.com/samtools/hts-specs/pull/433#discussion_r989893592 and related discussion for more details.