### PR TITLE
Miscellaneous rANS 32x speed ups

### DIFF
--- a/htscodecs/rANS_static16_int.h
+++ b/htscodecs/rANS_static16_int.h
@@ -542,15 +542,13 @@ static inline int decode_freq1(uint8_t *cp, uint8_t *cp_end, int shift,
 
 // Build s3 symbol lookup table.
 // This is 12 bit freq, 12 bit bias and 8 bit symbol.
-static inline int rans_F_to_s3(uint32_t *F, int shift, uint32_t *s3) {
-    int j, x, y;
+static inline int rans_F_to_s3(const uint32_t *F, int shift, uint32_t *s3) {
+    int j, x;
     for (j = x = 0; j < 256; j++) {
-        if (F[j]) {
-            if (F[j] > (1<<shift) - x)
-                return 1;
-            for (y = 0; y < F[j]; y++)
-                s3[y+x] = (((uint32_t)F[j])<<(shift+8))|(y<<8)|j;
-            x += F[j];
+        if (F[j] && F[j] <= (1<<shift) - x) {
+            uint32_t base = (((uint32_t)F[j])<<(shift+8))|j, y;
+            for (y = 0; y < F[j]; y++, x++)
+                s3[x] = base + (y<<8);
         }
     }
 

--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -162,7 +162,6 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
         SET512(SDv,  SD);
         int pc2 = _mm_popcnt_u32(gt_mask2);
 
-        //Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
         Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
         Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
 
@@ -334,13 +333,13 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
       R1 = _mm512_add_epi32(
                _mm512_mullo_epi32(
                    _mm512_srli_epi32(R1, TF_SHIFT), f1), b1);
+      __mmask16 renorm_mask1, renorm_mask2;
+      renorm_mask1=_mm512_cmplt_epu32_mask(R1, _mm512_set1_epi32(RANS_BYTE_L));
       R2 = _mm512_add_epi32(
                _mm512_mullo_epi32(
                    _mm512_srli_epi32(R2, TF_SHIFT), f2), b2);
 
       // renorm. this is the interesting part:
-      __mmask16 renorm_mask1, renorm_mask2;
-      renorm_mask1=_mm512_cmplt_epu32_mask(R1, _mm512_set1_epi32(RANS_BYTE_L));
       renorm_mask2=_mm512_cmplt_epu32_mask(R2, _mm512_set1_epi32(RANS_BYTE_L));
       // advance by however many words we actually read
       sp += _mm_popcnt_u32(renorm_mask1);
@@ -534,6 +533,27 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
     __m512i c1 = _mm512_i32gather_epi32(iN1, in, 1);
     __m512i c2 = _mm512_i32gather_epi32(iN2, in, 1);
 
+    // We cache the next 64-bytes locally and transpose.
+    // This means we can load 32 ints from t32[x] with load instructions
+    // instead of gathers.  The copy, transpose and expand is easier done
+    // in scalar code.
+#define BATCH 64
+    uint8_t t32[BATCH][32] __attribute__((aligned(64)));
+    int next_batch;
+    if (iN[0] > BATCH) {
+        int i, j;
+        for (i = 0; i < BATCH; i++)
+            // memcpy(c[i], &in[iN[i]-32], 32); fast mode
+            for (j = 0; j < 32; j++)
+                t32[BATCH-1-i][j] = in[iN[j]-1-i];
+        next_batch = BATCH;
+    } else {
+        next_batch = -1;
+    }
+
+    c1 = _mm512_and_si512(c1, _mm512_set1_epi32(0xff));
+    c2 = _mm512_and_si512(c2, _mm512_set1_epi32(0xff));
+
     for (; iN[0] >= 0; iN[0]--) {
         // Note, consider doing the same approach for the AVX2 encoder.
         // Maybe we can also get gather working well there?
@@ -543,8 +563,6 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
         // FIXME: maybe we need to cope with in[31] read over-flow
         // on loop cycles 0, 1, 2 where gather reads 32-bits instead of
         // 8 bits.  Use set instead there on c2?
-        c1 = _mm512_and_si512(c1, _mm512_set1_epi32(0xff));
-        c2 = _mm512_and_si512(c2, _mm512_set1_epi32(0xff));
 
         // index into syms[0][0] array, used for x_max, rcp_freq, and bias
         __m512i vidx1 = _mm512_slli_epi32(c1, 8);
@@ -574,8 +592,45 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
         last2 = c2;
         iN1 = _mm512_sub_epi32(iN1, _mm512_set1_epi32(1));
         iN2 = _mm512_sub_epi32(iN2, _mm512_set1_epi32(1));
-        c1 = _mm512_i32gather_epi32(iN1, in, 1);
-        c2 = _mm512_i32gather_epi32(iN2, in, 1);
+
+        // Code below is equivalent to this:
+        // c1 = _mm512_i32gather_epi32(iN1, in, 1);
+        // c2 = _mm512_i32gather_epi32(iN2, in, 1);
+
+        // Better when we have a power of 2
+        if (next_batch >= 0) {
+            if (--next_batch < 0 && iN[0] > BATCH) {
+                int i, j;
+                uint8_t c[32][BATCH];
+                iN[0] += BATCH;
+                for (j = 0; j < 32; j++) {
+                    iN[j] -= BATCH;
+                    memcpy(c[j], &in[iN[j]-BATCH], BATCH);
+                }
+                // transpose matrix
+                for (j = 0; j < 32; j++) {
+                    for (i = 0; i < BATCH; i+=16) {
+                        for (int z = 0; z < 16; z++)
+                            t32[i+z][j] = c[j][i+z];
+                    }
+                }
+                next_batch = BATCH-1;
+            }
+            if (next_batch >= 0) {
+              __m128i c1_ = _mm_load_si128((__m128i *)&t32[next_batch][0]);
+              __m128i c2_ = _mm_load_si128((__m128i *)&t32[next_batch][16]);
+              c1 = _mm512_cvtepu8_epi32(c1_);
+              c2 = _mm512_cvtepu8_epi32(c2_);
+            }
+        }
+        if (next_batch < 0) {
+            c1 = _mm512_i32gather_epi32(iN1, in, 1);
+            c2 = _mm512_i32gather_epi32(iN2, in, 1);
+
+            c1 = _mm512_and_si512(c1, _mm512_set1_epi32(0xff));
+            c2 = _mm512_and_si512(c2, _mm512_set1_epi32(0xff));
+        }
+        // End of "equivalent to" code block
 
         SET512x(xmax, x_max); // high latency
 
@@ -921,27 +976,25 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
     } else {
         // TF_SHIFT_O1_FAST.  This is the most commonly used variant.
 
+        // m[z] = R[z] & mask;
+        __m512i _masked1 = _mm512_and_si512(_Rv1, _maskv);
+        __m512i _masked2 = _mm512_and_si512(_Rv2, _maskv);
+
+        _Lv1 = _mm512_slli_epi32(_Lv1, TF_SHIFT_O1_FAST);
+        _Lv2 = _mm512_slli_epi32(_Lv2, TF_SHIFT_O1_FAST);
+
+        _masked1 = _mm512_add_epi32(_masked1, _Lv1);
+        _masked2 = _mm512_add_epi32(_masked2, _Lv2);
+
+        // This is the biggest bottleneck
+        __m512i _Sv1 = _mm512_i32gather_epi32(_masked1, (int *)&s3F[0][0],
+                                              sizeof(s3F[0][0]));
+        __m512i _Sv2 = _mm512_i32gather_epi32(_masked2, (int *)&s3F[0][0],
+                                              sizeof(s3F[0][0]));
         // SIMD version ends decoding early as it reads at most 64 bytes
         // from input via 4 vectorised loads.
         isz4 -= 64;
         for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
-            // m[z] = R[z] & mask;
-            __m512i _masked1 = _mm512_and_si512(_Rv1, _maskv);
-            __m512i _masked2 = _mm512_and_si512(_Rv2, _maskv);
-
-            //  S[z] = s3[lN[z]][m[z]];
-            _Lv1 = _mm512_slli_epi32(_Lv1, TF_SHIFT_O1_FAST);
-            _Lv2 = _mm512_slli_epi32(_Lv2, TF_SHIFT_O1_FAST);
-
-            _masked1 = _mm512_add_epi32(_masked1, _Lv1);
-            _masked2 = _mm512_add_epi32(_masked2, _Lv2);
-
-            // This is the biggest bottleneck
-            __m512i _Sv1 = _mm512_i32gather_epi32(_masked1, (int *)&s3F[0][0],
-                                                  sizeof(s3F[0][0]));
-            __m512i _Sv2 = _mm512_i32gather_epi32(_masked2, (int *)&s3F[0][0],
-                                                  sizeof(s3F[0][0]));
-
             //  f[z] = S[z]>>(TF_SHIFT_O1+8);
             __m512i _fv1 = _mm512_srli_epi32(_Sv1, TF_SHIFT_O1_FAST+8);
             __m512i _fv2 = _mm512_srli_epi32(_Sv2, TF_SHIFT_O1_FAST+8);
@@ -987,10 +1040,36 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
                 (_mm256_loadu_si256((const __m256i *)sp));
             sp += _mm_popcnt_u32(_imask2);
 
+            const __m512i m16 = _mm512_set1_epi32(0xffff);
+
             __m512i _renorm_vals1 =
-                _mm512_maskz_expand_epi32(_imask1, renorm_words1);
+                _mm512_mask_expand_epi32(_Rv1, _imask1, renorm_words1);
             __m512i _renorm_vals2 =
-                _mm512_maskz_expand_epi32(_imask2, renorm_words2);
+                _mm512_mask_expand_epi32(_Rv2, _imask2, renorm_words2);
+
+            _masked1 = _mm512_and_epi32(_renorm_vals1, _maskv);
+            _masked2 = _mm512_and_epi32(_renorm_vals2, _maskv);
+
+            _renorm_vals1 = _mm512_maskz_and_epi32(_imask1, _renorm_vals1,m16);
+            _renorm_vals2 = _mm512_maskz_and_epi32(_imask2, _renorm_vals2,m16);
+
+            //         Orig-I New-I   Orig-A New-A
+            // gcc7       672 699        930 934
+            // gcc13      690 684        880 967
+            // clang13    653 652        923 957
+
+            if (iN[0]+1 < isz4) {
+              _Lv1 = _mm512_slli_epi32(_Lv1, TF_SHIFT_O1_FAST);
+              _Lv2 = _mm512_slli_epi32(_Lv2, TF_SHIFT_O1_FAST);
+
+              _masked1 = _mm512_add_epi32(_masked1, _Lv1);
+              _masked2 = _mm512_add_epi32(_masked2, _Lv2);
+
+              _Sv1 = _mm512_i32gather_epi32(_masked1, (int *)&s3F[0][0],
+                                            sizeof(s3F[0][0]));
+              _Sv2 = _mm512_i32gather_epi32(_masked2, (int *)&s3F[0][0],
+                                            sizeof(s3F[0][0]));
+            }
 
             _Rv1 = _mm512_mask_slli_epi32(_Rv1, _imask1, _Rv1, 16);
             _Rv2 = _mm512_mask_slli_epi32(_Rv2, _imask2, _Rv2, 16);
@@ -998,17 +1077,17 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
             _Rv1 = _mm512_add_epi32(_Rv1, _renorm_vals1);
             _Rv2 = _mm512_add_epi32(_Rv2, _renorm_vals2);
 
+            iN[0]++;
 #ifdef TBUF8
             _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][0]),
-                             _mm512_cvtepi32_epi8(_Sv1)); // or _sv1?
+                             _mm512_cvtepi32_epi8(_sv1)); // or _sv1?
             _mm_storeu_si128((__m128i *)(&u.tbuf64[tidx][2]),
-                             _mm512_cvtepi32_epi8(_Sv2));
+                             _mm512_cvtepi32_epi8(_sv2));
 #else
             _mm512_storeu_si512((__m512i *)(&tbuf[tidx][ 0]), _sv1);
             _mm512_storeu_si512((__m512i *)(&tbuf[tidx][16]), _sv2);
 #endif
 
-            iN[0]++;
             if (++tidx == 32) {
                 iN[0]-=32;
 #ifdef TBUF8

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -992,7 +992,12 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
         return rans_uncompress_O1_32x16;
     } else {
 #if defined(HAVE_AVX512)
+#if defined(__clang__)
+        // Clang's AVX2 implementation decodes faster than AVX512
         if (have_avx512f && (!is_amd || !have_avx2))
+#else
+        if (have_avx512f)
+#endif
             return rans_uncompress_O0_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)


### PR DESCRIPTION
The main speed increase here is to the AVX512 implementation, specifically focusing on improving gathers on systems with long delays, but there have also been some tweaks to AVX2 encoder too.

The impetus for this patch was coping better on AMD Zen4.  It's no longer true that the AVX2 decoder outperforms the AVX512 one (although the encoder still does as I haven't investigated that much yet).  The exception is with clang (especially clang13) where the AVX2 decoder runs very fast - way faster than gcc will produce too.  This brings it ahead of the AVX512 code under clang.

I've yet to work out how clang is getting this speed, and how we can exploit that for other compilers.  It's likely instruction reordering or choosing different intrinsic implementations.