### PR TITLE
Remove divide by zero in rANS 4x8.

### DIFF
--- a/htscodecs/rANS_static.c
+++ b/htscodecs/rANS_static.c
@@ -96,7 +96,7 @@ unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
         free(out_buf);
         return NULL;
     }
-    tr = ((uint64_t)TOTFREQ<<31)/in_size + (1<<30)/in_size;
+    tr = in_size ? ((uint64_t)TOTFREQ<<31)/in_size + (1<<30)/in_size : 0;
 
  normalise_harder:
     // Normalise so T[i] == TOTFREQ

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1267,7 +1267,8 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
         out[0] = RANS_ORDER_CAT;
         c_meta_len = 1;
         c_meta_len += var_put_u32(&out[1], out_end, in_size);
-        memcpy(out+c_meta_len, in, in_size);
+        if (in_size)
+            memcpy(out+c_meta_len, in, in_size);
         *out_size = c_meta_len + in_size;
         return out;
     }
@@ -1380,7 +1381,8 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
     if (*out_size >= in_size) {
         out[0] &= ~3;
         out[0] |= RANS_ORDER_CAT | no_size;
-        memcpy(out+c_meta_len, in, in_size);
+        if (in_size)
+            memcpy(out+c_meta_len, in, in_size);
         *out_size = in_size;
     }
 

--- a/tests/arith_dynamic_test.c
+++ b/tests/arith_dynamic_test.c
@@ -266,12 +266,13 @@ int main(int argc, char **argv) {
                 bytes += out_size;
             }
         } else {
-            for (;;) {
+            int loop = 0;
+            for (;;loop++) {
                 uint32_t in_size, out_size;
                 unsigned char *out;
 
                 in_size = fread(in_buf, 1, BLK_SIZE, infp);
-                if (in_size <= 0)
+                if (loop && in_size <= 0)
                     break;
 
                 if (in_size < 4)

--- a/tests/rANS_static4x16pr_test.c
+++ b/tests/rANS_static4x16pr_test.c
@@ -309,12 +309,13 @@ int main(int argc, char **argv) {
                 bytes += out_size;
             }
         } else {
-            for (;;) {
+            int loop = 0;
+            for (;;loop++) {
                 uint32_t in_size, out_size;
                 unsigned char *out;
 
                 in_size = fread(in_buf, 1, blk_size, infp);
-                if (in_size <= 0)
+                if (loop && in_size <= 0)
                     break;
 
                 if (in_size < 4)

--- a/tests/rANS_static_test.c
+++ b/tests/rANS_static_test.c
@@ -259,12 +259,13 @@ int main(int argc, char **argv) {
                 bytes += out_size;
             }
         } else {
-            for (;;) {
+            int loop=0;
+            for (;;loop++) {
                 uint32_t in_size, out_size;
                 unsigned char *out;
 
                 in_size = fread(in_buf, 1, BLK_SIZE, infp);
-                if (in_size <= 0)
+                if (loop && in_size <= 0)
                     break;
 
                 out = rans_compress(in_buf, in_size, &out_size,


### PR DESCRIPTION
When given 0 bytes of input, we get a floating point exception in the code attempting to renormalise the frequencies.

The test harness can't trigger this case as 0 is EOF in the read loop, but that has been changed so a null file still calls the compression. Also tested the other entropy encoders, but they already coped fine.

Bug reported by Shubham Chandak