### PR TITLE
A mixture of fuzz-testing improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,11 +31,17 @@ tests/*.trs
 tests/.deps/
 tests/.libs/
 tests/arith_dynamic
+tests/arith_dynamic_fuzz
 tests/entropy
+tests/entropy_fuzz
 tests/fqzcomp_qual
+tests/fqzcomp_qual_fuzz
 tests/Makefile
 tests/rans4x16pr
+tests/rans4x16pr_fuzz
 tests/rans4x8
+tests/rans4x8_fuzz
 tests/test.out/
 tests/tokenise_name3
+tests/tokenise_name3_fuzz
 tests/varint

--- a/htscodecs/fqzcomp_qual.c
+++ b/htscodecs/fqzcomp_qual.c
@@ -911,7 +911,7 @@ int fqz_pick_parameters(fqz_gparams *gp,
         // NB: stab is already all zero
     }
 
-    if (gp->max_sel) {
+    if (gp->max_sel && s->num_records) {
         int max = 0;
         for (i = 0; i < s->num_records; i++) {
             if (max < (s->flags[i] >> 16))
@@ -1117,6 +1117,12 @@ unsigned char *compress_block_fqz2f(int vers,
 
     for (i = 0; i < in_size; i++) {
         if (state.p == 0) {
+            if (state.rec >= s->num_records || s->len[state.rec] <= 0) {
+                free(comp);
+                comp = NULL;
+                goto err;
+            }
+
             if (compress_new_read(s, &state, gp, pm, &model, &rc,
                                   in, &i, /*&rec,*/ &last))
                 continue;

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -822,13 +822,7 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
  */
 #include "rANS_static32x16pr.h"
 
-// Test interface for restricting the auto-detection methods so we
-// can forcibly compare different implementations on the same machine.
-// See RANS_CPU_ defines in rANS_static4x16.h
 static int rans_cpu = 0xFFFF; // all
-void rans_set_cpu(int opts) {
-    rans_cpu = opts;
-}
 
 #if (defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
 // Icc and Clang both also set __GNUC__ on linux, but not on Windows.
@@ -861,6 +855,7 @@ static int have_avx2    UNUSED = 0;
 static int have_avx512f UNUSED = 0;
 static int is_amd       UNUSED = 0;
 
+#define HAVE_HTSCODECS_TLS_CPU_INIT
 static void htscodecs_tls_cpu_init(void) {
     unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
     // These may be unused, depending on HAVE_* config.h macros
@@ -1122,6 +1117,16 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
 }
 
 #endif
+
+// Test interface for restricting the auto-detection methods so we
+// can forcibly compare different implementations on the same machine.
+// See RANS_CPU_ defines in rANS_static4x16.h
+void rans_set_cpu(int opts) {
+    rans_cpu = opts;
+#ifdef HAVE_HTSCODECS_TLS_CPU_INIT
+    htscodecs_tls_cpu_init();
+#endif
+}
 
 /*-----------------------------------------------------------------------------
  * Simple interface to the order-0 vs order-1 encoders and decoders.

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -887,10 +887,6 @@ static void htscodecs_tls_cpu_init(void) {
 
     if (!have_popcnt) have_avx512f = have_avx2 = have_sse4_1 = 0;
     if (!have_ssse3)  have_sse4_1 = 0;
-
-    if (!(rans_cpu & RANS_CPU_ENC_AVX512)) have_avx512f = 0;
-    if (!(rans_cpu & RANS_CPU_ENC_AVX2))   have_avx2 = 0;
-    if (!(rans_cpu & RANS_CPU_ENC_SSE4))   have_sse4_1 = 0;
 }
 
 static inline
@@ -899,6 +895,15 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
      unsigned int in_size,
      unsigned char *out,
      unsigned int *out_size) {
+
+    int have_e_sse4_1  = have_sse4_1;
+    int have_e_avx2    = have_avx2;
+    int have_e_avx512f = have_avx512f;
+
+    if (!(rans_cpu & RANS_CPU_ENC_AVX512)) have_e_avx512f = 0;
+    if (!(rans_cpu & RANS_CPU_ENC_AVX2))   have_e_avx2    = 0;
+    if (!(rans_cpu & RANS_CPU_ENC_SSE4))   have_e_sse4_1  = 0;
+
     if (!do_simd) { // SIMD disabled
         return order & 1
             ? rans_compress_O1_4x16
@@ -918,29 +923,29 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
 
     if (order & 1) {
 #if defined(HAVE_AVX512)
-        if (have_avx512f && (!is_amd || !have_avx2))
+        if (have_e_avx512f && (!is_amd || !have_e_avx2))
             return rans_compress_O1_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-        if (have_avx2)
+        if (have_e_avx2)
             return rans_compress_O1_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
-        if (have_sse4_1) 
+        if (have_e_sse4_1)
             return rans_compress_O1_32x16;
 #endif
         return rans_compress_O1_32x16;
     } else {
 #if defined(HAVE_AVX512)
-        if (have_avx512f && (!is_amd || !have_avx2))
+        if (have_e_avx512f && (!is_amd || !have_e_avx2))
             return rans_compress_O0_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-        if (have_avx2)
+        if (have_e_avx2)
             return rans_compress_O0_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
-        if (have_sse4_1)
+        if (have_e_sse4_1)
             return rans_compress_O0_32x16;
 #endif
         return rans_compress_O0_32x16;
@@ -953,6 +958,14 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
      unsigned int in_size,
      unsigned char *out,
      unsigned int out_size) {
+
+    int have_d_sse4_1  = have_sse4_1;
+    int have_d_avx2    = have_avx2;
+    int have_d_avx512f = have_avx512f;
+
+    if (!(rans_cpu & RANS_CPU_DEC_AVX512)) have_d_avx512f = 0;
+    if (!(rans_cpu & RANS_CPU_DEC_AVX2))   have_d_avx2    = 0;
+    if (!(rans_cpu & RANS_CPU_DEC_SSE4))   have_d_sse4_1  = 0;
 
     if (!do_simd) { // SIMD disabled
         return order & 1
@@ -973,29 +986,29 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
 
     if (order & 1) {
 #if defined(HAVE_AVX512)
-        if (have_avx512f)
+        if (have_d_avx512f)
             return rans_uncompress_O1_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-        if (have_avx2)
+        if (have_d_avx2)
             return rans_uncompress_O1_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
-        if (have_sse4_1)
+        if (have_d_sse4_1)
             return rans_uncompress_O1_32x16_sse4;
 #endif
         return rans_uncompress_O1_32x16;
     } else {
 #if defined(HAVE_AVX512)
-        if (have_avx512f && (!is_amd || !have_avx2))
+        if (have_d_avx512f && (!is_amd || !have_d_avx2))
             return rans_uncompress_O0_32x16_avx512;
 #endif
 #if defined(HAVE_AVX2)
-        if (have_avx2)
+        if (have_d_avx2)
             return rans_uncompress_O0_32x16_avx2;
 #endif
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
-        if (have_sse4_1)
+        if (have_d_sse4_1)
             return rans_uncompress_O0_32x16_sse4;
 #endif
         return rans_uncompress_O0_32x16;

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1176,9 +1176,10 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
 
     if (in_size <= 20)
         order &= ~RANS_ORDER_STRIPE;
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (in_size <= 1000)
         order &= ~RANS_ORDER_X32;
-
+#endif
     if (order & RANS_ORDER_STRIPE) {
         int N = (order>>8) & 0xff;
         if (N == 0) N = 4; // default for compatibility with old tests

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -88,7 +88,7 @@ fuzzer_ldadd   = $(top_builddir)/htscodecs/libcodecsfuzz.a \
 	$(top_builddir)/htscodecs/libcodecsfuzz_avx2.a \
 	$(top_builddir)/htscodecs/libcodecsfuzz_avx512.a
 
-EXTRA_PROGRAMS = rans4x8_fuzz rans4x16pr_fuzz arith_dynamic_fuzz tokenise_name3_fuzz fqzcomp_qual_fuzz
+EXTRA_PROGRAMS = rans4x8_fuzz rans4x16pr_fuzz arith_dynamic_fuzz tokenise_name3_fuzz fqzcomp_qual_fuzz entropy_fuzz
 rans4x8_fuzz_SOURCES = rANS_static_fuzz.c
 rans4x8_fuzz_CFLAGS  = $(fuzzer_cflags)
 rans4x8_fuzz_LDFLAGS = $(fuzzer_ldflags)
@@ -113,3 +113,8 @@ fqzcomp_qual_fuzz_SOURCES = fqzcomp_qual_fuzz.c
 fqzcomp_qual_fuzz_CFLAGS  = $(fuzzer_cflags)
 fqzcomp_qual_fuzz_LDFLAGS = $(fuzzer_ldflags)
 fqzcomp_qual_fuzz_LDADD   = $(fuzzer_ldadd)
+
+entropy_fuzz_SOURCES = entropy_fuzz.c
+entropy_fuzz_CFLAGS  = $(fuzzer_cflags)
+entropy_fuzz_LDFLAGS = $(fuzzer_ldflags)
+entropy_fuzz_LDADD   = $(fuzzer_ldadd)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -88,7 +88,16 @@ fuzzer_ldadd   = $(top_builddir)/htscodecs/libcodecsfuzz.a \
 	$(top_builddir)/htscodecs/libcodecsfuzz_avx2.a \
 	$(top_builddir)/htscodecs/libcodecsfuzz_avx512.a
 
-EXTRA_PROGRAMS = rans4x8_fuzz rans4x16pr_fuzz arith_dynamic_fuzz tokenise_name3_fuzz fqzcomp_qual_fuzz entropy_fuzz
+EXTRA_PROGRAMS = \
+	rans4x8_fuzz \
+	rans4x16pr_fuzz \
+	arith_dynamic_fuzz \
+	tokenise_name3_fuzz \
+	tokenise_name3_fuzzrt \
+	fqzcomp_qual_fuzz \
+	fqzcomp_qual_fuzzrt \
+	entropy_fuzz
+
 rans4x8_fuzz_SOURCES = rANS_static_fuzz.c
 rans4x8_fuzz_CFLAGS  = $(fuzzer_cflags)
 rans4x8_fuzz_LDFLAGS = $(fuzzer_ldflags)
@@ -109,6 +118,11 @@ tokenise_name3_fuzz_CFLAGS  = $(fuzzer_cflags)
 tokenise_name3_fuzz_LDFLAGS = $(fuzzer_ldflags)
 tokenise_name3_fuzz_LDADD   = $(fuzzer_ldadd)
 
+tokenise_name3_fuzzrt_SOURCES = tokenise_name3_fuzzrt.c
+tokenise_name3_fuzzrt_CFLAGS  = $(fuzzer_cflags)
+tokenise_name3_fuzzrt_LDFLAGS = $(fuzzer_ldflags)
+tokenise_name3_fuzzrt_LDADD   = $(fuzzer_ldadd)
+
 fqzcomp_qual_fuzz_SOURCES = fqzcomp_qual_fuzz.c
 fqzcomp_qual_fuzz_CFLAGS  = $(fuzzer_cflags)
 fqzcomp_qual_fuzz_LDFLAGS = $(fuzzer_ldflags)
@@ -118,3 +132,8 @@ entropy_fuzz_SOURCES = entropy_fuzz.c
 entropy_fuzz_CFLAGS  = $(fuzzer_cflags)
 entropy_fuzz_LDFLAGS = $(fuzzer_ldflags)
 entropy_fuzz_LDADD   = $(fuzzer_ldadd)
+
+fqzcomp_qual_fuzzrt_SOURCES = fqzcomp_qual_fuzzrt.c
+fqzcomp_qual_fuzzrt_CFLAGS  = $(fuzzer_cflags)
+fqzcomp_qual_fuzzrt_LDFLAGS = $(fuzzer_ldflags)
+fqzcomp_qual_fuzzrt_LDADD   = $(fuzzer_ldadd)

--- a/tests/entropy.c
+++ b/tests/entropy.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
     unsigned char *in = load(infp, &in_size);
     int order_a[] = {0,1,                            // r4x8
                      64,65, 128,129, 192,193,        // r4x16, arith
-                     4,5, 68,69, 132,133, 194,197,   // r4x16 SIMD
+                     4,5, 68,69, 132,133, 196,197,   // r4x16 SIMD
                      };
     char *codec[] = {"r4x8", "r4x16", "r32x16", "arith"};
     int i, j;

--- a/tests/entropy_fuzz.c
+++ b/tests/entropy_fuzz.c
@@ -1,0 +1,151 @@
+/* Fuzz testing target. */
+/*
+ * Copyright (c) 2022 Genome Research Ltd.
+ * Author(s): Rob Davies
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *
+ *    3. Neither the names Genome Research Ltd and Wellcome Trust Sanger
+ *       Institute nor the names of its contributors may be used to endorse
+ *       or promote products derived from this software without specific
+ *       prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY GENOME RESEARCH LTD AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL GENOME RESEARCH
+ * LTD OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <config.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <assert.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include "htscodecs/arith_dynamic.h"
+#include "htscodecs/rANS_static.h"
+#include "htscodecs/rANS_static4x16.h"
+#include "htscodecs/rANS_static32x16pr.h"
+
+int LLVMFuzzerTestOneInput(uint8_t *in, size_t in_size) {
+
+    const int order_a[] = {
+        0,1,        // No extras
+        0x40,041,   // RANS_ORDER_RLE
+        0x80,0x81,  // RANS_ORDER_PACK
+        0xc0,0xc1,  // RANS_ORDER_RLE|RANS_ORDER_PACK
+    };
+
+#if defined(__x86_64__)
+    const int cpu_enc_a[] = {
+        0, RANS_CPU_ENC_SSE4, RANS_CPU_ENC_AVX2, RANS_CPU_ENC_AVX512
+    };
+    const int cpu_dec_a[] = {
+        0, RANS_CPU_DEC_SSE4, RANS_CPU_DEC_AVX2, RANS_CPU_DEC_AVX512
+    };
+#elif defined(__ARM_NEON) && defined(__aarch64__)
+    const int cpu_enc_a[] = { 0, RANS_CPU_ENC_NEON };
+    const int cpu_dec_a[] = { 0, RANS_CPU_DEC_NEON };
+#else
+    const int cpu_enc_a[] = { 0 };
+    const int cpu_dec_a[] = { 0 };
+#endif
+    int i;
+
+    if (in_size > 200000)
+        return -1;
+
+    // rans_compress() only supports order 0 and 1
+    for (i = 0; i < 1; i++) {
+        uint8_t *comp, *uncomp;
+        uint32_t csize, usize;
+        comp = rans_compress(in, in_size, &csize, i);
+        if (!comp) abort();
+        uncomp = rans_uncompress(comp, csize, &usize);
+        if (!uncomp) abort();
+        if (usize != in_size) abort();
+        if (memcmp(uncomp, in, in_size) != 0) abort();
+        free(comp);
+        free(uncomp);
+    }
+
+    for (i = 0; i < sizeof(order_a) / sizeof(*order_a); i++) {
+        int order = order_a[i];
+        uint8_t *comp, *uncomp, *comp0 = NULL;
+        uint32_t csize, usize, csize0 = 0;
+        int c;
+        comp = rans_compress_4x16(in, in_size, &csize, order);
+        if (!comp) abort();
+        uncomp = rans_uncompress_4x16(comp, csize, &usize);
+        if (!uncomp) abort();
+        if (usize != in_size) abort();
+        if (memcmp(uncomp, in, in_size) != 0) abort();
+        free(comp);
+        free(uncomp);
+
+        comp = arith_compress(in, in_size, &csize, order);
+        if (!comp) abort();
+        uncomp = arith_uncompress(comp, csize, &usize);
+        if (!uncomp) abort();
+        if (usize != in_size) abort();
+        if (memcmp(uncomp, in, in_size) != 0) abort();
+        free(comp);
+        free(uncomp);
+        
+        // Check all SIMD variants for RANS_ORDER_X32
+        for (c = 0; c < sizeof(cpu_enc_a)/sizeof(*cpu_enc_a); c++) {
+            rans_set_cpu(cpu_enc_a[c]);
+            comp = rans_compress_4x16(in, in_size, &csize,
+                                      order | RANS_ORDER_X32);
+            if (!comp) abort();
+            if (comp0) {
+                if (csize != csize0 ||
+                    memcmp(comp0, comp, csize) != 0) {
+                    fprintf(stderr,
+                            "Compressed data mismatch order 0x%x cpu 0x%x\n",
+                            order, cpu_enc_a[c]);
+                    abort();
+                }
+                free(comp);
+            } else {
+                comp0 = comp;
+                csize0 = csize;
+            }
+        }
+        for (c = 0; c < sizeof(cpu_dec_a)/sizeof(*cpu_dec_a); c++) {
+            rans_set_cpu(cpu_dec_a[c]);
+            uncomp = rans_uncompress_4x16(comp0, csize0, &usize);
+            if (!uncomp) abort();
+            if (usize != in_size ||
+                memcmp(uncomp, in, in_size) != 0) {
+                fprintf(stderr,
+                        "Uncompressed data mismatch order 0x%x cpu 0x%x\n",
+                        order, cpu_dec_a[c]);
+                abort();
+            }
+            free(uncomp);
+        }
+        free(comp0);
+    }
+    return 0;
+}

--- a/tests/fqzcomp_qual_fuzzrt.c
+++ b/tests/fqzcomp_qual_fuzzrt.c
@@ -1,0 +1,137 @@
+/* Fuzz testing target. */
+/*
+ * Copyright (c) 2023 Genome Research Ltd.
+ * Author(s): James Bonfield
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *
+ *    2. Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ *
+ *    3. Neither the names Genome Research Ltd and Wellcome Trust Sanger
+ *       Institute nor the names of its contributors may be used to endorse
+ *       or promote products derived from this software without specific
+ *       prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY GENOME RESEARCH LTD AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL GENOME RESEARCH
+ * LTD OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "config.h"
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+#include <fcntl.h>
+#include <ctype.h>
+
+#include "htscodecs/fqzcomp_qual.h"
+
+#ifndef MAX_REC
+#define MAX_REC 5000
+#endif
+
+#ifndef MAX_SEQ
+#  define MAX_SEQ 5000
+#endif
+
+static unsigned int slice_len[MAX_REC];
+static unsigned int slice_flags[MAX_REC];
+
+static fqz_slice fixed_slice = {0};
+
+fqz_slice *fake_slice(size_t buf_len, int nrec) {
+    fixed_slice.len = slice_len;
+    fixed_slice.flags = slice_flags;
+    fixed_slice.num_records = nrec;
+
+    // 1 long record
+    if (nrec == 1) {
+	slice_len[0] = buf_len;
+	slice_flags[0] = 0; // FIXME
+	return &fixed_slice;
+    }
+
+    // N 1-byte records
+    if (nrec == buf_len) {
+	int i;
+	for (i = 0; i < buf_len; i++) {
+	    slice_len[i] = 1;
+	    slice_flags[i] = 0; // FIXME
+	}
+	return &fixed_slice;
+    }
+
+    // Otherwise variable length records
+
+    // Reproducability of randomness
+    int seed = rand();
+    srand(0);
+
+    int nlen = buf_len/10+1;
+    int i, l, n = 0;
+    for (i = 0; i < buf_len; i+=l, n++) {
+	l = rand() % (nlen+1);
+	l += l==0;
+	slice_len[n] = i+l < buf_len ? l : buf_len-i;
+	slice_flags[n] = 0; // FIXME
+    }
+    fixed_slice.num_records = n;
+
+    srand(seed); // new random state
+
+    return &fixed_slice;
+}
+
+int LLVMFuzzerTestOneInput(uint8_t *in, size_t in_size) {
+    size_t c_size, u_size;
+
+    int mode = 0;
+    for (mode = 0; mode < 3; mode++) {
+	int mval[3] = {0,1,in_size};
+	fqz_slice *s = fake_slice(in_size, mval[mode]);
+
+	// Semi random strat, but based on a few bits of input data
+	// for reproducability.
+	// This lets the fuzzer explore the parameter space itself.
+	int strat = in_size ? in[0] & 3 : 0;
+	char *comp = fqz_compress(3, s, (char *)in, in_size, &c_size,
+				  strat, NULL);
+	if (!comp) {
+	    fprintf(stderr, "REJECT FQZ %d to (null)n", (int)in_size);
+	    return -1;
+	}
+
+	char *uncomp = fqz_decompress(comp, c_size, &u_size, NULL, 0);
+	if (!uncomp)
+	    abort();
+
+	if (in_size != u_size)
+	    abort();
+
+	if (memcmp(uncomp, in, in_size) != 0)
+	    abort();
+    
+	free(comp);
+	free(uncomp);
+    }
+    
+    return 0;
+}

--- a/tests/tokenise_name3_fuzzrt.c
+++ b/tests/tokenise_name3_fuzzrt.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023 Genome Research Ltd.
+ * Author(s): James Bonfield
+ * 
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *    1. Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ * 
+ *    2. Redistributions in binary form must reproduce the above
+ *       copyright notice, this list of conditions and the following
+ *       disclaimer in the documentation and/or other materials provided
+ *       with the distribution.
+ * 
+ *    3. Neither the names Genome Research Ltd and Wellcome Trust Sanger
+ *    Institute nor the names of its contributors may be used to endorse
+ *    or promote products derived from this software without specific
+ *    prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY GENOME RESEARCH LTD AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL GENOME RESEARCH
+ * LTD OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Round-trip fuzz testing.  While tokenise_name3_fuzz.c tests the name
+// decoder when given random input, this tests it can encode and then
+// (if an error isn't reported) decode and get back the same content.
+//
+// It's complicated as we need to construct meta-data for how many names
+// we have.
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <limits.h>
+#include <ctype.h>
+#include <assert.h>
+#include <inttypes.h>
+#include <math.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <time.h>
+
+#include "htscodecs/tokenise_name3.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *in, size_t in_sz) {
+    int level, arith;
+    char in2[8192];
+
+    // 4096 is default max size for libfuzzer anyway
+    if (in_sz > 8192)
+	return -1;
+
+    // Turn newlines to nuls so we can do round-trip testing
+    // on multi-name data.
+    int i;
+    for (i = 0; i < in_sz; i++)
+	in2[i] = in[i] == '\n' ? 0 : in[i];
+    if (in_sz && in2[in_sz-1] > '\n')
+	in2[in_sz++] = 0;
+
+    for (arith = 0; arith < 2; arith++) {
+	for (level = 1; level <= 9; level += 8) { // 1 & 9 only
+	    int clen;
+	    uint8_t *cdat = tok3_encode_names((char *)in2, in_sz, level,
+					      arith, &clen, NULL);
+	    if (!cdat)
+		// skip this input from corpus as it's unparseable
+		return -1;
+
+	    uint32_t ulen;
+	    uint8_t *udat = tok3_decode_names(cdat, clen, &ulen);
+	    if (!udat || ulen != in_sz)
+		abort();
+
+	    if (memcmp(in2, udat, ulen) != 0)
+		abort();
+
+	    free(cdat);
+	    free(udat);
+	}
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
- Fix rans_set_cpu to work a second time.  This only really matters for test/entropy.
- Add a test/entropy_fuzz.c  (@daviesrob you'll want this commit as it has the Makefile work, but you may want to edit the entropy_fuzz.c file itself.  Mine is just a copy of entropy.c, which is working and finding bugs)
- Fix the rans_set_cpu to once again support different CPU types for encoder and decoder.  We do test every codec, but we accidentally lost this ability to have half and half, which affected cross-validation between codecs.
- Small typo fix in entropy.c where it wasn't using RLE+PACK+SIMD.