### PR TITLE
Add cpuid checks behind an HAVE_CPUID check.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,6 +120,25 @@ AS_IF([test "$ax_cv_builtin_prefetch" = "yes"],
            [Define to 1 if you have a __builtin_prefetch])],
 	[])
 
+dnl Check is cpuid works, needed by rANS_static4x16pr.c
+AC_MSG_CHECKING(for cpuid support)
+AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([
+        #include <cpuid.h>
+        #include <stddef.h>
+    ], [
+        unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
+        int level = __get_cpuid_max(0, NULL);
+        if (level >= 1)
+            __cpuid_count(1, 0, eax, ebx, ecx, edx);
+    ])], [
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_CPUID, 1, [Set to 1 to use cpuid])
+    ], [
+        AC_MSG_RESULT(no)
+    ]
+)
+
 dnl AC_CHECK_LIB([lzma], [lzma_easy_buffer_encode], [
 dnl 	LIBS="-llzma $LIBS"
 dnl 	AC_DEFINE([HAVE_LIBLZMA],1,[Define to 1 if you have the liblzma library.])])

--- a/configure.ac
+++ b/configure.ac
@@ -120,24 +120,8 @@ AS_IF([test "$ax_cv_builtin_prefetch" = "yes"],
            [Define to 1 if you have a __builtin_prefetch])],
 	[])
 
-dnl Check is cpuid works, needed by rANS_static4x16pr.c
-AC_MSG_CHECKING(for cpuid support)
-AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM([
-        #include <cpuid.h>
-        #include <stddef.h>
-    ], [
-        unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0;
-        int level = __get_cpuid_max(0, NULL);
-        if (level >= 1)
-            __cpuid_count(1, 0, eax, ebx, ecx, edx);
-    ])], [
-        AC_MSG_RESULT(yes)
-        AC_DEFINE(HAVE_CPUID, 1, [Set to 1 to use cpuid])
-    ], [
-        AC_MSG_RESULT(no)
-    ]
-)
+dnl Check is cpuid works, needed by rANS_static4x16pr.c.
+AC_CHECK_DECLS([__get_cpuid_max, __cpuid_count], [], [], [[#include <cpuid.h>]])
 
 dnl AC_CHECK_LIB([lzma], [lzma_easy_buffer_encode], [
 dnl 	LIBS="-llzma $LIBS"

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -824,7 +824,9 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
 
 static int rans_cpu = 0xFFFF; // all
 
-#if defined(__x86_64__) && defined(HAVE_CPUID)
+#if defined(__x86_64__) && \
+    defined(HAVE_DECL___CPUID_COUNT)   && HAVE_DECL___CPUID_COUNT && \
+    defined(HAVE_DECL___GET_CPUID_MAX) && HAVE_DECL___GET_CPUID_MAX
 #include <cpuid.h>
 
 #if defined(__clang__) && defined(__has_attribute)

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -824,8 +824,7 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
 
 static int rans_cpu = 0xFFFF; // all
 
-#if (defined(__GNUC__) || defined(__clang__)) && defined(__x86_64__)
-// Icc and Clang both also set __GNUC__ on linux, but not on Windows.
+#if defined(__x86_64__) && defined(HAVE_CPUID)
 #include <cpuid.h>
 
 #if defined(__clang__) && defined(__has_attribute)


### PR DESCRIPTION
Fixes #115.

Testing compiler versions is tricky, especially given some vendors wrap up standard compilers as their own, but change version numbers (Apple, Intel) and compilers also often masquerade as another (eg setting GNUC).

Instead we just check if it links.  Note there's no guard around this here for x86-64, but that's done in the code itself.  (In theory we may have cpuid on another architecture that we wish to use at some point.)