### PR TITLE
Avoid disabled typedef in FreeBSD-specific code

### DIFF
--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1043,11 +1043,11 @@ static inline int have_neon(void) {
 #elif defined(__APPLE__)
     return 1;
 #elif defined(__FreeBSD__) && defined(__arm__)
-    u_long cap;
+    unsigned long cap;
     if (elf_aux_info(AT_HWCAP, &cap, sizeof cap) != 0) return 0;
     return (cap & HWCAP_NEON) != 0;
 #elif defined(__FreeBSD__) && defined(__aarch64__) && defined(HWCAP_ASIMD)
-    u_long cap;
+    unsigned long cap;
     if (elf_aux_info(AT_HWCAP, &cap, sizeof cap) != 0) return 0;
     return (cap & HWCAP_ASIMD) != 0;
 #elif defined(_WIN32)


### PR DESCRIPTION
Since 6dadc2a8d42d4d101b0bc96807147fce96fe0ddf / samtools/htslib#1628, this code is compiled with `_XOPEN_SOURCE` set, usually to 600.

Setting this causes FreeBSD's `<sys/types.h>` not to define these old BSD-style typenames such as `u_long`. Happily we can just write it out as the corresponding native type — fortunately [`u_long`'s definition](https://cgit.freebsd.org/src/blame/sys/sys/types.h#n48) has not changed in 30+ years…