### PR TITLE
Add tab_size void cast to silence compiler warning

### DIFF
--- a/htscodecs/rANS_static16_int.h
+++ b/htscodecs/rANS_static16_int.h
@@ -415,6 +415,7 @@ static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
 
     tab_size = cp - out;
     assert(tab_size < 257*257*3);
+    (void) tab_size; // silence compiler warnings about unused variable
 
     *cp_p = cp;
     htscodecs_tls_free(F);


### PR DESCRIPTION
PR for https://github.com/samtools/htscodecs/issues/93

The commit is based on [htscodecs@11b5007](https://github.com/samtools/htscodecs/tree/11b5007ffb68bea9f6c777874a215e4187ce659a), which is the commit that the htscodecs submodule in [htslib](https://github.com/samtools/htslib/tree/5acbc150b2c12ea77111d845c06179507df976ae) is currently set to. Might need rebasing, as the master branch here does not seem to have that unused variable issue.