### PR TITLE
Switch MacOS CI tests to an ARM-based image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -98,8 +98,8 @@ rocky_task:
 task:
   << : *ENVIRONMENT
   name: macosx
-  osx_instance:
-    image: catalina-base
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
 
   package_install_script:
     - brew install autoconf automake libtool


### PR DESCRIPTION
Before x86-64 is phased out at the end of the year.

Uses cirrus-ci recommended container, see:
  https://cirrus-ci.org/guide/macOS/