### PR TITLE
Chandak overflow

### DIFF
--- a/htscodecs/c_range_coder.h
+++ b/htscodecs/c_range_coder.h
@@ -31,13 +31,18 @@ typedef struct {
     uc *in_buf;
     uc *out_buf;
     uc *in_end;
+    uc *out_end;
+    int err;
 } RangeCoder;
 
 static inline void RC_SetInput(RangeCoder *rc, char *in, char *in_end) {
     rc->out_buf = rc->in_buf = (uc *)in;
     rc->in_end = (uc *)in_end;
 }
-static inline void RC_SetOutput(RangeCoder *rc, char *out) { rc->in_buf = rc->out_buf = (uc *)out; }
+
+// NB: call RC_SetOutput first, and then RC_SetOutputEnd
+static inline void RC_SetOutput(RangeCoder *rc, char *out) { rc->in_buf = rc->out_buf = (uc *)out; rc->out_end = NULL;}
+static inline void RC_SetOutputEnd(RangeCoder *rc, char *out_end) { rc->out_end = (uc *)out_end; }
 static inline char *RC_GetInput(RangeCoder *rc) { return (char *)rc->in_buf; }
 static inline char *RC_GetOutput(RangeCoder *rc) { return (char *)rc->out_buf; }
 static inline size_t RC_OutSize(RangeCoder *rc) { return rc->out_buf - rc->in_buf; }
@@ -51,6 +56,7 @@ static inline void RC_StartEncode(RangeCoder *rc)
     rc->Carry = 0;
     rc->Cache = 0;
     rc->code  = 0;
+    rc->err   = 0;
 }
 
 static inline void RC_StartDecode(RangeCoder *rc)
@@ -61,11 +67,37 @@ static inline void RC_StartDecode(RangeCoder *rc)
     rc->Carry = 0;
     rc->Cache = 0;
     rc->code  = 0;
+    rc->err   = 0;
     if (rc->in_buf+5 > rc->in_end) {
         rc->in_buf = rc->in_end; // prevent decode
         return;
     }
     DO(5) rc->code = (rc->code<<8) | *rc->in_buf++;
+}
+
+static inline void RC_ShiftLowCheck(RangeCoder *rc) {
+    if (rc->low < Thres || rc->Carry) {
+        if (rc->out_end && rc->FFNum >= rc->out_end - rc->out_buf) {
+            rc->err = -1;
+            return;
+        }
+
+        *rc->out_buf++ = rc->Cache + rc->Carry;
+
+        // Flush any stored FFs
+        while (rc->FFNum) {
+            *rc->out_buf++ = rc->Carry-1; // (Carry-1)&255;
+            rc->FFNum--;
+        }
+
+        // Take copy of top byte ready for next flush
+        rc->Cache = rc->low >> 24;
+        rc->Carry = 0;
+    } else {
+        // Low if FFxx xxxx.  Bump FF count and shift in as before
+        rc->FFNum++;
+    }
+    rc->low = rc->low<<8;
 }
 
 static inline void RC_ShiftLow(RangeCoder *rc) {
@@ -88,12 +120,15 @@ static inline void RC_ShiftLow(RangeCoder *rc) {
     rc->low = rc->low<<8;
 }
 
-static inline void RC_FinishEncode(RangeCoder *rc) 
+static inline int RC_FinishEncode(RangeCoder *rc)
 { 
-    DO(5) RC_ShiftLow(rc);
+    DO(5) RC_ShiftLowCheck(rc);
+    return rc->err;
 }
 
-static inline void RC_FinishDecode(RangeCoder *rc) {}
+static inline int RC_FinishDecode(RangeCoder *rc) {
+    return rc->err;
+}
 
 static inline void RC_Encode (RangeCoder *rc, uint32_t cumFreq, uint32_t freq, uint32_t totFreq) 
 {
@@ -105,7 +140,7 @@ static inline void RC_Encode (RangeCoder *rc, uint32_t cumFreq, uint32_t freq, u
 
     while (rc->range < TOP) {
         rc->range <<= 8;
-        RC_ShiftLow(rc);
+        RC_ShiftLowCheck(rc);
     }
 }
 
@@ -119,8 +154,10 @@ static inline void RC_Decode (RangeCoder *rc, uint32_t cumFreq, uint32_t freq, u
     rc->code -= cumFreq * rc->range;
     rc->range *= freq;
     while (rc->range < TOP) {
-        if (rc->in_buf >= rc->in_end)
-            return; // FIXME: could signal error, instead of caller just generating nonsense
+        if (rc->in_buf >= rc->in_end) {
+            rc->err = -1;
+            return;
+        }
         rc->code = (rc->code<<8) + *rc->in_buf++;
         rc->range <<= 8;
     }

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1468,10 +1468,16 @@ uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
 
     // Encode name
     for (i = j = 0; i < len; j=++i) {
-        while (i < len && blk[i] > '\n')
+        while (i < len && (signed char)blk[i] >= ' ') // non-ASCII check
             i++;
         if (i >= len)
             break;
+
+        if (blk[i] != '\0' && blk[i] != '\n') {
+            // Names must be 7-bit ASCII printable
+            free_context(ctx);
+            return NULL;
+        }
 
         blk[i] = '\0';
         // try both 0 and 1 and pick best?

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -756,6 +756,8 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
 
     for (; i < len; i++) {
         if (ntok >= ctx->max_tok) {
+            if (ctx->max_tok >= MAX_TOKENS)
+                return -1;
             memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
             memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
             memset(&ctx->token_icount[ctx->max_tok], 0, sizeof(int));
@@ -968,6 +970,8 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
     fprintf(stderr, "Tok %d (end)\n", N_END);
 #endif
     if (ntok >= ctx->max_tok) {
+        if (ctx->max_tok >= MAX_TOKENS)
+            return -1;
         memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
         memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
         memset(&ctx->token_icount[ctx->max_tok], 0, sizeof(int));

--- a/tests/tokenise_name3_test.c
+++ b/tests/tokenise_name3_test.c
@@ -146,6 +146,10 @@ static int encode(int argc, char **argv) {
             int out_len;
             uint8_t *out = tok3_encode_names(blk, len, level, use_arith,
                                              &out_len, &last_start);
+            if (!out) {
+                fprintf(stderr, "Couldn't encode names\n");
+                exit(1);
+            }
             if (write(1, &out_len, 4) < 4) exit(1);
             if (write(1, out, out_len) < out_len) exit(1);   // encoded data
             free(out);


### PR DESCRIPTION
Fixes a couple buffer overruns during encode in fqzcomp and name tokeniser.  Both codecs are primarily fuzzed with random input for decode, but encode matters a lot too.

The fqzcomp code failed when given an extreme case of 1 million 1bp reads.  The code incorrectly computed the worst case expansion by failing to account for (mainly) the 2-bits of average quality across the reads.  This has been fixed both in a revised buffer growth, but also by adding proper bounds checking to the range coder.

The name tokeniser failed when hitting 128 tokens due to a lack of checks in the encoder.  Could be triggered by a read name of 128 # symbols.

Thanks to @shubhamchandak94 for the bug report.