### PR TITLE
Prevent use of unaligned uint16_t pointers

### DIFF
--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -222,20 +222,20 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
         SET512(xmax, SB);
 
         uint16_t gt_mask1 = _mm512_cmpgt_epi32_mask(Rv1, xmax1);
-        int pc1 = _mm_popcnt_u32(gt_mask1) * 2;
+        int pc1 = _mm_popcnt_u32(gt_mask1);
         __m512i Rp1 = _mm512_and_si512(Rv1, _mm512_set1_epi32(0xffff));
         __m512i Rp2 = _mm512_and_si512(Rv2, _mm512_set1_epi32(0xffff));
         uint16_t gt_mask2 = _mm512_cmpgt_epi32_mask(Rv2, xmax2);
         SET512(SDv,  SD);
-        int pc2 = _mm_popcnt_u32(gt_mask2) * 2;
+        int pc2 = _mm_popcnt_u32(gt_mask2);
 
         Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
         Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
 
-        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc2, pc2-1, Rp2);
-        ptr -= pc2;
-        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc1, pc1-1, Rp1);
-        ptr -= pc1;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc2*2, (1<<pc2)-1, Rp2);
+        ptr -= pc2*2;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc1*2, (1<<pc1)-1, Rp1);
+        ptr -= pc1*2;
 
         SET512(rfv,  SA);
         Rv1 = _mm512_mask_srli_epi32(Rv1, gt_mask1, Rv1, 16);
@@ -688,20 +688,20 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
         SET512x(xmax, x_max); // high latency
 
         uint16_t gt_mask1 = _mm512_cmpgt_epi32_mask(Rv1, xmax1);
-        int pc1 = _mm_popcnt_u32(gt_mask1) * 2;
+        int pc1 = _mm_popcnt_u32(gt_mask1);
         __m512i Rp1 = _mm512_and_si512(Rv1, _mm512_set1_epi32(0xffff));
         __m512i Rp2 = _mm512_and_si512(Rv2, _mm512_set1_epi32(0xffff));
         uint16_t gt_mask2 = _mm512_cmpgt_epi32_mask(Rv2, xmax2);
         SET512x(SDv, cmpl_freq); // good
-        int pc2 = _mm_popcnt_u32(gt_mask2) * 2;
+        int pc2 = _mm_popcnt_u32(gt_mask2);
 
         Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
         Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
 
-        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc2, pc2-1, Rp2);
-        ptr -= pc2;
-        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc1, pc1-1, Rp1);
-        ptr -= pc1;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc2*2, (1<<pc2)-1, Rp2);
+        ptr -= pc2*2;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc1*2, (1<<pc1)-1, Rp1);
+        ptr -= pc1*2;
 
         Rv1 = _mm512_mask_srli_epi32(Rv1, gt_mask1, Rv1, 16);
         Rv2 = _mm512_mask_srli_epi32(Rv2, gt_mask2, Rv2, 16);
@@ -1087,11 +1087,11 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
 
             __m512i renorm_words1 = _mm512_cvtepu16_epi32
                 (_mm256_loadu_si256((const __m256i *)sp));
-            sp += _mm_popcnt_u32(_imask1);
+            sp += _mm_popcnt_u32(_imask1) * 2;
 
             __m512i renorm_words2 = _mm512_cvtepu16_epi32
                 (_mm256_loadu_si256((const __m256i *)sp));
-            sp += _mm_popcnt_u32(_imask2);
+            sp += _mm_popcnt_u32(_imask2) * 2;
 
             __m512i _renorm_vals1 =
                 _mm512_maskz_expand_epi32(_imask1, renorm_words1);

--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -204,7 +204,6 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
 
     LOAD512(Rv, ransN);
 
-    uint16_t *ptr16 = (uint16_t *)ptr;
     for (i=(in_size &~(32-1)); i>0; i-=32) {
         uint8_t *c = &in[i-32];
 
@@ -223,20 +222,20 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
         SET512(xmax, SB);
 
         uint16_t gt_mask1 = _mm512_cmpgt_epi32_mask(Rv1, xmax1);
-        int pc1 = _mm_popcnt_u32(gt_mask1);
+        int pc1 = _mm_popcnt_u32(gt_mask1) * 2;
         __m512i Rp1 = _mm512_and_si512(Rv1, _mm512_set1_epi32(0xffff));
         __m512i Rp2 = _mm512_and_si512(Rv2, _mm512_set1_epi32(0xffff));
         uint16_t gt_mask2 = _mm512_cmpgt_epi32_mask(Rv2, xmax2);
         SET512(SDv,  SD);
-        int pc2 = _mm_popcnt_u32(gt_mask2);
+        int pc2 = _mm_popcnt_u32(gt_mask2) * 2;
 
         Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
         Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
 
-        _mm512_mask_cvtepi32_storeu_epi16(ptr16-pc2, (1<<pc2)-1, Rp2);
-        ptr16 -= pc2;
-        _mm512_mask_cvtepi32_storeu_epi16(ptr16-pc1, (1<<pc1)-1, Rp1);
-        ptr16 -= pc1;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc2, pc2-1, Rp2);
+        ptr -= pc2;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc1, pc1-1, Rp1);
+        ptr -= pc1;
 
         SET512(rfv,  SA);
         Rv1 = _mm512_mask_srli_epi32(Rv1, gt_mask1, Rv1, 16);
@@ -299,7 +298,6 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
         qv2 = _mm512_add_epi32(qv2, biasv2);
         Rv2 = _mm512_add_epi32(Rv2, qv2);
     }
-    ptr = (uint8_t *)ptr16;
     STORE512(Rv, ransN);
 
     for (z = 32-1; z >= 0; z--)
@@ -359,7 +357,7 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
             goto err;
     }
 
-    uint16_t *sp = (uint16_t *)cp;
+    uint8_t *sp = cp;
 
     int out_end = (out_sz&~(32-1));
     const uint32_t mask = (1u << TF_SHIFT)-1;
@@ -381,9 +379,9 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
 
       // Protect against running off the end of in buffer.
       // We copy it to a worst-case local buffer when near the end.
-      if ((uint8_t *)sp+64 > cp_end) {
-        memmove(overflow, sp, cp_end - (uint8_t *)sp);
-        sp = (uint16_t *)overflow;
+      if (cp_end - sp < 64) {
+        memmove(overflow, sp, cp_end - sp);
+        sp = overflow;
         cp_end = overflow + sizeof(overflow);
       }
 
@@ -410,7 +408,7 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
       // renorm. this is the interesting part:
       renorm_mask2=_mm512_cmplt_epu32_mask(R2, _mm512_set1_epi32(RANS_BYTE_L));
       // advance by however many words we actually read
-      sp += _mm_popcnt_u32(renorm_mask1);
+      sp += _mm_popcnt_u32(renorm_mask1) * 2;
       __m512i renorm_words2 = _mm512_cvtepu16_epi32(_mm256_loadu_si256(
                                       (const __m256i *)sp));
 
@@ -440,7 +438,7 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
       renorm_vals2 = _mm512_maskz_and_epi32(renorm_mask2, renorm_vals2, m16);
 
       // advance by however many words we actually read
-      sp += _mm_popcnt_u32(renorm_mask2);
+      sp += _mm_popcnt_u32(renorm_mask2) * 2;
 
       R1 = _mm512_add_epi32(R1, renorm_vals1);
       R2 = _mm512_add_epi32(R2, renorm_vals2);
@@ -575,7 +573,6 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
 
     LOAD512(Rv, ransN);
 
-    uint16_t *ptr16 = (uint16_t *)ptr;
     LOAD512(iN, iN);
     LOAD512(last, lN);
 
@@ -621,7 +618,8 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
         // ------------------------------------------------------------
         //      for (z = NX-1; z >= 0; z--) {
         //          if (ransN[z] >= x_max[z]) {
-        //              *--ptr16 = ransN[z] & 0xffff;
+        //              ptr += 2;
+        //              *((uint16_t *) ptr) = ransN[z] & 0xffff;
         //              ransN[z] >>= 16;
         //          }
         //      }
@@ -690,20 +688,20 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
         SET512x(xmax, x_max); // high latency
 
         uint16_t gt_mask1 = _mm512_cmpgt_epi32_mask(Rv1, xmax1);
-        int pc1 = _mm_popcnt_u32(gt_mask1);
+        int pc1 = _mm_popcnt_u32(gt_mask1) * 2;
         __m512i Rp1 = _mm512_and_si512(Rv1, _mm512_set1_epi32(0xffff));
         __m512i Rp2 = _mm512_and_si512(Rv2, _mm512_set1_epi32(0xffff));
         uint16_t gt_mask2 = _mm512_cmpgt_epi32_mask(Rv2, xmax2);
         SET512x(SDv, cmpl_freq); // good
-        int pc2 = _mm_popcnt_u32(gt_mask2);
+        int pc2 = _mm_popcnt_u32(gt_mask2) * 2;
 
         Rp1 = _mm512_maskz_compress_epi32(gt_mask1, Rp1);
         Rp2 = _mm512_maskz_compress_epi32(gt_mask2, Rp2);
 
-        _mm512_mask_cvtepi32_storeu_epi16(ptr16-pc2, (1<<pc2)-1, Rp2);
-        ptr16 -= pc2;
-        _mm512_mask_cvtepi32_storeu_epi16(ptr16-pc1, (1<<pc1)-1, Rp1);
-        ptr16 -= pc1;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc2, pc2-1, Rp2);
+        ptr -= pc2;
+        _mm512_mask_cvtepi32_storeu_epi16(ptr-pc1, pc1-1, Rp1);
+        ptr -= pc1;
 
         Rv1 = _mm512_mask_srli_epi32(Rv1, gt_mask1, Rv1, 16);
         Rv2 = _mm512_mask_srli_epi32(Rv2, gt_mask2, Rv2, 16);
@@ -750,8 +748,6 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
 
     STORE512(Rv, ransN);
     STORE512(last, lN);
-
-    ptr = (uint8_t *)ptr16;
 
     for (z = 32-1; z>=0; z--)
         RansEncPutSymbol(&ransN[z], &ptr, &syms[0][lN[z]]);
@@ -845,7 +841,7 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
     for (z = 0; z < NX; z++)
         iN[z] = z*isz4;
 
-    uint16_t *sp = (uint16_t *)ptr;
+    uint8_t *sp = ptr;
     const uint32_t mask = (1u << shift)-1;
 
     __m512i _maskv  = _mm512_set1_epi32(mask);
@@ -865,7 +861,7 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
 
     if (shift == TF_SHIFT_O1) {
         isz4 -= 64;
-        for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
+        for (; iN[0] < isz4 && ptr_end - sp > 64; ) {
             // m[z] = R[z] & mask;
             __m512i _masked1 = _mm512_and_si512(_Rv1, _maskv);
             __m512i _masked2 = _mm512_and_si512(_Rv2, _maskv);
@@ -939,11 +935,11 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
 
             __m512i renorm_words1 = _mm512_cvtepu16_epi32
                 (_mm256_loadu_si256((const __m256i *)sp));
-            sp += _mm_popcnt_u32(_imask1);
+            sp += _mm_popcnt_u32(_imask1) * 2;
 
             __m512i renorm_words2 = _mm512_cvtepu16_epi32
                 (_mm256_loadu_si256((const __m256i *)sp));
-            sp += _mm_popcnt_u32(_imask2);
+            sp += _mm_popcnt_u32(_imask2) * 2;
 
             __m512i _renorm_vals1 =
                 _mm512_maskz_expand_epi32(_imask1, renorm_words1);
@@ -985,7 +981,7 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
 
         STORE512(_Rv, R);
         STORE512(_Lv, lN);
-        ptr = (uint8_t *)sp;
+        ptr = sp;
 
         if (1) {
             iN[0]-=tidx;
@@ -1034,7 +1030,7 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
         // SIMD version ends decoding early as it reads at most 64 bytes
         // from input via 4 vectorised loads.
         isz4 -= 64;
-        for (; iN[0] < isz4 && (uint8_t *)sp+64 < ptr_end; ) {
+        for (; iN[0] < isz4 && ptr_end - sp > 64; ) {
             // m[z] = R[z] & mask;
             __m512i _masked1 = _mm512_and_si512(_Rv1, _maskv);
             __m512i _masked2 = _mm512_and_si512(_Rv2, _maskv);
@@ -1133,7 +1129,7 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
 
         STORE512(_Rv, R);
         STORE512(_Lv, lN);
-        ptr = (uint8_t *)sp;
+        ptr = sp;
 
         if (1) {
             iN[0]-=tidx;

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -190,31 +190,10 @@ unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
         RansEncSymbol *s1 = &syms[in[i-3]];
         RansEncSymbol *s0 = &syms[in[i-4]];
 
-#if 1
         RansEncPutSymbol(&rans3, &ptr, s3);
         RansEncPutSymbol(&rans2, &ptr, s2);
         RansEncPutSymbol(&rans1, &ptr, s1);
         RansEncPutSymbol(&rans0, &ptr, s0);
-#else
-        // Slightly beter on gcc, much better on clang
-        uint16_t *ptr16 = (uint16_t *)ptr;
-
-        if (rans3 >= s3->x_max) *--ptr16 = (uint16_t)rans3, rans3 >>= 16;
-        if (rans2 >= s2->x_max) *--ptr16 = (uint16_t)rans2, rans2 >>= 16;
-        uint32_t q3 = (uint32_t) (((uint64_t)rans3 * s3->rcp_freq) >> s3->rcp_shift);
-        uint32_t q2 = (uint32_t) (((uint64_t)rans2 * s2->rcp_freq) >> s2->rcp_shift);
-        rans3 += s3->bias + q3 * s3->cmpl_freq;
-        rans2 += s2->bias + q2 * s2->cmpl_freq;
-
-        if (rans1 >= s1->x_max) *--ptr16 = (uint16_t)rans1, rans1 >>= 16;
-        if (rans0 >= s0->x_max) *--ptr16 = (uint16_t)rans0, rans0 >>= 16;
-        uint32_t q1 = (uint32_t) (((uint64_t)rans1 * s1->rcp_freq) >> s1->rcp_shift);
-        uint32_t q0 = (uint32_t) (((uint64_t)rans0 * s0->rcp_freq) >> s0->rcp_shift);
-        rans1 += s1->bias + q1 * s1->cmpl_freq;
-        rans0 += s0->bias + q0 * s0->cmpl_freq;
-
-        ptr = (uint8_t *)ptr16;
-#endif
     }
 
     RansEncFlush(&rans3, &ptr);

--- a/htscodecs/rANS_word.h
+++ b/htscodecs/rANS_word.h
@@ -77,8 +77,10 @@ static inline RansState RansEncRenorm(RansState x, uint8_t** pptr, uint32_t freq
 {
     uint32_t x_max = ((RANS_BYTE_L >> scale_bits) << 16) * freq-1; // this turns into a shift.
     if (x > x_max) {
-        uint16_t* ptr = (uint16_t *)*pptr;
-        *--ptr = (uint16_t) (x & 0xffff);
+        uint8_t* ptr = *pptr;
+        ptr -= 2;
+        ptr[0] = x & 0xff;
+        ptr[1] = (x >> 8) & 0xff;
         x >>= 16;
         *pptr = (uint8_t *)ptr;
     }


### PR DESCRIPTION
UBSan on clang complains about dereferencing unaligned `uint16_t`pointers even when the dereference is being done by `memmove()`. Strictly it's correct as even setting the pointer to such a value is undefined behaviour according to the standard.

Silence the noise by changing the pointers to `uint8_t` and adjusting the arithmetic on them as necessary.

Some bounds checks to ensure fast code won't read beyond the end of its input are also adjusted to prevent any possibility of generating an address beyond the limits of the input memory.

(`configure CFLAGS='-g -O2 -fsanitize=address,undefined -fno-sanitize-recover=all' LDFLAGS='-g -O2 -fsanitize=address,undefined'` to highlight the problem this solves.)