### PR TITLE
Bump CI FreeBSD image_family again, to 14.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -77,7 +77,7 @@ rocky_task:
 task:
   name: freebsd
   freebsd_instance:
-    image_family: freebsd-14-1
+    image_family: freebsd-14-2
 
   pkginstall_script:
     - pkg update -f

--- a/.github/workflows/unix-build.yml
+++ b/.github/workflows/unix-build.yml
@@ -9,11 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-    
-    defaults:
-      run:
-        shell: bash {0}
-
 
     steps:
     - name: Checkout

--- a/.github/workflows/unix-build.yml
+++ b/.github/workflows/unix-build.yml
@@ -32,6 +32,8 @@ jobs:
     - name: Ubuntu-latest using gcc with sanitizers
       if: runner.os == 'Linux'
       run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-suggests --no-install-recommends libbz2-dev
         autoreconf -i
         ./configure CC="gcc -fsanitize=address,undefined"
 


### PR DESCRIPTION
Followup to PR #129 — The freebsd-org-cloud-dev GCP project has now dropped freebsd-14-1-*. See also <https://cirrus-ci.org/guide/FreeBSD/> and its suggested `gcloud compute images list …` command.