### PR TITLE
Add arith+bzip2 support to name tokeniser

### DIFF
--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1241,60 +1241,155 @@ static int64_t rans_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t 
     return clen+nb;
 }
 
-static int compress(uint8_t *in, uint64_t in_len, int level, int use_arith,
+static int compress(uint8_t *in, uint64_t in_len, enum name_type type,
+                    int level, int use_arith,
                     uint8_t *out, uint64_t *out_len) {
     uint64_t best_sz = UINT64_MAX;
-    int best = 0;
     uint64_t olen = *out_len;
+    int ret = -1;
 
-    //fprintf(stderr, "=== try %d ===\n", (int)in_len);
-
-    int m, rmethods[5][12] = {
-        {2,   0,      128},                                   // 1
-        {2,   0,                         192+8},              // 3
-        {3,   0,  128,                   193+8},              // 5
-        {6,   0,1,    129,   65,    193, 193+8},              // 7
-        {9,   0,1,128,129,64,65,192,193, 193+8},              // 9
-    };
-
-    // 1-9 to 0-4
+    // Map levels 1-9 to 0-4, for parameter lookup in R[] below
     level = (level-1)/2;
     if (level<0) level=0;
     if (level>4) level=4;
 
-    for (m = 1; m <= rmethods[level][0]; m++) {
+    // rANS4x16pr and arith_dynamic parameters to explore.
+    // We brute force these, so fast levels test 1 setting and slow test more
+    int R[5][N_ALL][7] = {
+        {   // -1
+            /* TYPE     */ {1, 128},
+            /* ALPHA    */ {1, 129},
+            /* CHAR     */ {1, 0},
+            /* DIGITS0  */ {1, 8},
+            /* DZLEN    */ {1, 0},
+            /* DUP      */ {1, 8},
+            /* DIFF     */ {1, 8},
+            /* DIGITS   */ {1, 8},
+            /* DDELTA   */ {1, 0},
+            /* DDELTA0  */ {1, 128},
+            /* MATCH    */ {1, 0},
+            /* NOP      */ {1, 0},
+            /* END      */ {1, 0}
+        },
+
+        {   // -3
+            /* TYPE     */ {2, 192,0},
+            /* ALPHA    */ {2, 129,1},
+            /* CHAR     */ {1, 0},
+            /* DIGITS0  */ {2, 128+8,0}, // size%4==0
+            /* DZLEN    */ {1, 0},
+            /* DUP      */ {1, 192+8},   // size%4==0
+            /* DIFF     */ {1, 128+8},   // size%4==0
+            /* DIGITS   */ {1, 192+8},   // size%4==0
+            /* DDELTA   */ {1, 0},
+            /* DDELTA0  */ {1, 128},
+            /* MATCH    */ {1, 0},
+            /* NOP      */ {1, 0},
+            /* END      */ {1, 0}
+        },
+
+        {   // -5
+            /* TYPE     */ {2, 192,0},
+            /* ALPHA    */ {4, 1,128,0,129},
+            /* CHAR     */ {1, 0},
+            /* DIGITS0  */ {2, 200,0},
+            /* DZLEN    */ {1, 0},
+            /* DUP      */ {1, 200},
+            /* DIFF     */ {2, 192,200},
+            /* DIGITS   */ {2, 132,201},
+            /* DDELTA   */ {1, 0},
+            /* DDELTA0  */ {1, 128},
+            /* MATCH    */ {1, 0},
+            /* NOP      */ {1, 0},
+            /* END      */ {1, 0}
+        },
+
+        {   // -7
+            /* TYPE     */ {3, 193,0,1},
+            /* ALPHA    */ {5, 128, 1,128,0,129},
+            /* CHAR     */ {2, 1,0},
+            /* DIGITS0  */ {2, 200,0},    // or 201,0
+            /* DZLEN    */ {1, 0},
+            /* DUP      */ {1, 201},
+            /* DIFF     */ {2, 192,200},  // or 192,201
+            /* DIGITS   */ {2, 132, 201}, // +bz2 here and -9
+            /* DDELTA   */ {1, 0},
+            /* DDELTA0  */ {1, 128},
+            /* MATCH    */ {1, 0},
+            /* NOP      */ {1, 0},
+            /* END      */ {1, 0}
+        },
+
+        {   // -9
+            /* TYPE     */ {6, 192,0,1,  65,  193,132},
+            /* ALPHA    */ {4, 132, 1, 0,129},
+            /* CHAR     */ {3, 1,0,192},
+            /* DIGITS0  */ {4, 201,0, 192,64},
+            /* DZLEN    */ {3, 0,128,1},
+            /* DUP      */ {1, 201},
+            /* DIFF     */ {3, 192,  201,65},
+            /* DIGITS   */ {6, 132, 201,1,  192,129,  193},
+            /* DDELTA   */ {3, 1,0,  192},
+            /* DDELTA0  */ {3, 192,1,  0},
+            /* MATCH    */ {1, 0},
+            /* NOP      */ {1, 0},
+            /* END      */ {1, 0}
+        },
+    };
+    // Minor tweak to level 3 DIGITS if arithmetic, to use O(201) instead.
+    if (use_arith) R[1][N_DIGITS][1]=201;
+
+    int *meth = R[level][type];
+
+    int last = 0, m;
+    uint8_t best_static[8192];
+    uint8_t *best_dat = best_static;
+    for (m = 1; m <= meth[0]; m++) {
         *out_len = olen;
 
-        if (in_len % 4 != 0 && (rmethods[level][m] & 8))
+        if (!use_arith && (meth[m] & 4))
+            meth[m] &= ~4;
+
+        if (in_len % 4 != 0 && (meth[m] & 8))
             continue;
 
+        last = 0;
         if (use_arith) {
-            if (arith_encode(in, in_len, out, out_len, rmethods[level][m]) < 0)
-                return -1;
+            if (arith_encode(in, in_len, out, out_len, meth[m]) <0)
+                goto err;
         } else {
-            if (rans_encode(in, in_len, out, out_len, rmethods[level][m]) < 0)
-                return -1;
+            if (rans_encode(in, in_len, out, out_len, meth[m]) < 0)
+                goto err;
         }
 
         if (best_sz > *out_len) {
             best_sz = *out_len;
-            best = rmethods[level][m];
+            last = 1;
+
+            if (m+1 > meth[0])
+                // no need to memcpy if we're not going to overwrite out
+                break;
+
+            if (best_sz > 8192 && best_dat == best_static) {
+                // No need to realloc as best_sz only ever decreases
+                best_dat = malloc(best_sz);
+                if (!best_dat)
+                    return -1;
+            }
+            memcpy(best_dat, out, best_sz);
         }
     }
 
-    *out_len = olen;
-    if (use_arith) {
-        if (arith_encode(in, in_len, out, out_len, best) < 0)
-            return -1;
-    } else {
-        if (rans_encode(in, in_len, out, out_len, best) < 0)
-            return -1;
-    }
+    if (!last)
+        memcpy(out, best_dat, best_sz);
+    *out_len = best_sz;
+    ret = 0;
 
-//    uint64_t tmp;
-//    fprintf(stderr, "%d -> %d via method %x, %x\n", (int)in_len, (int)best_sz, best, out[i7get(out,&tmp)]);
+ err:
+    if (best_dat != best_static)
+        free(best_dat);
 
-    return 0;
+    return ret;
 }
 
 static uint64_t uncompressed_size(uint8_t *in, uint64_t in_len) {
@@ -1446,8 +1541,8 @@ uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
             return NULL;
         }
 
-        if (compress(ctx->desc[i].buf, ctx->desc[i].buf_l, level, use_arith,
-                     out, &out_len) < 0) {
+        if (compress(ctx->desc[i].buf, ctx->desc[i].buf_l, i&0xf, level,
+                     use_arith, out, &out_len) < 0) {
             free_context(ctx);
             return NULL;
         }


### PR DESCRIPTION
When arithmetic mode is enabled, we now also try the bz2 backend to arith, post any pack/rle.

Also refactored the code to cache the best result and return it rather than hte best method and recalculate it.  This is a significant speed increase, helping to offset the extra cost in tok3 -17/-19.

Finally, to offset the reduced compute cost, -5 and -15 have a slight tweak to methods to offer a smoother transition of speeds.

Aggregate benchmarks with a mix of ~12 mill read names from many vendors and instrument models.

```
        OLD             NEW
        sec  byte       sec  byte
1       1.70 6053051    1.63 6053051
3       1.91 4925224    1.72 4925224 <-- default in CRAM 3.1
5       3.01 4815078    2.84 4781855
7       4.58 4755225    3.97 4755225
9       4.88 4754659    4.29 4754659

11      3.21 5999169    2.66 5999169
13      4.05 4897903    2.99 4897903
15      5.64 4732432    4.82 4678202 <-- archive mode?
17      7.72 4659489    7.92 4621910
19      9.63 4659358    9.77 4621779
```

The use of bzip2 is most noticable on NovaSeq data where the X and Y coordinates are non-random due to the gridded cluster layout.

On a block of pos-sorted novaseq names:
```
       Old               New
5     .223   329847     .200   329748
7     .308   329596     .275   329596
9     .327   329596     .287   329596
15    .481   327726     .383   324153 -1.1%
17    .593   323824     .575   302605 -6.6%
19    .738   323824     .714   302605 -6.6%
```
On a block of name-sorted novaseq names:
```
       Old               New
5     .219   117010     .203   87900 -25%
7     .272    88081     .254   88081
9     .288    87863     .274   87863
15    .302   110259     .279   80271 -27%
17    .386    80211     .398   67578 -16%
19    .457    80081     .463   67448 -16%
```
