### PR TITLE
Fix ARM compilation with certain Conda compilers

### DIFF
--- a/htscodecs/rANS_static16_int.h
+++ b/htscodecs/rANS_static16_int.h
@@ -294,8 +294,6 @@ static inline int encode_freq_d(uint8_t *cp, uint32_t *F0, uint32_t *F) {
                 dz++;
                 *cp++ = 0;
             }
-        } else {
-            assert(F[j] == 0);
         }
     }
     
@@ -313,7 +311,7 @@ static inline int encode_freq_d(uint8_t *cp, uint32_t *F0, uint32_t *F) {
 // Returns the desired TF_SHIFT; 10 or 12 bit, or -1 on error.
 static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
                                RansEncSymbol syms[256][256], uint8_t **cp_p) {
-    int tab_size = 0, i, j, z;
+    int i, j, z;
     uint8_t *out = *cp_p, *cp = out;
 
     // Compute O1 frequency statistics
@@ -412,9 +410,6 @@ static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
         }
         free(c_freq);
     }
-
-    tab_size = cp - out;
-    assert(tab_size < 257*257*3);
 
     *cp_p = cp;
     htscodecs_tls_free(F);

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1018,7 +1018,7 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
 static inline int have_neon() {
 #if defined(__linux__) && defined(__arm__)
     return (getauxval(AT_HWCAP) & HWCAP_NEON) != 0;
-#elif defined(__linux__) && defined(__aarch64__)
+#elif defined(__linux__) && defined(__aarch64__) && defined(HWCAP_ASIMD)
     return (getauxval(AT_HWCAP) & HWCAP_ASIMD) != 0;
 #elif defined(__APPLE__)
     return 1;
@@ -1026,7 +1026,7 @@ static inline int have_neon() {
     u_long cap;
     if (elf_aux_info(AT_HWCAP, &cap, sizeof cap) != 0) return 0;
     return (cap & HWCAP_NEON) != 0;
-#elif defined(__FreeBSD__) && defined(__aarch64__)
+#elif defined(__FreeBSD__) && defined(__aarch64__) && defined(HWCAP_ASIMD)
     u_long cap;
     if (elf_aux_info(AT_HWCAP, &cap, sizeof cap) != 0) return 0;
     return (cap & HWCAP_ASIMD) != 0;


### PR DESCRIPTION
 Fix ARM compilation with certain Conda compilers

A broken conda config removed HWCAP_ASIMD definition.  It's fixed now,
but we check with ifdefs as suggested by John Marshall in comments on
the issue.

Hence code is buildable, just minus NEON support on specific OS and
hardware combinations.

Also a minor tweak to remove an assert related warning.