### PR TITLE
Downfall mitigation via simulated gathers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,32 @@ separate entity.  If you are attempting to make use of these codecs
 within your own library, such as we do within Staden io_lib, it may be
 useful to configure this with `--disable-shared --with-pic'.
 
+Intel GDS/Downfall
+------------------
+
+The new Intel microcode to patch the Gather Data Sampling (GDS) bug
+has severely impacted the performance of the AVX2 and AVX512 gather
+SIMD intrinsics.  So much so that simulating vector gather
+instructions using traditional scalar code is now more performant.
+Due to the slower AVX512 gathers on AMD Zen4, the simulated gather
+code is faster there too, even without having a Downfall mitigation.
+
+Unfortunately this simulated code is slower than the original gather
+code when run on an unpatched CPUs.  Without the GDS microcode patch
+on Intel CPUs, the simulated gathers slows the rate of decode by
+10-30% and the rate of encode for AVX512 by up to 50%.  The GDS
+microcode patch however can slow AVX2 decode and AVX512 encode by
+2-3x.
+
+Ideally we would auto-detect and select the optimal algorithm, but the
+easy solution is simply to pick the method with the most uniform
+performance without having bad worst-case rates.
+
+Hence by default the simulated gather implementation is now the
+default.  The old code can be reenabled by building with:
+
+    make CPPFLAGS=-DUSE_GATHER
+
 
 Testing
 -------

--- a/htscodecs/rANS_static16_int.h
+++ b/htscodecs/rANS_static16_int.h
@@ -537,15 +537,13 @@ static inline int decode_freq1(uint8_t *cp, uint8_t *cp_end, int shift,
 
 // Build s3 symbol lookup table.
 // This is 12 bit freq, 12 bit bias and 8 bit symbol.
-static inline int rans_F_to_s3(uint32_t *F, int shift, uint32_t *s3) {
-    int j, x, y;
+static inline int rans_F_to_s3(const uint32_t *F, int shift, uint32_t *s3) {
+    int j, x;
     for (j = x = 0; j < 256; j++) {
-        if (F[j]) {
-            if (F[j] > (1<<shift) - x)
-                return 1;
-            for (y = 0; y < F[j]; y++)
-                s3[y+x] = (((uint32_t)F[j])<<(shift+8))|(y<<8)|j;
-            x += F[j];
+        if (F[j] && F[j] <= (1<<shift) - x) {
+            uint32_t base = (((uint32_t)F[j])<<(shift+8))|j, y;
+            for (y = 0; y < F[j]; y++, x++)
+                s3[x] = base + (y<<8);
         }
     }
 

--- a/htscodecs/rANS_static32x16pr_avx2.c
+++ b/htscodecs/rANS_static32x16pr_avx2.c
@@ -766,6 +766,23 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
 
     uint16_t *ptr16 = (uint16_t *)ptr;
 
+// (AMD)   8  16  32  64 128 256
+// Clang 265 284 292 298 305 304
+// gcc13 300 320 326 327 320 305
+// gcc7  298 320 327 331 325 315
+#define BATCH 64     //^
+    uint8_t t32[BATCH][32] __attribute__((aligned(64)));
+    int next_batch;
+    if (iN[0] > BATCH) {
+        int i, j;
+        for (i = 0; i < BATCH; i++)
+            for (j = 0; j < 32; j++)
+                t32[BATCH-1-i][j] = in[iN[j]-i];
+        next_batch = BATCH;
+    } else {
+        next_batch = -1;
+    }
+
     LOAD(Rv, ransN);
 
     for (; iN[0] >= 0; ) {
@@ -799,58 +816,85 @@ unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_si
         // [2] B2......
         // [3] ......B3  OR to get B2B1B0B3 and shuffle to B3B2B1B0
 
+        unsigned char new_sym[32], *new_symp;
+
+        if (next_batch >= 0) {
+            if (--next_batch <= 0 && iN[0] > BATCH) {
+                int i, j;
+                uint8_t c[32][BATCH];
+                for (j = 0; j < 32; j++)
+                    memcpy(c[j], &in[iN[j]-BATCH+1], BATCH);
+
+                // transpose matrix
+                for (j = 0; j < 32; j++) {
+                    for (i = 0; i < BATCH; i+=16) {
+                        //uint8_t (*t32_i)[32] = &t32[i];
+                        //uint8_t *cji = &c[j][i];
+                        for (int z = 0; z < 16; z++)
+                            t32[i+z][j] = c[j][i+z];
+                            //t32_i[z][j] = cji[z]; // not necessary
+                    }
+                }
+                next_batch = BATCH-1;
+            }
+            new_symp = t32[next_batch];
+        }
+        if (next_batch < 0) {
+            new_symp = new_sym;
+            for (z = 0; z < 32; z++)
+                new_sym[z] = in[iN[z]];
+        }
+
         __m256i sh[16];
         for (z = 0; z < 16; z+=4) {
             int Z = z*2;
 
 #define m128_to_256 _mm256_castsi128_si256
-            __m256i t0, t1, t2, t3;
-            __m128i *s0, *s1, *s2, *s3;
-            s0 = (__m128i *)(&syms[in[iN[Z+0]]][lN[Z+0]]);
-            s1 = (__m128i *)(&syms[in[iN[Z+4]]][lN[Z+4]]);
-            s2 = (__m128i *)(&syms[in[iN[Z+1]]][lN[Z+1]]);
-            s3 = (__m128i *)(&syms[in[iN[Z+5]]][lN[Z+5]]);
+            __m256i t0, t1, t2, t3, t4, t5, t6, t7;
+            __m128i *s0, *s1, *s2, *s3, *s4, *s5, *s6, *s7;
 
-            t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0xE4);
-            t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0xE4);
-            t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x93);
-            t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x93);
+            s0 = (__m128i *)(&syms[new_symp[Z+0]][lN[Z+0]]);
+            s1 = (__m128i *)(&syms[new_symp[Z+4]][lN[Z+4]]);
+            s2 = (__m128i *)(&syms[new_symp[Z+1]][lN[Z+1]]);
+            s3 = (__m128i *)(&syms[new_symp[Z+5]][lN[Z+5]]);
+            s4 = (__m128i *)(&syms[new_symp[Z+2]][lN[Z+2]]);
+            s5 = (__m128i *)(&syms[new_symp[Z+6]][lN[Z+6]]);
+            s6 = (__m128i *)(&syms[new_symp[Z+3]][lN[Z+3]]);
+            s7 = (__m128i *)(&syms[new_symp[Z+7]][lN[Z+7]]);
 
-            lN[Z+0] = in[iN[Z+0]];
-            lN[Z+4] = in[iN[Z+4]];
-            lN[Z+1] = in[iN[Z+1]];
-            lN[Z+5] = in[iN[Z+5]];
+            __m256i M0 = m128_to_256(_mm_loadu_si128(s0));
+            __m256i M1 = m128_to_256(_mm_loadu_si128(s1));
+            __m256i M2 = m128_to_256(_mm_loadu_si128(s2));
+            __m256i M3 = m128_to_256(_mm_loadu_si128(s3));
+            __m256i M4 = m128_to_256(_mm_loadu_si128(s4));
+            __m256i M5 = m128_to_256(_mm_loadu_si128(s5));
+            __m256i M6 = m128_to_256(_mm_loadu_si128(s6));
+            __m256i M7 = m128_to_256(_mm_loadu_si128(s7));
+
+            t0 = _mm256_shuffle_epi32(M0, 0xE4);
+            t1 = _mm256_shuffle_epi32(M1, 0xE4);
+            t2 = _mm256_shuffle_epi32(M2, 0x93);
+            t3 = _mm256_shuffle_epi32(M3, 0x93);
+            t4 = _mm256_shuffle_epi32(M4, 0x4E);
+            t5 = _mm256_shuffle_epi32(M5, 0x4E);
+            t6 = _mm256_shuffle_epi32(M6, 0x39);
+            t7 = _mm256_shuffle_epi32(M7, 0x39);
 
             sh[z+0] = _mm256_permute2x128_si256(t0, t1, 0x20);
             sh[z+1] = _mm256_permute2x128_si256(t2, t3, 0x20);
-
-            s0 = (__m128i *)(&syms[in[iN[Z+2]]][lN[Z+2]]);
-            s1 = (__m128i *)(&syms[in[iN[Z+6]]][lN[Z+6]]);
-            s2 = (__m128i *)(&syms[in[iN[Z+3]]][lN[Z+3]]);
-            s3 = (__m128i *)(&syms[in[iN[Z+7]]][lN[Z+7]]);
-
-            t0 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s0)), 0x4E);
-            t1 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s1)), 0x4E);
-            t2 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s2)), 0x39);
-            t3 = _mm256_shuffle_epi32(m128_to_256(_mm_loadu_si128(s3)), 0x39);
-
-            lN[Z+2] = in[iN[Z+2]];
-            lN[Z+6] = in[iN[Z+6]];
-            lN[Z+3] = in[iN[Z+3]];
-            lN[Z+7] = in[iN[Z+7]];
-
-            sh[z+2] = _mm256_permute2x128_si256(t0, t1, 0x20);
-            sh[z+3] = _mm256_permute2x128_si256(t2, t3, 0x20);
+            sh[z+2] = _mm256_permute2x128_si256(t4, t5, 0x20);
+            sh[z+3] = _mm256_permute2x128_si256(t6, t7, 0x20);
 
             // potential to set xmax, rf, bias, and SD in-situ here, removing
             // the need to hold sh[] in regs.  Doing so doesn't seem to speed
             // things up though.
         }
+        memcpy(lN, new_symp, 32);
 
-        __m256i xA = _mm256_set_epi32(0,0,0,-1, 0,0,0,-1);
-        __m256i xB = _mm256_set_epi32(0,0,-1,0, 0,0,-1,0);
-        __m256i xC = _mm256_set_epi32(0,-1,0,0, 0,-1,0,0);
-        __m256i xD = _mm256_set_epi32(-1,0,0,0, -1,0,0,0);
+        const __m256i xA = _mm256_set_epi32(0,0,0,-1, 0,0,0,-1);
+        const __m256i xB = _mm256_set_epi32(0,0,-1,0, 0,0,-1,0);
+        const __m256i xC = _mm256_set_epi32(0,-1,0,0, 0,-1,0,0);
+        const __m256i xD = _mm256_set_epi32(-1,0,0,0, -1,0,0,0);
 
         // Extract 32-bit xmax elements from syms[] data (in sh vec array)
         __m256i xmax1 = SYM_LOAD( 0, xA, xB, xC, xD);

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -930,7 +930,7 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
 #ifdef USE_GATHER
         use_gather = 1;
 #else
-        use_gather = !have_avx2;
+        use_gather = !have_e_avx2;
 #endif
 
 #if defined(HAVE_AVX512)


### PR DESCRIPTION
Also incorporates the old #92.

Intel Downfall / GDS security flaw caused the issue of an updated microcode to mitigate the problem.  Unfortunately the consequence of this is that SIMD gather instructions are now considerably slower, particularly AVX2.  So much so that it turns out saving the SIMD register to memory, using traditional scalar code to do the memory fetches one at a time and then loading those scalar fetches back into the SIMD register, is *considerably* faster than the AVX2 gather microcode instruction.  The mind boggles, but there we are.  As it turns out I was already exploring these sort of things for AMD Zen4 too as that has (had) a far slower gather instruction than Intel.

We could do on-the-fly measurements and work out how far the gather is, so we know whether to use a simulated one or a real one, but it's muddled somewhat as the scalar code consists of many instructions which can get reordered by the compiler, so how efficient it is depends on the context.  Similarly with a single instruction, the cost of it depends on how many other instructions we can do while waiting on the result - whether we can hide the instruction latency basically.

For now, I've disabled real gathers entirely, but they can be reenabled using `-DUSE_GATHER` cpp define.

The plot below shows the speed for an Intel CascadeLake CPU with the microcode patch applied, booted as-is and with the "mitigations=off" linux kernel parameter.  (That turns off spectre and meltdown too, but I've also benchmarked the simulated code with/without mitigations and demonstrated it's not impacted.)

![image](https://github.com/samtools/htscodecs/assets/2210525/dfb3e700-c15f-4282-934c-0bb53d17a7bf)

Some comments:

0. All values are *rates* in MB/s, so higher is better.  Blue is encode, using the left Y axis.  Green is decode, using the right Y axis.
1. master-on and master-off are mitigations=on and mitigations=off with the master branch, using actual SIMD gathers.  SimG-on is simulated gathers, with mitigations=on (ie Downfall bug fixed).
2. We see for AVX2 encode speed is unaffected, but with AVX512 we do get an encode performance hit.  Both have decode performance hits, but AVX2 more so.
3. This PR (SimG-on) rescues most of the speed lost for AVX2.
4. This PR rescues *some* of the speed for AVX512, but it's quite challenging, particularly AVX512 order-1 encode.
5. If AVX512 is slower than AVX2, we don't have to use it.  We already had logic for that with AMD, so this has been extended.  Hence AVX512 slow encodes are mostly mitigated by using the AVX2 encoder.

With that final mitigation in place, the performance hit by using simulated gathers over actual gathers on an Intel machine without the new microcode (master=off) is in the 10-20% bracket.  That's probably acceptable, given the performance loss of not changing this code could be 65% (2.2x slower for AVX2 decode).

Also included below is the same system compiled using gcc 13.

![image](https://github.com/samtools/htscodecs/assets/2210525/3f73d4b1-e53a-4a0a-8fb7-950515afa5ce)


I'll produce some AMD Zen4 (Genoa) plots soon.