### PR TITLE
Trivial bug fix to tests/r4x16pr demo.

### DIFF
--- a/tests/rANS_static4x16pr_test.c
+++ b/tests/rANS_static4x16pr_test.c
@@ -291,7 +291,7 @@ int main(int argc, char **argv) {
 
                 if (4 != fread(&in_size, 1, 4, infp))
                     break;
-                if (in_size > blk_size)
+                if (in_size > blk_size2)
                     exit(1);
 
                 if (in_size != fread(in_buf, 1, in_size, infp)) {


### PR DESCRIPTION
If we have uncompressible data with size almost BLK_SIZE, then the compressed size gets larger than BLK_SIZE (ie the meta-data to indicate "CAT" mode).

This in turn triggers an incorrect overflow check in the decode part of test main(), which needed to check against allocated buffer size rather than BLK_SIZE.

This had no impact on the library, just the CLI test tool.