### PR TITLE
Guard SIMD tests with #ifdef tests for platforms

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,8 +105,14 @@ task:
   package_install_script:
     - brew install autoconf automake libtool
 
-  << : *COMPILE
+  # Try building and testing a multiarch library
+  compile_script:
+    - autoreconf -i
+    - ./configure CFLAGS="-g -O3 -Wall -Werror -arch arm64 -arch x86_64"
+    - make -j4
 
+  test_script:
+    - make check
 
 # # ----------
 # # Windows MINGW.

--- a/configure.ac
+++ b/configure.ac
@@ -130,9 +130,11 @@ AX_CHECK_COMPILE_FLAG([-mssse3], [
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
 	]],[[
+	  #if defined(__x86_64__)
 	  __m128i a = _mm_set_epi32(1, 2, 3, 4), b = _mm_set_epi32(4, 3, 2, 1);
 	  __m128i c = _mm_shuffle_epi8(a, b);
 	  return *((char *) &c);
+	  #endif
 	]])
 ])
 
@@ -145,8 +147,10 @@ AX_CHECK_COMPILE_FLAG([-mpopcnt], [
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
 	]],[[
+	  #if defined(__x86_64__)
 	  unsigned int i = _mm_popcnt_u32(1);
 	  return i != 1;
+	  #endif
 	]])
 ])
 
@@ -161,9 +165,11 @@ AX_CHECK_COMPILE_FLAG([-msse4.1], [
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
 	]],[[
+	  #if defined(__x86_64__)
 	  __m128i a = _mm_set_epi32(1, 2, 3, 4), b = _mm_set_epi32(4, 3, 2, 1);
 	  __m128i c = _mm_max_epu32(a, b);
 	  return *((char *) &c);
+	  #endif
 	]])
 ])
 AM_CONDITIONAL([RANS_32x16_SSE4],[test "x$sse4_prerequisites" = "xooo"])
@@ -176,10 +182,12 @@ AX_CHECK_COMPILE_FLAG([-mavx2], [
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
 	]],[[
+	  #if defined(__x86_64__)
 	  __m256i a = _mm256_set_epi32(1, 2, 3, 4, 5, 6, 7, 8);
 	  __m256i b = _mm256_add_epi32(a, a);
 	  long long c = _mm256_extract_epi64(b, 0);
 	  return (int) c;
+	  #endif
 	]])
 ])
 AM_CONDITIONAL([RANS_32x16_AVX2],[test "x$MAVX2" != "x"])
@@ -192,9 +200,11 @@ AX_CHECK_COMPILE_FLAG([-mavx512f], [
 ], [], [], [AC_LANG_PROGRAM([[
 	  #include "x86intrin.h"
 	]],[[
+	  #if defined(__x86_64__)
 	  __m512i a = _mm512_set1_epi32(1);
 	  __m512i b = _mm512_add_epi32(a, a);
 	  return *((char *) &b);
+	  #endif
 	]])
 ])
 AM_CONDITIONAL([RANS_32x16_AVX512],[test "x$MAVX512" != "x"])
@@ -205,10 +215,15 @@ AC_CACHE_CHECK([whether C compiler supports ARM Neon], [htscodecs_cv_have_neon],
     AC_LANG_PROGRAM([[
       #include "arm_neon.h"
     ]], [[
+      #if defined(__ARM_NEON)
       int32x4_t a = vdupq_n_s32(1);
       int32x4_t b = vaddq_s32(a, a);
       return *((char *) &b);
+      #endif
     ]])], [htscodecs_cv_have_neon=yes], [htscodecs_cv_have_neon=no])])
+AS_IF([test "$htscodecs_cv_have_neon" = yes],[
+  AC_DEFINE([HAVE_NEON],1,[Defined to 1 if the compiler can issue NEON instructions.])
+])
 AM_CONDITIONAL([RANS_32x16_NEON],[test "$htscodecs_cv_have_neon" = yes])
 
 AC_SUBST([HTSCODECS_SIMD_SRC])

--- a/htscodecs/rANS_static32x16pr_avx2.c
+++ b/htscodecs/rANS_static32x16pr_avx2.c
@@ -33,7 +33,7 @@
 
 #include "config.h"
 
-#ifdef HAVE_AVX2
+#if defined(__x86_64__) && defined(HAVE_AVX2)
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -39,7 +39,7 @@
 
 #include "config.h"
 
-#ifdef HAVE_AVX512
+#if defined(__x86_64__) && defined(HAVE_AVX512)
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/htscodecs/rANS_static32x16pr_neon.c
+++ b/htscodecs/rANS_static32x16pr_neon.c
@@ -32,7 +32,7 @@
  */
 
 #include "config.h"
-#ifdef __ARM_NEON
+#if defined(__ARM_NEON) && defined(HAVE_NEON)
 #include <arm_neon.h>
 
 #include <limits.h>

--- a/htscodecs/rANS_static32x16pr_sse4.c
+++ b/htscodecs/rANS_static32x16pr_sse4.c
@@ -33,7 +33,8 @@
 
 #include "config.h"
 
-#if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
+#if defined(__x86_64__) && \
+    defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1006,7 +1006,7 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
     }
 }
 
-#elif defined(__ARM_NEON)
+#elif defined(__ARM_NEON) && defined(HAVE_NEON)
 
 #if defined(__linux__) || defined(__FreeBSD__)
 #include <sys/auxv.h>


### PR DESCRIPTION
Required for MacOS multiarch binaries, where files get built for both x86 and ARM.  This means configure tests for compiler options need to pass even though they're being run for the wrong architecture, and source files need to include guards around the architecture-specific parts.

There is a risk that the configure SIMD tests will print "yes" when building for other than the target architectures.  However in most such cases the needed include files won't be present so the tests will work correctly.

Also make the NEON test define HAVE_NEON, so that the neon-specific code in rANS_static4x16pr.c can be excluded correctly if the test does happen to fail on an ARM-like platform.

Adjusts the MacOS CI test so that it makes a multiarch binary to ensure this all works.

Fixes #76 