### PR TITLE
Add FreeBSD to the CI tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,7 +18,6 @@ compile_template: &COMPILE
 #  on_failure:
 #    - cat tests/test-suite.log
 
-
 # ----------
 # Linux
 
@@ -151,3 +150,22 @@ task:
 #     - c:\tools\msys64\usr\bin\bash --login "autoreconf -i"
 #     - c:\tools\msys64\usr\bin\bash "./configure"
 #     - c:\tools\msys64\usr\bin\bash "make -j4"
+
+# ----------
+# FreeBSD
+task:
+  name: freebsd
+  freebsd_instance:
+    image_family: freebsd-13-1
+
+  pkginstall_script:
+    - pkg update -f
+    - pkg install -y gcc autoconf automake libdeflate libtool
+
+  compile_script:
+    - autoreconf -i
+    - ./configure
+    - make -j4 CFLAGS="-g -O3 -Wall -Werror"
+
+  test_script:
+    - make check CFLAGS="-g -O3 -Wall -Werror"


### PR DESCRIPTION
A basic config, but does the minimum necessary for testing.