### PR TITLE
Fix tok3 decode bounds checking.

### DIFF
--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1685,7 +1685,7 @@ uint8_t *tok3_decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
     while (o < sz) {
         uint8_t ttype = in[o++];
         if (ttype & 64) {
-            if (o+2 >= sz) goto err;
+            if (o+2 > sz) goto err;
             int j = in[o++]<<4;
             j += in[o++];
             if (ttype & 128) {


### PR DESCRIPTION
We were one byte too short on our bounds checking, which meant a serialised data stream that ended with a duplicate token failed the "o+2 >= sz" check.

This could be reproduced with a pair of names "00x\n12\n".