### PR TITLE
UUID4 name tokeniser plus improvements to mixed data sets.

### DIFF
--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -610,12 +610,16 @@ int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, in
         prefix_len = 6;  // IonTorrent
         *fixed_len = 6;
         *is_fixed = 1;
-    } else if (l > 37 && d[f+8] == '-' && d[f+13] == '-' && d[f+18] == '-' && d[f+23] == '-' &&
-               ((d[f+0] >= '0' && d[f+0] <='9') || (d[f+0] >= 'a' && d[f+0] <= 'f')) &&
-               ((d[f+35] >= '0' && d[f+35] <='9') || (d[f+35] >= 'a' && d[f+35] <= 'f'))) {
+    } else if (l >= 36
+               && d[f+8]=='-' && d[f+13]=='-' && d[f+18]=='-' && d[f+23]=='-'
+               && isxdigit((uint8_t)d[f+0])  && isxdigit((uint8_t)d[f+7])
+               && isxdigit((uint8_t)d[f+9])  && isxdigit((uint8_t)d[f+12])
+               && isxdigit((uint8_t)d[f+14]) && isxdigit((uint8_t)d[f+17])
+               && isxdigit((uint8_t)d[f+19]) && isxdigit((uint8_t)d[f+22])
+               && isxdigit((uint8_t)d[f+24]) && isxdigit((uint8_t)d[f+35])) {
         // ONT: f33d30d5-6eb8-4115-8f46-154c2620a5da_Basecall_1D_template...
-        prefix_len = 37;
-        *fixed_len = 37;
+        prefix_len = 36;
+        *fixed_len = 36;
         *is_fixed = 1;
     } else {
         // Check Illumina and trim back to lane:tile:x:y.
@@ -638,7 +642,6 @@ int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, in
             *is_fixed = 0;
         }
     }
-    //prefix_len = INT_MAX;
 
     if (!ctx->t_head) {
         ctx->t_head = calloc(1, sizeof(*ctx->t_head));
@@ -647,6 +650,7 @@ int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, in
     }
 
     // Find an item in the trie
+    int from_punct = from;
     for (nlines = i = 0; i < len; i++, nlines++) {
         t = ctx->t_head;
         while (i < len && data[i] > '\n') {
@@ -661,16 +665,10 @@ int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, in
                 x = x->sibling;
             t = x;
 
-//          t = t->next[c];
-
-//          if (!t)
-//              return -1;
-
             from = t->n;
+            if ((ispunct(c) || isspace(c)) && t->n != n)
+                from_punct = t->n;
             if (i == prefix_len) p3 = t->n;
-            //if (t->count >= .0035*ctx->t_head->count && t->n != n) p3 = t->n; // pacbio
-            //if (i == 60) p3 = t->n; // pacbio
-            //if (i == 7) p3 = t->n; // iontorrent
             t->n = n;
         }
     }
@@ -678,7 +676,7 @@ int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, in
     //printf("Looked for %d, found %d, prefix %d\n", n, from, p3);
 
     *exact = (n != from) && len;
-    return *exact ? from : p3;
+    return *exact ? from : (p3 != -1 ? p3 : from_punct);
 }
 
 
@@ -731,17 +729,8 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
     encode_token_diff(ctx, cnum-pnum);
     int ntok = 1;
 
-    // Look for common form of UUID4 names and special case them
-    i = 0;
-    if (len == 36) {
-        for (i = 0; i < len; i++) {
-            if (!(isxdigit((uint8_t)name[i]) || name[i] == '-'))
-                break;
-        }
-    }
-
-    // Is uuid4 (eg ONT).
-    if (i == len) {
+    if (fixed_len == 36) {
+        // ONT uuid4 format data
         if (37 >= ctx->max_tok) {
             do {
                 memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
@@ -752,17 +741,15 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
 #ifdef ENC_DEBUG
         fprintf(stderr, "Tok %d (%d x uuid chr)", ntok, len);
 #endif
-        //encode_token_nop(ctx, ntok++);
-        for (i = 0; i < len; i++, ntok++) {
+        for (i = 0; i < 36; i++, ntok++) {
             encode_token_char(ctx, ntok, name[i]);
             ctx->lc[cnum].last[ntok].token_int = name[i];
             ctx->lc[cnum].last[ntok].token_type = N_CHAR;
         }
-        goto end;
-    }
-
-    i = 0;
-    if (is_fixed) {
+        is_fixed = 0;
+        i = 36;
+    } else if (is_fixed) {
+        // Other fixed length data
         if (ntok >= ctx->max_tok) {
             memset(&ctx->desc[ctx->max_tok << 4], 0, 16*sizeof(ctx->desc[0]));
             memset(&ctx->token_dcount[ctx->max_tok], 0, sizeof(int));
@@ -782,6 +769,8 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
         ctx->lc[cnum].last[ntok].token_str = 0;
         ctx->lc[cnum].last[ntok++].token_type = N_ALPHA;
         i = fixed_len;
+    } else {
+        i = 0;
     }
 
     for (; i < len; i++) {
@@ -997,7 +986,6 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
         //putchar(' ');
     }
 
- end:
 #ifdef ENC_DEBUG
     fprintf(stderr, "Tok %d (end)\n", N_END);
 #endif


### PR DESCRIPTION
1.  UUID4 improvements.

With this change on my local corpus:

```
htscodecs-corpus/names/01.names     169625
htscodecs-corpus/names/02.names     417607
htscodecs-corpus/names/03.names     49868
htscodecs-corpus/names/05.names     288460
htscodecs-corpus/names/08.names     42594
htscodecs-corpus/names/09.names     255867
htscodecs-corpus/names/10.names     307270
htscodecs-corpus/names/20.names     139707
htscodecs-corpus/names/_139.names   86966   *
htscodecs-corpus/names/_shuf.names  638699  *
htscodecs-corpus/names/nv.names     329535
htscodecs-corpus/names/nv2.names    87802
htscodecs-corpus/names/rr.names     91103
htscodecs-corpus/names/uuid4+.names 153556  *
htscodecs-corpus/names/uuid4.names  153439  *
```

Master:

```
htscodecs-corpus/names/01.names     169625
htscodecs-corpus/names/02.names     417607
htscodecs-corpus/names/03.names     49981
htscodecs-corpus/names/05.names     288460
htscodecs-corpus/names/08.names     42594
htscodecs-corpus/names/09.names     255867
htscodecs-corpus/names/10.names     307270
htscodecs-corpus/names/20.names     139707
htscodecs-corpus/names/_139.names   100798  *
htscodecs-corpus/names/_shuf.names  710366  *
htscodecs-corpus/names/nv.names     329535
htscodecs-corpus/names/nv2.names    87802
htscodecs-corpus/names/rr.names     91103
htscodecs-corpus/names/uuid4+.names 187560  *
htscodecs-corpus/names/uuid4.names  242453  *
```

For uuid4 see #132.  The difference between uuid4 and uuid4+ is the latter has "-flowcell-10" appended to every line.  The old code had explicit check for ONT UUIDs, but not bare ones without an extension, so it needed 37 chars and not 36.  Hence master compresses the data with "-flowcell-10" better than without.  Regardless of that however, both compress better still by using an array of CHAR tokens instead of separate string-char-string-char-... combinations (due to nuls).

2. The other change can be seen in _139.names (a mix of 5k names from 01, 03 and 09.names) and _shuf (a mix of all of them).  This still isn't optimal, but it's considerably closer.

We can demonstrate this easily with two names of foo:<num> and bar:<num> where <num> is +1 in foo and +1-16 in bar.  

```
perl -e '$b1=1;$b2=1;for ($i=0;$i<5000;$i++) {print "foo:$b1\n";print "bar:$b2\n";$b1++;$b2+=1+int(rand(16))}' > _
```

Theoretically foo should have no information per record other than the initial meta-data describing the format.
Bar however has 4 bits of ddelta offset per record, so has 2.5Kb of information to encode.  Mixing them should not increase the size as we are strictly alternating and the diff distance is a fixed -2.

We can do `cat _ | tokenise_name` vs `egrep foo _ | ...` and `egrep bar _ | ...` to validate the mixed vs separate names.
Master gives 13300, 86 and 2603 respectively.
This PR gives 2684, 86 and 2603 repsectively.

The change achieves this by improving the returned node rather than -1, which defaults to the previous record.  It was previously always delta bar against foo and foo against bar.