### PR TITLE
Change the version of FreeBSD for cirrus-ci to 14.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ rocky_task:
 task:
   name: freebsd
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-1
 
   pkginstall_script:
     - pkg update -f


### PR DESCRIPTION
See https://cirrus-ci.org/guide/FreeBSD/ for the valid image names.