### PR TITLE
Rans4x16 frees and release v1.6.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+Release 1.6.3: 22nd May 2025
+----------------------------
+
+A tiny bug fix to 1.6.2 to fix a memory leak in rans_compress_to_4x16,
+detected by htslib's CI system. (#136)
+
+
 Release 1.6.2: 22nd May 2025
 ----------------------------
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(htscodecs, 1.6.2)
+AC_INIT(htscodecs, 1.6.3)
 
 # Some functions benefit from -O3 optimisation, so if the user didn't
 # explicitly set any compiler flags, we'll plump for O3.
@@ -61,7 +61,7 @@ AM_EXTRA_RECURSIVE_TARGETS([fuzz])
 #       libhtscodecs.so.1.1.0
 
 VERS_CURRENT=3
-VERS_REVISION=7
+VERS_REVISION=8
 VERS_AGE=1
 AC_SUBST(VERS_CURRENT)
 AC_SUBST(VERS_REVISION)

--- a/htscodecs/htscodecs.h
+++ b/htscodecs/htscodecs.h
@@ -43,7 +43,7 @@
  * Note currently this needs manually editing as it isn't automatically
  * updated by autoconf.
  */
-#define HTSCODECS_VERSION 100602
+#define HTSCODECS_VERSION 100603
 
 /*
  * A const string form of the HTSCODECS_VERSION define.

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1332,6 +1332,7 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
         c_meta_len += var_put_u32(&out[1], out_end, in_size);
 
         if (c_meta_len + in_size > *out_size) {
+            free(out_free);
             *out_size = 0;
             return NULL;
         }
@@ -1460,6 +1461,7 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
     }
 
     if (c_meta_len > *out_size) {
+        free(out_free);
         free(rle);
         free(packed);
         *out_size = 0;
@@ -1473,6 +1475,7 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
     }
 
     if (!rans_enc_func(do_simd, order)(in, in_size, out+c_meta_len, out_size)) {
+        free(out_free);
         free(rle);
         free(packed);
         *out_size = 0;
@@ -1484,6 +1487,7 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
         out[0] |= RANS_ORDER_CAT | no_size;
 
         if (out + c_meta_len + in_size > out_end) {
+            free(out_free);
             free(rle);
             free(packed);
             *out_size = 0;


### PR DESCRIPTION
I clearly need to improve the test harness to do things that are erroneous / don't fit, as somehow htslib is testing this code path.  It turns out #127 had a memory leak in it when recovering from rans encoding failure.

This PR doesn't add those tests, but it's noted for something I need to fix later.