### PR TITLE
Make all inputs constant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+Bug fixes
+
+- Guarantee that input data remains constant. Change tok3_encode_names to not
+  alter input.
+
+
 Release 1.6.7: 24th June 2026
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ needed to be allocated when compressing a block of data.
 ```
 #include "htscodecs/rANS_static.h"
 
-unsigned char *rans_compress(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress(const unsigned char *in, unsigned int in_size,
                              unsigned int *out_size, int order);
-unsigned char *rans_uncompress(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress(const unsigned char *in, unsigned int in_size,
                                unsigned int *out_size);
 ```
 
@@ -143,14 +143,14 @@ No (un)compress_to functions exist for this older codec.
 #define RANS_ORDER_PACK   0x80  // Pack 2,4,8 or infinite symbols into a byte.
 
 unsigned int rans_compress_bound_4x16(unsigned int size, int order);
-unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
+unsigned char *rans_compress_to_4x16(const unsigned char *in,  unsigned int in_size,
                                      unsigned char *out, unsigned int *out_size,
                                      int order);
-unsigned char *rans_compress_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_4x16(const unsigned char *in, unsigned int in_size,
                                   unsigned int *out_size, int order);
-unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
+unsigned char *rans_uncompress_to_4x16(const unsigned char *in,  unsigned int in_size,
                                        unsigned char *out, unsigned int *out_size);
-unsigned char *rans_uncompress_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress_4x16(const unsigned char *in, unsigned int in_size,
                                     unsigned int *out_size);
 ```
 
@@ -166,17 +166,17 @@ and dispatching to an appropriate SIMD implementation if available.
 ```
 #include "htscodecs/arith_dynamic.h"
 
-unsigned char *arith_compress(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress(const unsigned char *in, unsigned int in_size,
                               unsigned int *out_size, int order);
 
-unsigned char *arith_uncompress(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress(const unsigned char *in, unsigned int in_size,
                                 unsigned int *out_size);
 
-unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
+unsigned char *arith_compress_to(const unsigned char *in,  unsigned int in_size,
                                  unsigned char *out, unsigned int *out_size,
                                  int order);
 
-unsigned char *arith_uncompress_to(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress_to(const unsigned char *in, unsigned int in_size,
                                    unsigned char *out, unsigned int *out_sz);
 
 unsigned int arith_compress_bound(unsigned int size, int order);
@@ -190,10 +190,10 @@ the exception of X32 as there is currently no unrolling of this code.
 ```
 #include "htscodecs/tokenise_name3.h"
 
-uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
+uint8_t *tok3_encode_names(const char *blk, int len, int level, int use_arith,
                            int *out_len, int *last_start_p);
 
-uint8_t *tok3_decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len);
+uint8_t *tok3_decode_names(const uint8_t *in, uint32_t sz, uint32_t *out_len);
 ```
 
 This differs to the general purpose entropy encoders as it takes a
@@ -227,9 +227,9 @@ typedef struct {
     uint32_t *flags;  // of size num_records
 } fqz_slice;
 
-char *fqz_compress(int vers, fqz_slice *s, char *in, size_t uncomp_size,
+char *fqz_compress(int vers, fqz_slice *s, const char *in, size_t uncomp_size,
                    size_t *comp_size, int strat, fqz_gparams *gp);
-char *fqz_decompress(char *in, size_t comp_size, size_t *uncomp_size,
+char *fqz_decompress(const char *in, size_t comp_size, size_t *uncomp_size,
                      int *lengths, int nlengths);
 ```
 

--- a/htscodecs/arith_dynamic.c
+++ b/htscodecs/arith_dynamic.c
@@ -95,7 +95,7 @@ unsigned int arith_compress_bound(unsigned int size, int order) {
 // NB: The output buffer does not hold the original size, so it is up to
 // the caller to store this.
 static
-unsigned char *arith_compress_O0(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress_O0(const unsigned char *in, unsigned int in_size,
                                  unsigned char *out, unsigned int *out_size) {
     int i, bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
     unsigned char *out_free = NULL;
@@ -137,7 +137,7 @@ unsigned char *arith_compress_O0(unsigned char *in, unsigned int in_size,
 }
 
 static
-unsigned char *arith_uncompress_O0(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress_O0(const unsigned char *in, unsigned int in_size,
                                    unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
     int i;
@@ -169,7 +169,7 @@ unsigned char *arith_uncompress_O0(unsigned char *in, unsigned int in_size,
 
 //-----------------------------------------------------------------------------
 static
-unsigned char *arith_compress_O1(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress_O1(const unsigned char *in, unsigned int in_size,
                                  unsigned char *out, unsigned int *out_size) {
     int i, bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
     unsigned char *out_free = NULL;
@@ -224,7 +224,7 @@ unsigned char *arith_compress_O1(unsigned char *in, unsigned int in_size,
 }
 
 static
-unsigned char *arith_uncompress_O1(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress_O1(const unsigned char *in, unsigned int in_size,
                                    unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
     unsigned char *out_free = NULL;
@@ -271,7 +271,7 @@ unsigned char *arith_uncompress_O1(unsigned char *in, unsigned int in_size,
 #if 0
 
 #if 0
-unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress_O2(const unsigned char *in, unsigned int in_size,
                                  unsigned char *out, unsigned int *out_size) {
     fprintf(stderr, "WARNING: using undocumented O2 arith\n");
 
@@ -326,7 +326,7 @@ unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
     return out;
 }
 #else
-unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress_O2(const unsigned char *in, unsigned int in_size,
                                  unsigned char *out, unsigned int *out_size) {
     fprintf(stderr, "WARNING: using undocumented O2 arith\n");
 
@@ -392,7 +392,7 @@ unsigned char *arith_compress_O2(unsigned char *in, unsigned int in_size,
 }
 #endif
 
-unsigned char *arith_uncompress_O2(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress_O2(const unsigned char *in, unsigned int in_size,
                                    unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
 
@@ -438,7 +438,7 @@ unsigned char *arith_uncompress_O2(unsigned char *in, unsigned int in_size,
 #define MAX_RUN 4
 
 static
-unsigned char *arith_compress_O0_RLE(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress_O0_RLE(const unsigned char *in, unsigned int in_size,
                                      unsigned char *out, unsigned int *out_size) {
     int i, bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
     unsigned char *out_free = NULL;
@@ -515,7 +515,7 @@ unsigned char *arith_compress_O0_RLE(unsigned char *in, unsigned int in_size,
 }
 
 static
-unsigned char *arith_uncompress_O0_RLE(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress_O0_RLE(const unsigned char *in, unsigned int in_size,
                                        unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
     int i;
@@ -572,7 +572,7 @@ unsigned char *arith_uncompress_O0_RLE(unsigned char *in, unsigned int in_size,
 }
 
 static
-unsigned char *arith_compress_O1_RLE(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress_O1_RLE(const unsigned char *in, unsigned int in_size,
                                      unsigned char *out, unsigned int *out_size) {
     int i, bound = arith_compress_bound(in_size,0)-5; // -5 for order/size
     unsigned char *out_free = NULL;
@@ -657,7 +657,7 @@ unsigned char *arith_compress_O1_RLE(unsigned char *in, unsigned int in_size,
 }
 
 static
-unsigned char *arith_uncompress_O1_RLE(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress_O1_RLE(const unsigned char *in, unsigned int in_size,
                                        unsigned char *out, unsigned int out_sz) {
     RangeCoder rc;
     int i;
@@ -727,7 +727,7 @@ unsigned char *arith_uncompress_O1_RLE(unsigned char *in, unsigned int in_size,
  *
  * Smallest is method, <in_size> <input>, so worst case 2 bytes longer.
  */
-unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
+unsigned char *arith_compress_to(const unsigned char *in,  unsigned int in_size,
                                  unsigned char *out, unsigned int *out_size,
                                  int order) {
     unsigned int c_meta_len;
@@ -1025,14 +1025,14 @@ unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
     return out;
 }
 
-unsigned char *arith_compress(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress(const unsigned char *in, unsigned int in_size,
                               unsigned int *out_size, int order) {
     return arith_compress_to(in, in_size, NULL, out_size, order);
 }
 
-unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
+unsigned char *arith_uncompress_to(const unsigned char *in,  unsigned int in_size,
                                    unsigned char *out, unsigned int *out_size) {
-    unsigned char *in_end = in + in_size;
+    const unsigned char *in_end = in + in_size;
     unsigned char *out_free = NULL;
     unsigned char *tmp_free = NULL;
 
@@ -1277,7 +1277,7 @@ unsigned char *arith_uncompress_to(unsigned char *in,  unsigned int in_size,
     return NULL;
 }
 
-unsigned char *arith_uncompress(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress(const unsigned char *in, unsigned int in_size,
                                 unsigned int *out_size) {
     return arith_uncompress_to(in, in_size, NULL, out_size);
 }

--- a/htscodecs/arith_dynamic.h
+++ b/htscodecs/arith_dynamic.h
@@ -38,17 +38,17 @@
 extern "C" {
 #endif
 
-unsigned char *arith_compress(unsigned char *in, unsigned int in_size,
+unsigned char *arith_compress(const unsigned char *in, unsigned int in_size,
                               unsigned int *out_size, int order);
 
-unsigned char *arith_uncompress(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress(const unsigned char *in, unsigned int in_size,
                                 unsigned int *out_size);
 
-unsigned char *arith_compress_to(unsigned char *in,  unsigned int in_size,
+unsigned char *arith_compress_to(const unsigned char *in,  unsigned int in_size,
                                  unsigned char *out, unsigned int *out_size,
                                  int order);
 
-unsigned char *arith_uncompress_to(unsigned char *in, unsigned int in_size,
+unsigned char *arith_uncompress_to(const unsigned char *in, unsigned int in_size,
                                    unsigned char *out, unsigned int *out_sz);
 
 unsigned int arith_compress_bound(unsigned int size, int order);

--- a/htscodecs/fqzcomp_qual.c
+++ b/htscodecs/fqzcomp_qual.c
@@ -1612,7 +1612,7 @@ unsigned char *uncompress_block_fqz2f(fqz_slice *s,
     return NULL;
 }
 
-char *fqz_compress(int vers, fqz_slice *s, char *in, size_t uncomp_size,
+char *fqz_compress(int vers, fqz_slice *s, const char *in, size_t uncomp_size,
                    size_t *comp_size, int strat, fqz_gparams *gp) {
     if (uncomp_size > INT_MAX) {
         *comp_size = 0;

--- a/htscodecs/fqzcomp_qual.h
+++ b/htscodecs/fqzcomp_qual.h
@@ -149,7 +149,7 @@ typedef struct {
  * @return              The compressed quality buffer on success,
  *                      NULL on failure.
  */
-char *fqz_compress(int vers, fqz_slice *s, char *in, size_t in_size,
+char *fqz_compress(int vers, fqz_slice *s, const char *in, size_t in_size,
                    size_t *out_size, int strat, fqz_gparams *gp);
 
 /** Decompress a block of quality values.

--- a/htscodecs/pack.c
+++ b/htscodecs/pack.c
@@ -53,7 +53,7 @@
  * Returns the packed buffer on success with new length in out_len,
  *         NULL of failure
  */
-uint8_t *hts_pack(uint8_t *data, int64_t len,
+uint8_t *hts_pack(const uint8_t *data, int64_t len,
                   uint8_t *out_meta, int *out_meta_len, uint64_t *out_len) {
     int p[256] = {0}, n;
     uint64_t i, j;
@@ -158,7 +158,7 @@ uint8_t *hts_pack(uint8_t *data, int64_t len,
  * Returns number of bytes of data[] consumed on success,
  *         zero on failure.
  */
-uint8_t hts_unpack_meta(uint8_t *data, uint32_t data_len,
+uint8_t hts_unpack_meta(const uint8_t *data, uint32_t data_len,
                         uint64_t udata_len, uint8_t *map, int *nsym) {
     if (data_len == 0)
         return 0;
@@ -204,7 +204,7 @@ uint8_t hts_unpack_meta(uint8_t *data, uint32_t data_len,
  * Returns uncompressed data (out) on success,
  *         NULL on failure.
  */
-uint8_t *hts_unpack(uint8_t *data, int64_t len, uint8_t *out, uint64_t out_len, int nsym, uint8_t *p) {
+uint8_t *hts_unpack(const uint8_t *data, int64_t len, uint8_t *out, uint64_t out_len, int nsym, uint8_t *p) {
     //uint8_t *out;
     uint8_t c = 0;
     int64_t i, j = 0, olen;

--- a/htscodecs/pack.h
+++ b/htscodecs/pack.h
@@ -49,7 +49,7 @@ extern "C" {
  * Returns the packed buffer on success with new length in out_len,
  *         NULL of failure
  */
-uint8_t *hts_pack(uint8_t *data, int64_t len,
+uint8_t *hts_pack(const uint8_t *data, int64_t len,
                   uint8_t *out_meta, int *out_meta_len, uint64_t *out_len);
 
 /*
@@ -63,7 +63,7 @@ uint8_t *hts_pack(uint8_t *data, int64_t len,
  * Returns number of bytes of data[] consumed on success,
  *         zero on failure.
  */
-uint8_t hts_unpack_meta(uint8_t *data, uint32_t data_len,
+uint8_t hts_unpack_meta(const uint8_t *data, uint32_t data_len,
                         uint64_t udata_len, uint8_t *map, int *nsym);
 
 /*
@@ -77,7 +77,7 @@ uint8_t hts_unpack_meta(uint8_t *data, uint32_t data_len,
  * Returns uncompressed data (out) on success,
  *         NULL on failure.
  */
-uint8_t *hts_unpack(uint8_t *data, int64_t len, uint8_t *out, uint64_t out_len, int nsym, uint8_t *map);
+uint8_t *hts_unpack(const uint8_t *data, int64_t len, uint8_t *out, uint64_t out_len, int nsym, uint8_t *map);
 
 #ifdef __cplusplus
 }

--- a/htscodecs/rANS_byte.h
+++ b/htscodecs/rANS_byte.h
@@ -534,7 +534,7 @@ static inline void RansDecRenorm(RansState* r, const uint8_t** pptr)
     *r = x;
 }
 
-static inline void RansDecRenorm2(RansState* r1, RansState* r2, uint8_t** pptr) {
+static inline void RansDecRenorm2(RansState* r1, RansState* r2, const uint8_t** pptr) {
     RansDecRenorm(r1, pptr);
     RansDecRenorm(r2, pptr);
 }

--- a/htscodecs/rANS_byte.h
+++ b/htscodecs/rANS_byte.h
@@ -122,10 +122,10 @@ static inline void RansEncFlush(RansState* r, uint8_t** pptr)
 
 // Initializes a rANS decoder.
 // Unlike the encoder, the decoder works forwards as you'd expect.
-static inline void RansDecInit(RansState* r, uint8_t** pptr)
+static inline void RansDecInit(RansState* r, const uint8_t** pptr)
 {
     uint32_t x;
-    uint8_t* ptr = *pptr;
+    const uint8_t* ptr = *pptr;
 
     x  = ptr[0] << 0;
     x |= ptr[1] << 8;
@@ -464,10 +464,10 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr) {
  * The only minor tweak here is to adjust the reorder a few opcodes
  * to reduce dependency delays.
  */
-static inline void RansDecRenorm2(RansState* r1, RansState* r2, uint8_t** pptr) {
+static inline void RansDecRenorm2(RansState* r1, RansState* r2, const uint8_t** pptr) {
     uint32_t  x1   = *r1;
     uint32_t  x2   = *r2;
-    uint8_t  *ptr = *pptr;
+    const uint8_t  *ptr = *pptr;
 
     __asm__ ("movzbl (%0), %%eax\n\t"
              "mov    %1, %%edx\n\t"
@@ -509,14 +509,14 @@ static inline void RansDecRenorm2(RansState* r1, RansState* r2, uint8_t** pptr) 
 
 #else /* __x86_64 */
 
-static inline void RansDecRenorm(RansState* r, uint8_t** pptr)
+static inline void RansDecRenorm(RansState* r, const uint8_t** pptr)
 {
     // renormalize
     uint32_t x = *r;
 
 #ifdef __clang__
     // Generates cmov instructions on clang, but alas not gcc
-    uint8_t* ptr = *pptr;
+    const uint8_t* ptr = *pptr;
     uint32_t y = (x << 8) | *ptr;
     uint32_t cond = x < RANS_BYTE_L;
     x    = cond ? y : x;
@@ -525,7 +525,7 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr)
     *pptr = ptr;
 #else
     if (x >= RANS_BYTE_L) return;
-    uint8_t* ptr = *pptr;
+    const uint8_t* ptr = *pptr;
     x = (x << 8) | *ptr++;
     if (x < RANS_BYTE_L) x = (x << 8) | *ptr++;
     *pptr = ptr;
@@ -541,10 +541,10 @@ static inline void RansDecRenorm2(RansState* r1, RansState* r2, uint8_t** pptr) 
 
 #endif /* __x86_64 */
 
-static inline void RansDecRenormSafe(RansState* r, uint8_t** pptr, uint8_t *ptr_end)
+static inline void RansDecRenormSafe(RansState* r, const uint8_t** pptr, const uint8_t *ptr_end)
 {
     uint32_t x = *r;
-    uint8_t* ptr = *pptr;
+    const uint8_t* ptr = *pptr;
     if (x >= RANS_BYTE_L || ptr >= ptr_end) return;
     x = (x << 8) | *ptr++;
     if (x < RANS_BYTE_L && ptr < ptr_end)

--- a/htscodecs/rANS_static.c
+++ b/htscodecs/rANS_static.c
@@ -72,7 +72,7 @@
  */
 
 static
-unsigned char *rans_compress_O0(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_O0(const unsigned char *in, unsigned int in_size,
                                 unsigned int *out_size) {
     unsigned char *out_buf = malloc(1.05*in_size + 257*257*3 + 9);
     unsigned char *cp, *out_end;
@@ -218,11 +218,11 @@ typedef struct {
 } ari_decoder;
 
 static
-unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress_O0(const unsigned char *in, unsigned int in_size,
                                   unsigned int *out_size) {
     /* Load in the static tables */
-    unsigned char *cp = in + 9;
-    unsigned char *cp_end = in + in_size;
+    const unsigned char *cp = in + 9;
+    const unsigned char *cp_end = in + in_size;
     const uint32_t mask = (1u << TF_SHIFT)-1;
     int i, j, rle;
     unsigned int x, y;
@@ -384,7 +384,7 @@ unsigned char *rans_uncompress_O0(unsigned char *in, unsigned int in_size,
 }
 
 static
-unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_O1(const unsigned char *in, unsigned int in_size,
                                 unsigned int *out_size) {
     unsigned char *out_buf = NULL, *out_end, *cp;
     unsigned int tab_size, rle_i, rle_j;
@@ -596,11 +596,11 @@ unsigned char *rans_compress_O1(unsigned char *in, unsigned int in_size,
 }
 
 static
-unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress_O1(const unsigned char *in, unsigned int in_size,
                                   unsigned int *out_size) {
     /* Load in the static tables */
-    unsigned char *cp = in + 9;
-    unsigned char *ptr_end = in + in_size;
+    const unsigned char *cp = in + 9;
+    const unsigned char *ptr_end = in + in_size;
     int i, j = -999, rle_i, rle_j;
     unsigned int x;
     unsigned int out_sz, in_sz;
@@ -725,7 +725,7 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
             map[i] = 0;
 
     RansState rans0, rans1, rans2, rans3;
-    uint8_t *ptr = cp;
+    const uint8_t *ptr = cp;
     if (cp > ptr_end - 16) goto cleanup; // Not enough input bytes left
     RansDecInit(&rans0, &ptr); if (rans0 < RANS_BYTE_L) goto cleanup;
     RansDecInit(&rans1, &ptr); if (rans1 < RANS_BYTE_L) goto cleanup;
@@ -826,7 +826,7 @@ unsigned char *rans_uncompress_O1(unsigned char *in, unsigned int in_size,
 /*-----------------------------------------------------------------------------
  * Simple interface to the order-0 vs order-1 encoders and decoders.
  */
-unsigned char *rans_compress(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress(const unsigned char *in, unsigned int in_size,
                              unsigned int *out_size, int order) {
     if (in_size > INT_MAX) {
         *out_size = 0;
@@ -838,7 +838,7 @@ unsigned char *rans_compress(unsigned char *in, unsigned int in_size,
         : rans_compress_O0(in, in_size, out_size);
 }
 
-unsigned char *rans_uncompress(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress(const unsigned char *in, unsigned int in_size,
                                unsigned int *out_size) {
     /* Both rans_uncompress functions need to be able to read at least 9
        bytes. */

--- a/htscodecs/rANS_static.h
+++ b/htscodecs/rANS_static.h
@@ -38,9 +38,9 @@
 extern "C" {
 #endif
 
-unsigned char *rans_compress(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress(const unsigned char *in, unsigned int in_size,
                              unsigned int *out_size, int order);
-unsigned char *rans_uncompress(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress(const unsigned char *in, unsigned int in_size,
                                unsigned int *out_size);
 
 #ifdef __cplusplus

--- a/htscodecs/rANS_static16_int.h
+++ b/htscodecs/rANS_static16_int.h
@@ -73,9 +73,9 @@
 #define TOTFREQ_O1 (1<<TF_SHIFT_O1)
 #define TOTFREQ_O1_FAST (1<<TF_SHIFT_O1_FAST)
 
-unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_O0_4x16(const unsigned char *in, unsigned int in_size,
                                      unsigned char *out, unsigned int *out_size);
-unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress_O0_4x16(const unsigned char *in, unsigned int in_size,
                                        unsigned char *out, unsigned int out_sz);
 
 int rans_compute_shift(uint32_t *F0, uint32_t (*F)[256], uint32_t *T,
@@ -188,11 +188,11 @@ static inline int encode_alphabet(uint8_t *cp, uint32_t *F) {
     return cp - op;
 }
 
-static inline int decode_alphabet(uint8_t *cp, uint8_t *cp_end, uint32_t *F) {
+static inline int decode_alphabet(const uint8_t *cp, const uint8_t *cp_end, uint32_t *F) {
     if (cp == cp_end)
         return 0;
 
-    uint8_t *op = cp;
+    const uint8_t *op = cp;
     int rle = 0;
     int j = *cp++;
     if (cp+2 >= cp_end)
@@ -251,12 +251,12 @@ static inline int encode_freq(uint8_t *cp, uint32_t *F) {
     return cp - op;
 }
 
-static inline int decode_freq(uint8_t *cp, uint8_t *cp_end, uint32_t *F,
+static inline int decode_freq(const uint8_t *cp, const uint8_t *cp_end, uint32_t *F,
                               uint32_t *fsum) {
     if (cp == cp_end)
         return 0;
 
-    uint8_t *op = cp;
+    const uint8_t *op = cp;
     cp += decode_alphabet(cp, cp_end, F);
 
     int j, tot = 0;
@@ -309,7 +309,7 @@ static inline int encode_freq_d(uint8_t *cp, uint32_t *F0, uint32_t *F) {
 // Also initialises the RansEncSymbol structs.
 //
 // Returns the desired TF_SHIFT; 10 or 12 bit, or -1 on error.
-static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
+static inline int encode_freq1(const uint8_t *in, uint32_t in_size, int Nway,
                                RansEncSymbol syms[256][256], uint8_t **cp_p) {
     int i, j, z;
     uint8_t *out = *cp_p, *cp = out;
@@ -422,12 +422,12 @@ static inline int encode_freq1(uint8_t *in, uint32_t in_size, int Nway,
 
 // Part of decode_freq1 below.  This decodes an order-1 frequency table
 // using an order-0 table to determine which stats may be stored.
-static inline int decode_freq_d(uint8_t *cp, uint8_t *cp_end, uint32_t *F0,
+static inline int decode_freq_d(const uint8_t *cp, const uint8_t *cp_end, uint32_t *F0,
                                 uint32_t *F, uint32_t *total) {
     if (cp == cp_end)
         return 0;
 
-    uint8_t *op = cp;
+    const uint8_t *op = cp;
     int j, dz, T = 0;
 
     for (j = dz = 0; j < 256 && cp < cp_end; j++) {
@@ -465,11 +465,11 @@ typedef struct {
 // been passed in.)
 //
 // Returns the number of bytes decoded.
-static inline int decode_freq1(uint8_t *cp, uint8_t *cp_end, int shift,
+static inline int decode_freq1(const uint8_t *cp, const uint8_t *cp_end, int shift,
                                uint32_t s3 [256][TOTFREQ_O1],
                                uint32_t s3F[256][TOTFREQ_O1_FAST],
                                uint8_t *sfb[256], fb_t fb[256][256]) {
-    uint8_t *cp_start = cp;
+    const uint8_t *cp_start = cp;
     int i, j, x;
     uint32_t F0[256] = {0};
     int fsz = decode_alphabet(cp, cp_end, F0);

--- a/htscodecs/rANS_static32x16pr.c
+++ b/htscodecs/rANS_static32x16pr.c
@@ -64,7 +64,7 @@
 
 #define NX 32
 
-unsigned char *rans_compress_O0_32x16(unsigned char *in,
+unsigned char *rans_compress_O0_32x16(const unsigned char *in,
                                       unsigned int in_size,
                                       unsigned char *out,
                                       unsigned int *out_size) {
@@ -187,7 +187,7 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
                 // RansEncPutSymbol added in-situ
                 RansState *rp = &ransN[z]-3;
                 RansEncSymbol *sy[4];
-                uint8_t *C = &in[i-(NX-z)]-3;
+                const uint8_t *C = &in[i-(NX-z)]-3;
 
                 sy[0] = &syms[C[3]];
                 sy[1] = &syms[C[2]];
@@ -251,7 +251,7 @@ unsigned char *rans_compress_O0_32x16(unsigned char *in,
     return out;
 }
 
-unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16(const unsigned char *in,
                                         unsigned int in_size,
                                         unsigned char *out,
                                         unsigned int out_sz) {
@@ -267,8 +267,9 @@ unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *out_free = NULL;
-    unsigned char *cp_end = in + in_size;
+    const unsigned char *cp = in;
+    unsigned char *out_free = NULL;
+    const unsigned char *cp_end = in + in_size;
     int i;
     uint32_t s3[TOTFREQ]; // For TF_SHIFT <= 12
 
@@ -409,7 +410,7 @@ unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
 
 
 //-----------------------------------------------------------------------------
-unsigned char *rans_compress_O1_32x16(unsigned char *in,
+unsigned char *rans_compress_O1_32x16(const unsigned char *in,
                                       unsigned int in_size,
                                       unsigned char *out,
                                       unsigned int *out_size) {
@@ -469,7 +470,7 @@ unsigned char *rans_compress_O1_32x16(unsigned char *in,
         lN[z] = c;
     }
 
-    unsigned char *i32[NX];
+    const unsigned char *i32[NX];
     for (i = 0; i < NX; i++)
         i32[i] = &in[iN[i]];
 
@@ -524,7 +525,7 @@ unsigned char *rans_compress_O1_32x16(unsigned char *in,
 #define MAGIC2 179
 //#define MAGIC2 0
 
-unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16(const unsigned char *in,
                                         unsigned int in_size,
                                         unsigned char *out,
                                         unsigned int out_sz) {
@@ -540,7 +541,8 @@ unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *cp_end = in+in_size, *out_free = NULL;
+    const unsigned char *cp = in, *cp_end = in+in_size;
+    unsigned char *out_free = NULL;
     unsigned char *c_freq = NULL;
     int i;
 
@@ -580,8 +582,8 @@ unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
     // compressed header? If so uncompress it
-    unsigned char *tab_end = NULL;
-    unsigned char *c_freq_end = cp_end;
+    const unsigned char *tab_end = NULL;
+    const unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
         uint32_t u_freq_sz, c_freq_sz;
@@ -608,7 +610,7 @@ unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
         goto err;
 
     RansState R[NX];
-    uint8_t *ptr = cp, *ptr_end = in + in_size - 2*NX;
+    const uint8_t *ptr = cp, *ptr_end = in + in_size - 2*NX;
     int z;
     for (z = 0; z < NX; z++) {
         RansDecInit(&R[z], &ptr);

--- a/htscodecs/rANS_static32x16pr.h
+++ b/htscodecs/rANS_static32x16pr.h
@@ -57,22 +57,22 @@ extern "C" {
 
 //----------------------------------------------------------------------
 // Standard scalar versions
-unsigned char *rans_compress_O0_32x16(unsigned char *in,
+unsigned char *rans_compress_O0_32x16(const unsigned char *in,
                                       unsigned int in_size,
                                       unsigned char *out,
                                       unsigned int *out_size);
 
-unsigned char *rans_uncompress_O0_32x16(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16(const unsigned char *in,
                                         unsigned int in_size,
                                         unsigned char *out,
                                         unsigned int out_sz);
 
-unsigned char *rans_compress_O1_32x16(unsigned char *in,
+unsigned char *rans_compress_O1_32x16(const unsigned char *in,
                                       unsigned int in_size,
                                       unsigned char *out,
                                       unsigned int *out_size);
 
-unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16(const unsigned char *in,
                                         unsigned int in_size,
                                         unsigned char *out,
                                         unsigned int out_sz);
@@ -80,17 +80,17 @@ unsigned char *rans_uncompress_O1_32x16(unsigned char *in,
 //----------------------------------------------------------------------
 // Intel SSE4 implementation.  Only the O0 decoder for now
 #if defined(HAVE_SSE4_1) && defined(HAVE_SSSE3) && defined(HAVE_POPCNT)
-unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
+unsigned char *rans_compress_O0_32x16_sse4(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size);
 
-unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16_sse4(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz);
 
-unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16_sse4(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz);
@@ -99,22 +99,22 @@ unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
 //----------------------------------------------------------------------
 // Intel AVX2 implementation
 #ifdef HAVE_AVX2
-unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
+unsigned char *rans_compress_O0_32x16_avx2(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size);
 
-unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16_avx2(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz);
 
-unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in,
+unsigned char *rans_compress_O1_32x16_avx2(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size);
 
-unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16_avx2(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz);
@@ -123,22 +123,22 @@ unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
 //----------------------------------------------------------------------
 // Intel AVX512 implementation
 #ifdef HAVE_AVX512
-unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
+unsigned char *rans_compress_O0_32x16_avx512(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int *out_size);
 
-unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16_avx512(const unsigned char *in,
                                                unsigned int in_size,
                                                unsigned char *out,
                                                unsigned int out_sz);
 
-unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
+unsigned char *rans_compress_O1_32x16_avx512(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int *out_size);
 
-unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16_avx512(const unsigned char *in,
                                                unsigned int in_size,
                                                unsigned char *out,
                                                unsigned int out_sz);
@@ -147,22 +147,22 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
 //----------------------------------------------------------------------
 // Arm Neon implementation
 #if defined(__ARM_NEON) && defined(__aarch64__)
-unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
+unsigned char *rans_compress_O0_32x16_neon(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size);
 
-unsigned char *rans_uncompress_O0_32x16_neon(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16_neon(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz);
 
-unsigned char *rans_compress_O1_32x16_neon(unsigned char *in,
+unsigned char *rans_compress_O1_32x16_neon(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size);
 
-unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16_neon(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz);

--- a/htscodecs/rANS_static32x16pr_avx2.c
+++ b/htscodecs/rANS_static32x16pr_avx2.c
@@ -154,7 +154,7 @@ static inline __m256i _mm256_i32gather_epi32x(int *b, __m256i idx, int size) {
 #define _mm256_i32gather_epi32x _mm256_i32gather_epi32
 #endif
 
-unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
+unsigned char *rans_compress_O0_32x16_avx2(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size) {
@@ -453,7 +453,7 @@ unsigned char *rans_compress_O0_32x16_avx2(unsigned char *in,
     return out;
 }
 
-unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16_avx2(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz) {
@@ -469,8 +469,9 @@ unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *out_free = NULL;
-    unsigned char *cp_end = in + in_size;
+    const unsigned char *cp = in;
+    unsigned char *out_free = NULL;
+    const unsigned char *cp_end = in + in_size;
     int i;
     uint32_t s3[TOTFREQ] __attribute__((aligned(32))); // For TF_SHIFT <= 12
 
@@ -503,7 +504,7 @@ unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
             goto err;
     }
 
-    uint8_t *sp = cp;
+    const uint8_t *sp = cp;
     uint8_t overflow[64+64] = {0};
     cp_end -= 64;
 
@@ -695,7 +696,7 @@ unsigned char *rans_uncompress_O0_32x16_avx2(unsigned char *in,
 
 //-----------------------------------------------------------------------------
 
-unsigned char *rans_compress_O1_32x16_avx2(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_O1_32x16_avx2(const unsigned char *in, unsigned int in_size,
                                            unsigned char *out, unsigned int *out_size) {
     unsigned char *cp, *out_end, *out_free = NULL;
     unsigned int tab_size;
@@ -1027,7 +1028,7 @@ static inline void transpose_and_copy(uint8_t *out, int iN[32],
     rot32_simd(t, out, iN);
 }
 
-unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16_avx2(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz) {
@@ -1043,7 +1044,8 @@ unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *cp_end = in+in_size, *out_free = NULL;
+    const unsigned char *cp = in, *cp_end = in+in_size;
+    unsigned char *out_free = NULL;
     unsigned char *c_freq = NULL;
 
     uint32_t (*s3)[TOTFREQ_O1] = htscodecs_tls_alloc(256*TOTFREQ_O1*4);
@@ -1061,8 +1063,8 @@ unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
     // compressed header? If so uncompress it
-    unsigned char *tab_end = NULL;
-    unsigned char *c_freq_end = cp_end;
+    const unsigned char *tab_end = NULL;
+    const unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
         uint32_t u_freq_sz, c_freq_sz;
@@ -1090,7 +1092,7 @@ unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
         goto err;
 
     RansState R[NX] __attribute__((aligned(32)));
-    uint8_t *ptr = cp, *ptr_end = in + in_size;
+    const uint8_t *ptr = cp, *ptr_end = in + in_size;
     int z;
     for (z = 0; z < NX; z++) {
         RansDecInit(&R[z], &ptr);
@@ -1103,7 +1105,7 @@ unsigned char *rans_uncompress_O1_32x16_avx2(unsigned char *in,
     for (z = 0; z < NX; z++)
         iN[z] = z*isz4;
 
-    uint8_t *sp = ptr;
+    const uint8_t *sp = ptr;
     const uint32_t mask = (1u << shift)-1;
 
     __m256i maskv  = _mm256_set1_epi32(mask);

--- a/htscodecs/rANS_static32x16pr_avx512.c
+++ b/htscodecs/rANS_static32x16pr_avx512.c
@@ -104,7 +104,7 @@ static inline __m512i _mm512_i32gather_epi32x(__m512i idx, void *v, int size) {
 }
 
 // 32-bit indices, 8-bit quantities into 32-bit lanes
-static inline __m512i _mm512_i32gather_epi32x1(__m512i idx, void *v) {
+static inline __m512i _mm512_i32gather_epi32x1(__m512i idx, const void *v) {
     uint8_t *b = (uint8_t *)v;
     volatile int c[16] __attribute__((aligned(32)));
 
@@ -123,7 +123,7 @@ static inline __m512i _mm512_i32gather_epi32x1(__m512i idx, void *v) {
 #define _mm512_i32gather_epi32x _mm512_i32gather_epi32
 #endif
 
-unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
+unsigned char *rans_compress_O0_32x16_avx512(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int *out_size) {
@@ -205,7 +205,7 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
     LOAD512(Rv, ransN);
 
     for (i=(in_size &~(32-1)); i>0; i-=32) {
-        uint8_t *c = &in[i-32];
+        const uint8_t *c = &in[i-32];
 
         // GATHER versions
         // Much faster now we have an efficient loadu mechanism in place,
@@ -312,7 +312,7 @@ unsigned char *rans_compress_O0_32x16_avx512(unsigned char *in,
     return out;
 }
 
-unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16_avx512(const unsigned char *in,
                                                unsigned int in_size,
                                                unsigned char *out,
                                                unsigned int out_sz) {
@@ -323,8 +323,9 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
         return NULL; // protect against some overflow cases
 
     /* Load in the static tables */
-    unsigned char *cp = in, *out_free = NULL;
-    unsigned char *cp_end = in + in_size;
+    const unsigned char *cp = in;
+    unsigned char *out_free = NULL;
+    const unsigned char *cp_end = in + in_size;
     int i;
     uint32_t s3[TOTFREQ]  __attribute__((aligned(64))); // For TF_SHIFT <= 12
 
@@ -357,7 +358,7 @@ unsigned char *rans_uncompress_O0_32x16_avx512(unsigned char *in,
             goto err;
     }
 
-    uint8_t *sp = cp;
+    const uint8_t *sp = cp;
 
     int out_end = (out_sz&~(32-1));
     const uint32_t mask = (1u << TF_SHIFT)-1;
@@ -509,7 +510,7 @@ static inline void transpose_and_copy_avx512(uint8_t *out, int iN[32],
 }
 #endif // TBUF
 
-unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
+unsigned char *rans_compress_O1_32x16_avx512(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int *out_size) {
@@ -771,7 +772,7 @@ unsigned char *rans_compress_O1_32x16_avx512(unsigned char *in,
 }
 
 #define NX 32
-unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16_avx512(const unsigned char *in,
                                                unsigned int in_size,
                                                unsigned char *out,
                                                unsigned int out_sz) {
@@ -782,7 +783,8 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
         return NULL; // protect against some overflow cases
 
     /* Load in the static tables */
-    unsigned char *cp = in, *cp_end = in+in_size, *out_free = NULL;
+    const unsigned char *cp = in, *cp_end = in+in_size;
+    unsigned char *out_free = NULL;
     unsigned char *c_freq = NULL;
 
     uint32_t (*s3)[TOTFREQ_O1] = htscodecs_tls_alloc(256*TOTFREQ_O1*4);
@@ -799,8 +801,8 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
     // compressed header? If so uncompress it
-    unsigned char *tab_end = NULL;
-    unsigned char *c_freq_end = cp_end;
+    const unsigned char *tab_end = NULL;
+    const unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
         uint32_t u_freq_sz, c_freq_sz;
@@ -828,7 +830,7 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
         goto err;
 
     RansState R[NX] __attribute__((aligned(64)));
-    uint8_t *ptr = cp, *ptr_end = in + in_size;
+    const uint8_t *ptr = cp, *ptr_end = in + in_size;
     int z;
     for (z = 0; z < NX; z++) {
         RansDecInit(&R[z], &ptr);
@@ -841,7 +843,7 @@ unsigned char *rans_uncompress_O1_32x16_avx512(unsigned char *in,
     for (z = 0; z < NX; z++)
         iN[z] = z*isz4;
 
-    uint8_t *sp = ptr;
+    const uint8_t *sp = ptr;
     const uint32_t mask = (1u << shift)-1;
 
     __m512i _maskv  = _mm512_set1_epi32(mask);

--- a/htscodecs/rANS_static32x16pr_neon.c
+++ b/htscodecs/rANS_static32x16pr_neon.c
@@ -604,8 +604,9 @@ unsigned char *rans_uncompress_O0_32x16_neon(const unsigned char *in,
         return NULL; // protect against some overflow cases
 
     /* Load in the static tables */
-    unsigned char *cp = in, *out_free = NULL;
-    unsigned char *cp_end = in + in_size;
+    const unsigned char *cp = in; 
+    unsigned char *out_free = NULL;
+    const unsigned char *cp_end = in + in_size;
     int i;
     uint32_t s3[TOTFREQ]; // For TF_SHIFT <= 12
 
@@ -665,7 +666,7 @@ unsigned char *rans_uncompress_O0_32x16_neon(const unsigned char *in,
     // 500MB/s.  Clang does a lot of reordering of this code, removing some
     // of the manual tuning benefits.  Short of dropping to assembly, for now
     // I would recommend using gcc to compile this file.
-    uint8_t *sp = cp;
+    const uint8_t *sp = cp;
     uint8_t overflow[64+64] = {0};
     for (i=0; i < out_end; i+=NX) {
         // Decode freq, bias and symbol from s3 lookups
@@ -1422,7 +1423,8 @@ unsigned char *rans_uncompress_O1_32x16_neon(const unsigned char *in,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *cp_end = in+in_size, *out_free = NULL;
+    const unsigned char *cp = in, *cp_end = in+in_size;
+    unsigned char *out_free = NULL;
     unsigned char *c_freq = NULL;
     int i, j = -999;
     unsigned int x;
@@ -1451,8 +1453,8 @@ unsigned char *rans_uncompress_O1_32x16_neon(const unsigned char *in,
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
     // compressed header? If so uncompress it
-    unsigned char *tab_end = NULL;
-    unsigned char *c_freq_end = cp_end;
+    const unsigned char *tab_end = NULL;
+    const unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
         uint32_t u_freq_sz, c_freq_sz;
@@ -1530,7 +1532,7 @@ unsigned char *rans_uncompress_O1_32x16_neon(const unsigned char *in,
         goto err;
 
     RansState R[NX];
-    uint8_t *ptr = cp, *ptr_end = in + in_size;
+    const uint8_t *ptr = cp, *ptr_end = in + in_size;
     int z;
     for (z = 0; z < NX; z++) {
         RansDecInit(&R[z], &ptr);

--- a/htscodecs/rANS_static32x16pr_neon.c
+++ b/htscodecs/rANS_static32x16pr_neon.c
@@ -74,7 +74,7 @@ static uint8x8_t vtab[16] = {
 };
 #undef _
 
-unsigned char *rans_compress_O0_32x16_neon(unsigned char *in,
+unsigned char *rans_compress_O0_32x16_neon(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size) {
@@ -593,7 +593,7 @@ static uint8x8_t idx2[256] = {
 };
 
 // SIMD: 650MB/s
-unsigned char *rans_uncompress_O0_32x16_neon(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16_neon(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz) {
@@ -912,7 +912,7 @@ unsigned char *rans_uncompress_O0_32x16_neon(unsigned char *in,
 
 //-----------------------------------------------------------------------------
 
-unsigned char *rans_compress_O1_32x16_neon(unsigned char *in,
+unsigned char *rans_compress_O1_32x16_neon(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size) {
@@ -1406,7 +1406,7 @@ static inline void transpose_and_copy(uint8_t *out, int iN[32],
     }
 }
 
-unsigned char *rans_uncompress_O1_32x16_neon(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16_neon(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz) {

--- a/htscodecs/rANS_static32x16pr_sse4.c
+++ b/htscodecs/rANS_static32x16pr_sse4.c
@@ -206,7 +206,7 @@ static inline __m128i _mm_srlv_epi32x(__m128i a, __m128i b) {
 //    return _mm_loadu_si128((__m128i *)A);
 }
 
-unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
+unsigned char *rans_compress_O0_32x16_sse4(const unsigned char *in,
                                            unsigned int in_size,
                                            unsigned char *out,
                                            unsigned int *out_size) {
@@ -459,7 +459,7 @@ unsigned char *rans_compress_O0_32x16_sse4(unsigned char *in,
 }
 #endif // disable SSE4 encoder
 
-unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
+unsigned char *rans_uncompress_O0_32x16_sse4(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz) {
@@ -475,8 +475,9 @@ unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *out_free = NULL;
-    unsigned char *cp_end = in + in_size;
+    const unsigned char *cp = in;
+    unsigned char *out_free = NULL;
+    const unsigned char *cp_end = in + in_size;
     int i;
     uint32_t s3[TOTFREQ] __attribute__((aligned(32))); // For TF_SHIFT <= 12
 
@@ -509,7 +510,7 @@ unsigned char *rans_uncompress_O0_32x16_sse4(unsigned char *in,
             goto err;
     }
 
-    uint8_t *sp = cp;
+    const uint8_t *sp = cp;
 
     int out_end = (out_sz&~(NX-1));
     const uint32_t mask = (1u << TF_SHIFT)-1;
@@ -1027,7 +1028,7 @@ static inline void transpose_and_copy(uint8_t *out, int iN[32],
     }
 }
 
-unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
+unsigned char *rans_uncompress_O1_32x16_sse4(const unsigned char *in,
                                              unsigned int in_size,
                                              unsigned char *out,
                                              unsigned int out_sz) {
@@ -1043,7 +1044,8 @@ unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *cp_end = in+in_size, *out_free = NULL;
+    const unsigned char *cp = in, *cp_end = in+in_size;
+    unsigned char *out_free = NULL;
     unsigned char *c_freq = NULL;
 
     uint32_t (*s3)[TOTFREQ_O1] = htscodecs_tls_alloc(256*TOTFREQ_O1*4);
@@ -1060,8 +1062,8 @@ unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
     // compressed header? If so uncompress it
-    unsigned char *tab_end = NULL;
-    unsigned char *c_freq_end = cp_end;
+    const unsigned char *tab_end = NULL;
+    const unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
         uint32_t u_freq_sz, c_freq_sz;
@@ -1088,7 +1090,7 @@ unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
         goto err;
 
     RansState R[NX];
-    uint8_t *ptr = cp, *ptr_end = in + in_size;
+    const uint8_t *ptr = cp, *ptr_end = in + in_size;
     int z;
     for (z = 0; z < NX; z++) {
         RansDecInit(&R[z], &ptr);
@@ -1105,7 +1107,7 @@ unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
     // loop with shift as a variable.
     if (shift == TF_SHIFT_O1) {
         // TF_SHIFT_O1 = 12
-        uint8_t *sp = ptr;
+        const uint8_t *sp = ptr;
         const uint32_t mask = ((1u << TF_SHIFT_O1)-1);
         __m128i maskv  = _mm_set1_epi32(mask); // set mask in all lanes
         uint8_t tbuf[32][32];
@@ -1475,7 +1477,7 @@ unsigned char *rans_uncompress_O1_32x16_sse4(unsigned char *in,
         }
     } else {
         // TF_SHIFT_O1 = 10
-        uint8_t *sp = ptr;
+        const uint8_t *sp = ptr;
         const uint32_t mask = ((1u << TF_SHIFT_O1_FAST)-1);
         __m128i maskv  = _mm_set1_epi32(mask); // set mask in all lanes
         uint8_t tbuf[32][32] __attribute__((aligned(32)));

--- a/htscodecs/rANS_static4x16.h
+++ b/htscodecs/rANS_static4x16.h
@@ -39,14 +39,14 @@ extern "C" {
 #endif
 
 unsigned int rans_compress_bound_4x16(unsigned int size, int order);
-unsigned char *rans_compress_to_4x16(unsigned char *in,  unsigned int in_size,
+unsigned char *rans_compress_to_4x16(const unsigned char *in,  unsigned int in_size,
                                      unsigned char *out, unsigned int *out_size,
                                      int order);
-unsigned char *rans_compress_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_4x16(const unsigned char *in, unsigned int in_size,
                                   unsigned int *out_size, int order);
-unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
+unsigned char *rans_uncompress_to_4x16(const unsigned char *in,  unsigned int in_size,
                                        unsigned char *out, unsigned int *out_size);
-unsigned char *rans_uncompress_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress_4x16(const unsigned char *in, unsigned int in_size,
                                     unsigned int *out_size);
 
 // CPU detection control.  Used for testing and benchmarking.

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -1804,7 +1804,7 @@ unsigned char *rans_uncompress_to_4x16(const unsigned char *in,  unsigned int in
             sz += var_get_u32(in+sz, in_end, &c_meta_size);
             u_meta_size /= 2;
 
-            meta_free = meta = rans_dec_func(do_simd, 0)(in+sz, in_size-sz, NULL, u_meta_size);
+            meta = meta_free = rans_dec_func(do_simd, 0)(in+sz, in_size-sz, NULL, u_meta_size);
             if (!meta)
                 goto err;
         }

--- a/htscodecs/rANS_static4x16pr.c
+++ b/htscodecs/rANS_static4x16pr.c
@@ -109,7 +109,7 @@ unsigned int rans_compress_bound_4x16(unsigned int size, int order) {
 //
 // NB: The output buffer does not hold the original size, so it is up to
 // the caller to store this.
-unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_O0_4x16(const unsigned char *in, unsigned int in_size,
                                      unsigned char *out, unsigned int *out_size) {
     unsigned char *cp, *out_end;
     RansEncSymbol syms[256];
@@ -210,7 +210,7 @@ unsigned char *rans_compress_O0_4x16(unsigned char *in, unsigned int in_size,
     return out;
 }
 
-unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress_O0_4x16(const unsigned char *in, unsigned int in_size,
                                        unsigned char *out, unsigned int out_sz) {
     if (in_size < 16) // 4-states at least
         return NULL;
@@ -224,8 +224,9 @@ unsigned char *rans_uncompress_O0_4x16(unsigned char *in, unsigned int in_size,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *out_free = NULL;
-    unsigned char *cp_end = in + in_size - 8; // within 8 => be extra safe
+    const unsigned char *cp = in;
+    unsigned char *out_free = NULL;
+    const unsigned char *cp_end = in + in_size - 8; // within 8 => be extra safe
     int i, j;
     unsigned int x, y;
     uint16_t sfreq[TOTFREQ+32];
@@ -399,7 +400,7 @@ int rans_compute_shift(uint32_t *F0, uint32_t (*F)[256], uint32_t *T,
 }
 
 static
-unsigned char *rans_compress_O1_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_O1_4x16(const unsigned char *in, unsigned int in_size,
                                      unsigned char *out, unsigned int *out_size) {
     unsigned char *cp, *out_end, *out_free = NULL;
     unsigned int tab_size;
@@ -501,7 +502,7 @@ unsigned char *rans_compress_O1_4x16(unsigned char *in, unsigned int in_size,
 //#define MAGIC2 0
 
 static
-unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress_O1_4x16(const unsigned char *in, unsigned int in_size,
                                        unsigned char *out, unsigned int out_sz) {
     if (in_size < 16) // 4-states at least
         return NULL;
@@ -515,7 +516,9 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
 #endif
 
     /* Load in the static tables */
-    unsigned char *cp = in, *cp_end = in+in_size, *out_free = NULL;
+    const unsigned char *cp = in;
+    const unsigned char *cp_end = in+in_size;
+    unsigned char *out_free = NULL;
     unsigned char *c_freq = NULL;
     int i, j = -999;
     unsigned int x;
@@ -549,8 +552,8 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
     //fprintf(stderr, "out_sz=%d\n", out_sz);
 
     // compressed header? If so uncompress it
-    unsigned char *tab_end = NULL;
-    unsigned char *c_freq_end = cp_end;
+    const unsigned char *tab_end = NULL;
+    const unsigned char *c_freq_end = cp_end;
     unsigned int shift = *cp >> 4;
     if (*cp++ & 1) {
         uint32_t u_freq_sz, c_freq_sz;
@@ -625,7 +628,7 @@ unsigned char *rans_uncompress_O1_4x16(unsigned char *in, unsigned int in_size,
         goto err;
 
     RansState rans0, rans1, rans2, rans3;
-    uint8_t *ptr = cp, *ptr_end = in + in_size - 8;
+    const uint8_t *ptr = cp, *ptr_end = in + in_size - 8;
     RansDecInit(&rans0, &ptr); if (rans0 < RANS_BYTE_L) goto err;
     RansDecInit(&rans1, &ptr); if (rans1 < RANS_BYTE_L) goto err;
     RansDecInit(&rans2, &ptr); if (rans2 < RANS_BYTE_L) goto err;
@@ -934,7 +937,7 @@ static void htscodecs_tls_cpu_init(void) {
 
 static inline
 unsigned char *(*rans_enc_func(int do_simd, int order))
-    (unsigned char *in,
+    (const unsigned char *in,
      unsigned int in_size,
      unsigned char *out,
      unsigned int *out_size) {
@@ -1008,7 +1011,7 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
 
 static inline
 unsigned char *(*rans_dec_func(int do_simd, int order))
-    (unsigned char *in,
+    (const unsigned char *in,
      unsigned int in_size,
      unsigned char *out,
      unsigned int out_size) {
@@ -1101,7 +1104,7 @@ static inline int have_neon(void) {
 
 static inline
 unsigned char *(*rans_enc_func(int do_simd, int order))
-    (unsigned char *in,
+    (const unsigned char *in,
      unsigned int in_size,
      unsigned char *out,
      unsigned int *out_size) {
@@ -1124,7 +1127,7 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
 
 static inline
 unsigned char *(*rans_dec_func(int do_simd, int order))
-    (unsigned char *in,
+    (const unsigned char *in,
      unsigned int in_size,
      unsigned char *out,
      unsigned int out_size) {
@@ -1149,7 +1152,7 @@ unsigned char *(*rans_dec_func(int do_simd, int order))
 
 static inline
 unsigned char *(*rans_enc_func(int do_simd, int order))
-    (unsigned char *in,
+    (const unsigned char *in,
      unsigned int in_size,
      unsigned char *out,
      unsigned int *out_size) {
@@ -1167,7 +1170,7 @@ unsigned char *(*rans_enc_func(int do_simd, int order))
 
 static inline
 unsigned char *(*rans_dec_func(int do_simd, int order))
-    (unsigned char *in,
+    (const unsigned char *in,
      unsigned int in_size,
      unsigned char *out,
      unsigned int out_size) {
@@ -1200,7 +1203,7 @@ void rans_set_cpu(int opts) {
  *
  * Smallest is method, <in_size> <input>, so worst case 2 bytes longer.
  */
-unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_to_4x16(const unsigned char *in, unsigned int in_size,
                                      unsigned char *out,unsigned int *out_size,
                                      int order) {
     if (in_size > INT_MAX || (out && *out_size == 0)) {
@@ -1269,7 +1272,7 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
         if (in_size >= N*KN) {
             for (; i < in_size-N*KN;) {
                 int k;
-                unsigned char *ink = in+i;
+                const unsigned char *ink = in+i;
                 for (j = 0; j < N; j++)
                     for (k = 0; k < KN; k++)
                         transposed[idx[j]+x+k] = ink[j+N*k];
@@ -1578,14 +1581,14 @@ unsigned char *rans_compress_to_4x16(unsigned char *in, unsigned int in_size,
     return out;
 }
 
-unsigned char *rans_compress_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_compress_4x16(const unsigned char *in, unsigned int in_size,
                                   unsigned int *out_size, int order) {
     return rans_compress_to_4x16(in, in_size, NULL, out_size, order);
 }
 
-unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
+unsigned char *rans_uncompress_to_4x16(const unsigned char *in,  unsigned int in_size,
                                        unsigned char *out, unsigned int *out_size) {
-    unsigned char *in_end = in + in_size;
+    const unsigned char *in_end = in + in_size;
     unsigned char *out_free = NULL, *tmp_free = NULL, *meta_free = NULL;
 
     if (in_size == 0)
@@ -1784,7 +1787,7 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
         tmp1_size = osz;
     }
 
-    uint8_t *meta = NULL;
+    const uint8_t *meta = NULL;
     uint32_t u_meta_size = 0;
     if (do_rle) {
         // Uncompress meta data
@@ -1872,7 +1875,7 @@ unsigned char *rans_uncompress_to_4x16(unsigned char *in,  unsigned int in_size,
     return NULL;
 }
 
-unsigned char *rans_uncompress_4x16(unsigned char *in, unsigned int in_size,
+unsigned char *rans_uncompress_4x16(const unsigned char *in, unsigned int in_size,
                                     unsigned int *out_size) {
     return rans_uncompress_to_4x16(in, in_size, NULL, out_size);
 }

--- a/htscodecs/rANS_word.h
+++ b/htscodecs/rANS_word.h
@@ -438,7 +438,7 @@ static inline void RansDecRenorm(RansState* r, const uint8_t** pptr) {
 
 #else /* __x86_64 */
 
-static inline void RansDecRenorm(RansState* r, uint8_t** pptr)
+static inline void RansDecRenorm(RansState* r, const uint8_t** pptr)
 {
     // renormalize, branchless
     uint32_t x = *r;

--- a/htscodecs/rANS_word.h
+++ b/htscodecs/rANS_word.h
@@ -120,10 +120,10 @@ static inline void RansEncFlush(RansState* r, uint8_t** pptr)
 
 // Initializes a rANS decoder.
 // Unlike the encoder, the decoder works forwards as you'd expect.
-static inline void RansDecInit(RansState* r, uint8_t** pptr)
+static inline void RansDecInit(RansState* r, const uint8_t** pptr)
 {
     uint32_t x;
-    uint8_t* ptr = *pptr;
+    const uint8_t* ptr = *pptr;
 
     x  = ptr[0] << 0;
     x |= ptr[1] << 8;
@@ -413,12 +413,12 @@ static inline void RansDecAdvanceSymbolStep(RansState* r, RansDecSymbol const* s
  * These are based on joint ideas from Rob Davies and from looking at
  * the clang assembly output.
  */
-static inline void RansDecRenorm(RansState* r, uint8_t** pptr) {
+static inline void RansDecRenorm(RansState* r, const uint8_t** pptr) {
     //       q4        q40
     // clang 730/608   717/467
     // gcc8  733/588   737/458
     uint32_t  x   = *r;
-    uint8_t  *ptr = *pptr;
+    const uint8_t  *ptr = *pptr;
     __asm__ ("movzwl (%0),  %%eax\n\t"
              "mov    %1,    %%edx\n\t"
              "shl    $0x10, %%edx\n\t"
@@ -467,7 +467,7 @@ static inline void RansDecRenorm(RansState* r, uint8_t** pptr)
 // Note the data may not be word aligned here.
 // This function is only used sparingly, for the last few bytes in the buffer,
 // so speed isn't critical.
-static inline void RansDecRenormSafe(RansState* r, uint8_t** pptr, uint8_t *ptr_end)
+static inline void RansDecRenormSafe(RansState* r, const uint8_t** pptr, const uint8_t *ptr_end)
 {
     uint32_t x = *r;
     if (x >= RANS_BYTE_L || *pptr+1 >= ptr_end) return;

--- a/htscodecs/rle.c
+++ b/htscodecs/rle.c
@@ -45,7 +45,7 @@
 
 //-----------------------------------------------------------------------------
 // Auto compute rle_syms / rle_nsyms
-static void rle_find_syms(uint8_t *data, uint64_t data_len,
+static void rle_find_syms(const uint8_t *data, uint64_t data_len,
                           int64_t *saved, // dim >= 256 
                           uint8_t *rle_syms, int *rle_nsyms) {
     int last = -1, n;
@@ -97,7 +97,7 @@ static void rle_find_syms(uint8_t *data, uint64_t data_len,
     *rle_nsyms = n;
 }
 
-uint8_t *hts_rle_encode(uint8_t *data, uint64_t data_len,
+uint8_t *hts_rle_encode(const uint8_t *data, uint64_t data_len,
                         uint8_t *run,  uint64_t *run_len,
                         uint8_t *rle_syms, int *rle_nsyms,
                         uint8_t *out, uint64_t *out_len) {
@@ -140,11 +140,11 @@ uint8_t *hts_rle_encode(uint8_t *data, uint64_t data_len,
 // On input *out_len holds the allocated size of out[].
 // On output it holds the used size of out[].
 uint8_t *hts_rle_decode(uint8_t *lit, uint64_t lit_len,
-                        uint8_t *run, uint64_t run_len,
-                        uint8_t *rle_syms, int rle_nsyms,
+                        const uint8_t *run, uint64_t run_len,
+                        const uint8_t *rle_syms, int rle_nsyms,
                         uint8_t *out, uint64_t *out_len) {
     uint64_t j;
-    uint8_t *run_end = run + run_len;
+    const uint8_t *run_end = run + run_len;
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (*out_len > 100000)

--- a/htscodecs/rle.h
+++ b/htscodecs/rle.h
@@ -66,7 +66,7 @@ extern "C" {
  *         updates rle_syms / rle_nsyms too.
  * Returns NULL of failure
  */
-uint8_t *hts_rle_encode(uint8_t *data, uint64_t data_len,
+uint8_t *hts_rle_encode(const uint8_t *data, uint64_t data_len,
                         uint8_t *run,  uint64_t *run_len,
                         uint8_t *rle_syms, int *rle_nsyms,
                         uint8_t *out, uint64_t *out_len);
@@ -82,8 +82,8 @@ uint8_t *hts_rle_encode(uint8_t *data, uint64_t data_len,
  *         NULL on failure.
  */
 uint8_t *hts_rle_decode(uint8_t *lit, uint64_t lit_len,
-                        uint8_t *run, uint64_t run_len,
-                        uint8_t *rle_syms, int rle_nsyms,
+                        const uint8_t *run, uint64_t run_len,
+                        const uint8_t *rle_syms, int rle_nsyms,
                         uint8_t *out, uint64_t *out_len);
 
 // TODO: Add rle scanning func to compute rle_syms.

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -135,7 +135,8 @@ typedef struct {
 } last_context_tok;
 
 typedef struct {
-    char *last_name;
+    const char *last_name;
+    int last_name_len;
     int last_ntok;
     last_context_tok *last; // [last_ntok]
 } last_context;
@@ -409,7 +410,7 @@ static int decode_token_int1(name_context *ctx, int ntok,
 // Maybe XOR with previous string as context?
 // This permits partial match to be encoded efficiently.
 static int encode_token_alpha(name_context *ctx, int ntok,
-                              char *str, int len) {
+                              const char *str, int len) {
     int id = (ntok<<4) | N_ALPHA;
 
     if (encode_token_type(ctx, ntok, N_ALPHA) < 0)  return -1;
@@ -587,7 +588,7 @@ void dump_trie(trie_t *t, int depth) {
 #endif
 
 static
-int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, int *is_fixed, int *fixed_len) {
+int search_trie(name_context *ctx, const char *data, size_t len, int n, int *exact, int *is_fixed, int *fixed_len) {
     size_t i;
     trie_t *t;
     int from = -1, p3 = -1;
@@ -598,7 +599,7 @@ int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, in
     // Horrid hack for the encoder only.
     // We optimise per known name format here.
     int prefix_len;
-    char *d = *data == '@' ? data+1 : data;
+    const char *d = *data == '@' ? data+1 : data;
     int l   = *data == '@' ? len-1  : len;
     int f = (*data == '>') ? 1 : 0;
     if (l > 70 && d[f+0] == 'm' && d[7] == '_' && d[f+14] == '_' && d[f+61] == '/') {
@@ -692,7 +693,7 @@ int search_trie(name_context *ctx, char *data, size_t len, int n, int *exact, in
  * Returns 0 on success;
  *        -1 on failure.
  */
-static int encode_name(name_context *ctx, char *name, int len, int mode) {
+static int encode_name(name_context *ctx, const char *name, int len, int mode) {
     int i, is_fixed, fixed_len;
 
     int exact;
@@ -703,14 +704,17 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
     //cnum = cnum & (MAX_NAMES-1);
     //if (pnum == cnum) {pnum = cnum ? cnum-1 : 0;}
 #ifdef ENC_DEBUG
-    fprintf(stderr, "%d: pnum=%d (%d), exact=%d\n%s\n%s\n",
-            ctx->counter, pnum, cnum-pnum, exact, ctx->lc[pnum].last_name, name);
+    fprintf(stderr, "%d: pnum=%d (%d), exact=%d\n%.*s\n%.*s\n",
+            ctx->counter, pnum, cnum-pnum, exact,
+            ctx->lc[pnum].last_name_len, ctx->lc[pnum].last_name,
+            len, name);
 #endif
 
     // Return DUP or DIFF switch, plus the distance.
     if (exact && len == strlen(ctx->lc[pnum].last_name)) {
         encode_token_dup(ctx, cnum-pnum);
         ctx->lc[cnum].last_name = name;
+        ctx->lc[cnum].last_name_len = len;
         ctx->lc[cnum].last_ntok = ctx->lc[pnum].last_ntok;
         int nc = ctx->lc[cnum].last_ntok ? ctx->lc[cnum].last_ntok : MAX_TOKENS;
         ctx->lc[cnum].last = malloc(nc * sizeof(*ctx->lc[cnum].last));
@@ -1003,6 +1007,7 @@ static int encode_name(name_context *ctx, char *name, int len, int mode) {
     //printf("Encoded %.*s with %d tokens\n", len, name, ntok);
     
     ctx->lc[cnum].last_name = name;
+    ctx->lc[cnum].last_name_len = len;
     ctx->lc[cnum].last_ntok = ntok;
     last_context_tok *shrunk = realloc(ctx->lc[cnum].last,
                                        (ntok+1) * sizeof(*ctx->lc[cnum].last));
@@ -1040,9 +1045,10 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
             return -1;
 
         if (strlen(ctx->lc[pnum].last_name) +1 >= name_len) return -1;
-        strcpy(name, ctx->lc[pnum].last_name);
+        memcpy(name, ctx->lc[pnum].last_name, name_len);
         // FIXME: optimise this
         ctx->lc[cnum].last_name = name;
+        ctx->lc[cnum].last_name_len = name_len;
         ctx->lc[cnum].last_ntok = ctx->lc[pnum].last_ntok;
 
         int nc = ctx->lc[cnum].last_ntok ? ctx->lc[cnum].last_ntok : MAX_TOKENS;
@@ -1188,6 +1194,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
             ctx->lc[cnum].last[ntok].token_type = N_END;
 
             ctx->lc[cnum].last_name = name;
+            ctx->lc[cnum].last_name_len = name_len;
             ctx->lc[cnum].last_ntok = ntok;
 
             last_context_tok *shrunk
@@ -1497,7 +1504,6 @@ uint8_t *tok3_encode_names(const char *blk, int len, int level, int use_arith,
             return NULL;
         }
 
-        blk[i] = '\0';
         // try both 0 and 1 and pick best?
         if (encode_name(ctx, &blk[j], i-j, 1) < 0) {
             free_context(ctx);

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1045,7 +1045,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
             return -1;
 
         if (strlen(ctx->lc[pnum].last_name) +1 >= name_len) return -1;
-        memcpy(name, ctx->lc[pnum].last_name, name_len);
+        memmove(name, ctx->lc[pnum].last_name, name_len);
         // FIXME: optimise this
         ctx->lc[cnum].last_name = name;
         ctx->lc[cnum].last_name_len = name_len;

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1044,7 +1044,7 @@ static int decode_name(name_context *ctx, char *name, int name_buffer_size) {
         if (pnum == cnum)
             return -1;
         int name_length = ctx->lc[pnum].last_name_len;
-        if (ctx->lc[pnum].last_name_len +1 >= name_buffer_size) return -1;
+        if (name_length >= name_buffer_size) return -1;
         memcpy(name, ctx->lc[pnum].last_name, name_length);
         // FIXME: optimise this
         ctx->lc[cnum].last_name = name;

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -1023,7 +1023,7 @@ static int encode_name(name_context *ctx, const char *name, int len, int mode) {
 //-----------------------------------------------------------------------------
 // Name decoder
 
-static int decode_name(name_context *ctx, char *name, int name_len) {
+static int decode_name(name_context *ctx, char *name, int name_buffer_size) {
     int t0 = decode_token_type(ctx, 0);
     uint32_t dist;
     int pnum, cnum = ctx->counter++;
@@ -1043,12 +1043,12 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
     if (t0 == N_DUP) {
         if (pnum == cnum)
             return -1;
-
-        if (strlen(ctx->lc[pnum].last_name) +1 >= name_len) return -1;
-        memmove(name, ctx->lc[pnum].last_name, name_len);
+        int name_length = ctx->lc[pnum].last_name_len;
+        if (ctx->lc[pnum].last_name_len +1 >= name_buffer_size) return -1;
+        memcpy(name, ctx->lc[pnum].last_name, name_length);
         // FIXME: optimise this
         ctx->lc[cnum].last_name = name;
-        ctx->lc[cnum].last_name_len = name_len;
+        ctx->lc[cnum].last_name_len = name_length;
         ctx->lc[cnum].last_ntok = ctx->lc[pnum].last_ntok;
 
         int nc = ctx->lc[cnum].last_ntok ? ctx->lc[cnum].last_ntok : MAX_TOKENS;
@@ -1058,7 +1058,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
         memcpy(ctx->lc[cnum].last, ctx->lc[pnum].last,
                ctx->lc[cnum].last_ntok * sizeof(*ctx->lc[cnum].last));
 
-        return strlen(name)+1;
+        return name_length;
     }
 
     *name = 0;
@@ -1077,7 +1077,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
 
         switch (tok) {
         case N_CHAR:
-            if (len+1 >= name_len) return -1;
+            if (len+1 >= name_buffer_size) return -1;
             if (decode_token_char(ctx, ntok, &name[len]) < 0) return -1;
             //fprintf(stderr, "Tok %d CHAR %c\n", ntok, name[len]);
             ctx->lc[cnum].last[ntok].token_type = N_CHAR;
@@ -1085,7 +1085,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
             break;
 
         case N_ALPHA:
-            if ((len2 = decode_token_alpha(ctx, ntok, &name[len], name_len - len)) < 0)
+            if ((len2 = decode_token_alpha(ctx, ntok, &name[len], name_buffer_size - len)) < 0)
                 return -1;
             //fprintf(stderr, "Tok %d ALPHA %.*s\n", ntok, len2, &name[len]);
             ctx->lc[cnum].last[ntok].token_type = N_ALPHA;
@@ -1097,7 +1097,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
         case N_DIGITS0: // [0-9]*
             if (decode_token_int1(ctx, ntok, N_DZLEN, &vl) < 0) return -1;
             if (decode_token_int(ctx, ntok, N_DIGITS0, &v) < 0) return -1;
-            if (len+20+vl >= name_len) return -1;
+            if (len+20+vl >= name_buffer_size) return -1;
             len += append_uint32_fixed(&name[len], v, vl);
             //fprintf(stderr, "Tok %d DIGITS0 %0*d\n", ntok, vl, v);
             ctx->lc[cnum].last[ntok].token_type = N_DIGITS0;
@@ -1109,7 +1109,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
             if (ntok >= ctx->lc[pnum].last_ntok) return -1;
             if (decode_token_int1(ctx, ntok, N_DDELTA0, &v) < 0) return -1;
             v += ctx->lc[pnum].last[ntok].token_int;
-            if (len+ctx->lc[pnum].last[ntok].token_str+1 >= name_len) return -1;
+            if (len+ctx->lc[pnum].last[ntok].token_str+1 >= name_buffer_size) return -1;
             len += append_uint32_fixed(&name[len], v, ctx->lc[pnum].last[ntok].token_str);
             //fprintf(stderr, "Tok %d DELTA0 %0*d\n", ntok, ctx->lc[pnum].last[ntok].token_str, v);
             ctx->lc[cnum].last[ntok].token_type = N_DIGITS0;
@@ -1119,7 +1119,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
 
         case N_DIGITS: // [1-9][0-9]*
             if (decode_token_int(ctx, ntok, N_DIGITS, &v) < 0) return -1;
-            if (len+20 >= name_len) return -1;
+            if (len+20 >= name_buffer_size) return -1;
             len += append_uint32_var(&name[len], v);
             //fprintf(stderr, "Tok %d DIGITS %d\n", ntok, v);
             ctx->lc[cnum].last[ntok].token_type = N_DIGITS;
@@ -1130,7 +1130,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
             if (ntok >= ctx->lc[pnum].last_ntok) return -1;
             if (decode_token_int1(ctx, ntok, N_DDELTA, &v) < 0) return -1;
             v += ctx->lc[pnum].last[ntok].token_int;
-            if (len+20 >= name_len) return -1;
+            if (len+20 >= name_buffer_size) return -1;
             len += append_uint32_var(&name[len], v);
             //fprintf(stderr, "Tok %d DELTA %d\n", ntok, v);
             ctx->lc[cnum].last[ntok].token_type = N_DIGITS;
@@ -1145,7 +1145,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
             if (ntok >= ctx->lc[pnum].last_ntok) return -1;
             switch (ctx->lc[pnum].last[ntok].token_type) {
             case N_CHAR:
-                if (len+1 >= name_len) return -1;
+                if (len+1 >= name_buffer_size) return -1;
                 name[len++] = ctx->lc[pnum].last[ntok].token_int;
                 //fprintf(stderr, "Tok %d MATCH CHAR %c\n", ntok, ctx->lc[pnum].last[ntok].token_int);
                 ctx->lc[cnum].last[ntok].token_type = N_CHAR;
@@ -1154,7 +1154,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
 
             case N_ALPHA:
                 if (ctx->lc[pnum].last[ntok].token_int < 0 ||
-                    len+ctx->lc[pnum].last[ntok].token_int >= name_len) return -1;
+                    len+ctx->lc[pnum].last[ntok].token_int >= name_buffer_size) return -1;
                 memcpy(&name[len],
                        &ctx->lc[pnum].last_name[ctx->lc[pnum].last[ntok].token_str],
                        ctx->lc[pnum].last[ntok].token_int);
@@ -1166,7 +1166,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
                 break;
 
             case N_DIGITS:
-                if (len+20 >= name_len) return -1;
+                if (len+20 >= name_buffer_size) return -1;
                 len += append_uint32_var(&name[len], ctx->lc[pnum].last[ntok].token_int);
                 //fprintf(stderr, "Tok %d MATCH DIGITS %d\n", ntok, ctx->lc[pnum].last[ntok].token_int);
                 ctx->lc[cnum].last[ntok].token_type = N_DIGITS;
@@ -1174,7 +1174,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
                 break;
 
             case N_DIGITS0:
-                if (len+ctx->lc[pnum].last[ntok].token_str >= name_len) return -1;
+                if (len+ctx->lc[pnum].last[ntok].token_str >= name_buffer_size) return -1;
                 len += append_uint32_fixed(&name[len], ctx->lc[pnum].last[ntok].token_int, ctx->lc[pnum].last[ntok].token_str);
                 //fprintf(stderr, "Tok %d MATCH DIGITS %0*d\n", ntok, ctx->lc[pnum].last[ntok].token_str, ctx->lc[pnum].last[ntok].token_int);
                 ctx->lc[cnum].last[ntok].token_type = N_DIGITS0;
@@ -1189,12 +1189,12 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
 
         default: // an elided N_END
         case N_END:
-            if (len+1 >= name_len) return -1;
+            if (len+1 >= name_buffer_size) return -1;
             name[len++] = 0;
             ctx->lc[cnum].last[ntok].token_type = N_END;
 
             ctx->lc[cnum].last_name = name;
-            ctx->lc[cnum].last_name_len = name_len;
+            ctx->lc[cnum].last_name_len = len;
             ctx->lc[cnum].last_ntok = ntok;
 
             last_context_tok *shrunk

--- a/htscodecs/tokenise_name3.c
+++ b/htscodecs/tokenise_name3.c
@@ -474,7 +474,7 @@ static int encode_token_diff(name_context *ctx, uint32_t val) {
 //-----------------------------------------------------------------------------
 // Trie implementation for tracking common name prefixes.
 static
-int build_trie(name_context *ctx, char *data, size_t len, int n) {
+int build_trie(name_context *ctx, const char *data, size_t len, int n) {
     size_t i;
     trie_t *t;
 
@@ -1209,7 +1209,7 @@ static int decode_name(name_context *ctx, char *name, int name_len) {
 
 //-----------------------------------------------------------------------------
 // arith adaptive codec or static rANS 4x16pr codec
-static int arith_encode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len, int method) {
+static int arith_encode(const uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len, int method) {
     unsigned int olen = *out_len-6, nb;
     if (arith_compress_to(in, in_len, out+6, &olen, method) == NULL)
         return -1;
@@ -1223,7 +1223,7 @@ static int arith_encode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *ou
 
 // Returns number of bytes read from 'in' on success,
 //        -1 on failure.
-static int64_t arith_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len) {
+static int64_t arith_decode(const uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len) {
     unsigned int olen = *out_len;
 
     uint32_t clen;
@@ -1236,7 +1236,7 @@ static int64_t arith_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t
     return clen+nb;
 }
 
-static int rans_encode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len, int method) {
+static int rans_encode(const uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len, int method) {
     unsigned int olen = *out_len-6, nb;
     if (rans_compress_to_4x16(in, in_len, out+6, &olen, method) == NULL)
         return -1;
@@ -1250,7 +1250,7 @@ static int rans_encode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out
 
 // Returns number of bytes read from 'in' on success,
 //        -1 on failure.
-static int64_t rans_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len) {
+static int64_t rans_decode(const uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t *out_len) {
     unsigned int olen = *out_len;
 
     uint32_t clen;
@@ -1263,7 +1263,7 @@ static int64_t rans_decode(uint8_t *in, uint64_t in_len, uint8_t *out, uint64_t 
     return clen+nb;
 }
 
-static int compress(uint8_t *in, uint64_t in_len, enum name_type type,
+static int compress(const uint8_t *in, uint64_t in_len, enum name_type type,
                     int level, int use_arith,
                     uint8_t *out, uint64_t *out_len) {
     uint64_t best_sz = UINT64_MAX;
@@ -1414,7 +1414,7 @@ static int compress(uint8_t *in, uint64_t in_len, enum name_type type,
     return ret;
 }
 
-static uint64_t uncompressed_size(uint8_t *in, uint64_t in_len) {
+static uint64_t uncompressed_size(const uint8_t *in, uint64_t in_len) {
     uint32_t clen, ulen;
 
     // in[0] in part of buffer written by us
@@ -1426,7 +1426,7 @@ static uint64_t uncompressed_size(uint8_t *in, uint64_t in_len) {
     return ulen;
 }
 
-static int uncompress(int use_arith, uint8_t *in, uint64_t in_len,
+static int uncompress(int use_arith, const uint8_t *in, uint64_t in_len,
                       uint8_t *out, uint64_t *out_len) {
     uint32_t clen;
     var_get_u32(in, in+in_len, &clen);
@@ -1446,7 +1446,7 @@ static int uncompress(int use_arith, uint8_t *in, uint64_t in_len,
  * Returns a malloced buffer holding compressed data of size *out_len,
  *         or NULL on failure
  */
-uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
+uint8_t *tok3_encode_names(const char *blk, int len, int level, int use_arith,
                            int *out_len, int *last_start_p) {
     int last_start = 0, i, j, nreads;
 
@@ -1662,7 +1662,7 @@ uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
 }
 
 // Deprecated interface; to remove when we next to an ABI breakage
-uint8_t *encode_names(char *blk, int len, int level, int use_arith,
+uint8_t *encode_names(const char *blk, int len, int level, int use_arith,
                       int *out_len, int *last_start_p) {
     return tok3_encode_names(blk, len, level, use_arith, out_len,
                              last_start_p);
@@ -1674,7 +1674,7 @@ uint8_t *encode_names(char *blk, int len, int level, int use_arith,
  *
  * Returns NULL on failure.
  */
-uint8_t *tok3_decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
+uint8_t *tok3_decode_names(const uint8_t *in, uint32_t sz, uint32_t *out_len) {
     if (sz < 9)
         return NULL;
 
@@ -1832,6 +1832,6 @@ uint8_t *tok3_decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
 }
 
 // Deprecated interface; to remove when we next to an ABI breakage
-uint8_t *decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len) {
+uint8_t *decode_names(const uint8_t *in, uint32_t sz, uint32_t *out_len) {
     return tok3_decode_names(in, sz, out_len);
 }

--- a/htscodecs/tokenise_name3.h
+++ b/htscodecs/tokenise_name3.h
@@ -47,7 +47,7 @@ extern "C" {
  * Returns a malloced buffer holding compressed data of size *out_len,
  *         or NULL on failure
  */
-uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
+uint8_t *tok3_encode_names(const char *blk, int len, int level, int use_arith,
                            int *out_len, int *last_start_p);
 
 /*
@@ -56,7 +56,7 @@ uint8_t *tok3_encode_names(char *blk, int len, int level, int use_arith,
  *
  * Returns NULL on failure.
  */
-uint8_t *tok3_decode_names(uint8_t *in, uint32_t sz, uint32_t *out_len);
+uint8_t *tok3_decode_names(const uint8_t *in, uint32_t sz, uint32_t *out_len);
 
 #ifdef __cplusplus
 }

--- a/htscodecs/utils.h
+++ b/htscodecs/utils.h
@@ -143,7 +143,7 @@ static inline void unstripe(unsigned char *out, unsigned char *outN,
  * Order 0 histogram construction.  8-way unrolled to avoid cache collisions.
  */
 static inline
-int hist8(unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
+int hist8(const unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
     if (in_size > 500000) {
         uint32_t *f0 = htscodecs_tls_calloc((65536+37)*3, sizeof(*f0));
         if (f0 == NULL)
@@ -203,7 +203,7 @@ int hist8(unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
 
 // Hist8 with a crude entropy (bits / byte) estimator.
 static inline
-double hist8e(unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
+double hist8e(const unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
     uint32_t F1[256+MAGIC] = {0}, F2[256+MAGIC] = {0}, F3[256+MAGIC] = {0};
     uint32_t F4[256+MAGIC] = {0}, F5[256+MAGIC] = {0}, F6[256+MAGIC] = {0};
     uint32_t F7[256+MAGIC] = {0};
@@ -248,7 +248,7 @@ double hist8e(unsigned char *in, unsigned int in_size, uint32_t F0[256]) {
  * than its frequency.
  */
 static inline
-void present8(unsigned char *in, unsigned int in_size,
+void present8(const unsigned char *in, unsigned int in_size,
               uint32_t F0[256]) {
     uint32_t F1[256+MAGIC] = {0}, F2[256+MAGIC] = {0}, F3[256+MAGIC] = {0};
     uint32_t F4[256+MAGIC] = {0}, F5[256+MAGIC] = {0}, F6[256+MAGIC] = {0};
@@ -277,10 +277,10 @@ void present8(unsigned char *in, unsigned int in_size,
  */
 #if 1
 static inline
-int hist1_4(unsigned char *in, unsigned int in_size,
+int hist1_4(const unsigned char *in, unsigned int in_size,
             uint32_t F0[256][256], uint32_t *T0) {
     unsigned char l = 0, c;
-    unsigned char *in_end = in + in_size;
+    const unsigned char *in_end = in + in_size;
 
     unsigned char cc[5] = {0};
     if (in_size > 500000) {
@@ -363,7 +363,7 @@ int hist1_4(unsigned char *in, unsigned int in_size,
 //
 // Kept here for posterity incase we need it again, as it's quick tricky.
 static inline
-int hist1_4(unsigned char *in, unsigned int in_size,
+int hist1_4(const unsigned char *in, unsigned int in_size,
             uint32_t F0[256][256], uint32_t *T0) {
     uint32_t f0[65536+MAGIC] = {0};
     uint32_t f1[65536+MAGIC] = {0};

--- a/htscodecs/varint.h
+++ b/htscodecs/varint.h
@@ -237,8 +237,9 @@ int var_put_u32(uint8_t *cp, const uint8_t *endp, uint32_t i) {
 }
 
 static inline
-int var_get_u64(uint8_t *cp, const uint8_t *endp, uint64_t *i) {
-    uint8_t *op = cp, c;
+int var_get_u64(const uint8_t *cp, const uint8_t *endp, uint64_t *i) {
+    const uint8_t *op = cp;
+    uint8_t c;
     uint64_t j = 0;
 
     if (!endp || endp - cp >= 11) {
@@ -264,8 +265,9 @@ int var_get_u64(uint8_t *cp, const uint8_t *endp, uint64_t *i) {
 }
 
 static inline
-int var_get_u32(uint8_t *cp, const uint8_t *endp, uint32_t *i) {
-    uint8_t *op = cp, c;
+int var_get_u32(const uint8_t *cp, const uint8_t *endp, uint32_t *i) {
+    const uint8_t *op = cp;
+    uint8_t c;
     uint32_t j = 0;
 
     if (!endp || endp - cp >= 6) {
@@ -345,7 +347,7 @@ static inline int var_put_u32(uint8_t *cp, const uint8_t *endp, uint32_t i) {
     return cp-op;
 }
 
-static inline int var_get_u64(uint8_t *cp, const uint8_t *endp, uint64_t *i) {
+static inline int var_get_u64(const uint8_t *cp, const uint8_t *endp, uint64_t *i) {
     uint8_t *op = cp, c;
     uint64_t j = 0, s = 0;
 
@@ -374,7 +376,7 @@ static inline int var_get_u64(uint8_t *cp, const uint8_t *endp, uint64_t *i) {
     return cp-op;
 }
 
-static inline int var_get_u32(uint8_t *cp, const uint8_t *endp, uint32_t *i) {
+static inline int var_get_u32(const uint8_t *cp, const uint8_t *endp, uint32_t *i) {
     uint8_t *op = cp, c;
     uint32_t j = 0, s = 0;
 
@@ -415,12 +417,12 @@ static inline int var_put_s64(uint8_t *cp, const uint8_t *endp, int64_t i) {
     return var_put_u64(cp, endp, ((uint64_t)i << 1) ^ (i >> 63));
 }
 
-static inline int var_get_s32(uint8_t *cp, const uint8_t *endp, int32_t *i) {
+static inline int var_get_s32(const uint8_t *cp, const uint8_t *endp, int32_t *i) {
     int b = var_get_u32(cp, endp, (uint32_t *)i);
     *i = ((uint32_t)*i >> 1) ^ -(int32_t)(*i & 1);
     return b;
 }
-static inline int var_get_s64(uint8_t *cp, const uint8_t *endp, int64_t *i) {
+static inline int var_get_s64(const uint8_t *cp, const uint8_t *endp, int64_t *i) {
     int b = var_get_u64(cp, endp, (uint64_t *)i);
     *i = ((uint64_t)*i >> 1) ^ -(int64_t)(*i & 1);
     return b;


### PR DESCRIPTION
This makes all inputs constant, because input data should not be changed by encoding/decoding functions.

However I found two things in the code that make this not yet possible:

Line 1500 in tokenise_name3.c

`        blk[i] = '\0';` 

This overwrites the input with zeroes.

Line 1807 in rANS_static4x16pr.c
`            meta_free = meta = rans_dec_func(do_simd, 0)(in+sz, in_size-sz, NULL, u_meta_size);`

Meta is equal to the input pointer + something. Meta_free is a mutable buffer. Here both get equated for some reason? I don't fully understand what is happening here.
