### PR TITLE
Seperate out tokens based on punctuation.

### DIFF
--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -765,7 +765,7 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
         }
 
         uint8_t first_char = (uint8_t)name[i]; 
-        if (ispunct(first_char) || isspace(first_char)) {
+        if (!isalnum(first_char)) {
             /* Treat punctuation as seperate tokens. */
             goto n_char;
         }
@@ -775,7 +775,7 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
         int token_is_number = 1;
         while (s < len) {
             uint8_t c = (uint8_t)name[s];
-            if (ispunct(c) || isspace(c)) {
+            if (!isalnum(c)) {
                 break;
             }
             if (!isdigit(c)) {

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -764,7 +764,8 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
             ctx->max_tok = ntok+1;
         }
 
-        if (ispunct((uint8_t)name[i])) {
+        uint8_t first_char = (uint8_t)name[i]; 
+        if (ispunct(first_char) || isspace(first_char)) {
             /* Treat punctuation as seperate tokens. */
             goto n_char;
         }
@@ -774,7 +775,7 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
         int token_is_number = 1;
         while (s < len) {
             uint8_t c = (uint8_t)name[s];
-            if (ispunct(c)) {
+            if (ispunct(c) || isspace(c)) {
                 break;
             }
             if (!isdigit(c)) {
@@ -784,7 +785,7 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
         }
         char *token = name + i;
         int token_length = s - i; 
-        int token_starts_with_zero = token[0] == '0';
+        int token_starts_with_zero = first_char == '0';
         uint32_t v = 0;
         if (token_is_number) {
             /* Do not encode larger numbers because of uint32_t limits */


### PR DESCRIPTION
See also #131 

A very simple change. Tokens are not determined by a sequence of similar characters but separated out by punctuation chars. The stretches in between are then classified as numbers or strings.

This change simplifies the code. It also allows for adding hexadecimal tokens at a later point in time. (If desired). 

Tested on the following files.
[10000_illumina_ids.txt](https://github.com/user-attachments/files/20083765/10000_illumina_ids.txt)
[10000_illumina_ids_simpler.txt](https://github.com/user-attachments/files/20083766/10000_illumina_ids_simpler.txt)
[10000_pacbio_revio_ids.txt](https://github.com/user-attachments/files/20083767/10000_pacbio_revio_ids.txt)
[10000uuid4.txt](https://github.com/user-attachments/files/20083768/10000uuid4.txt)

file | before | after
:-- | --: | --:
10000_illumina_ids.txt | 38846 | 38846
10000_illumina_ids_simpler.txt | 23080 | 23080
10000uuid4.txt | 242453 | 176373
10000_pacbio_revio_ids.txt | 35484 | 35223

