### PR TITLE
Add include of config.h to test programs.

### DIFF
--- a/tests/arith_dynamic_fuzz.c
+++ b/tests/arith_dynamic_fuzz.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/arith_dynamic_test.c
+++ b/tests/arith_dynamic_test.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/entropy.c
+++ b/tests/entropy.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 /*
  * This test aims to test all entropy codecs on an input file.

--- a/tests/fqzcomp_qual_fuzz.c
+++ b/tests/fqzcomp_qual_fuzz.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdio.h>
 #include <stdint.h>

--- a/tests/fqzcomp_qual_test.c
+++ b/tests/fqzcomp_qual_test.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdio.h>
 #include <stdint.h>

--- a/tests/rANS_static4x16pr_fuzz.c
+++ b/tests/rANS_static4x16pr_fuzz.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 /*
 For best results, configure, from a build subdir, to use the address and

--- a/tests/rANS_static4x16pr_test.c
+++ b/tests/rANS_static4x16pr_test.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/rANS_static_fuzz.c
+++ b/tests/rANS_static_fuzz.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 /*
 For best results, configure, from a build subdir, to use the address and

--- a/tests/rANS_static_test.c
+++ b/tests/rANS_static_test.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/tokenise_name3_fuzz.c
+++ b/tests/tokenise_name3_fuzz.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/tests/tokenise_name3_test.c
+++ b/tests/tokenise_name3_test.c
@@ -30,6 +30,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/varint_test.c
+++ b/tests/varint_test.c
@@ -31,6 +31,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+#include "config.h"
 
 #include <stdlib.h>
 #include <stdint.h>


### PR DESCRIPTION
This helps pick up things like XOPEN_SOURCE definitions as required.

This is a less icky solution to the one in https://github.com/samtools/htslib/issues/1608, although it still needs to explicit `-D_POSIX_C_SOURCE=200112L` makefile definitions removing.